### PR TITLE
fix(zones): correctly lookup Roads of Avalon zone IDs

### DIFF
--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -1,122 +1,114 @@
-import {CATEGORIES} from '../constants/LoggerConstants.js';
+import { CATEGORIES } from "../constants/LoggerConstants.js";
 
 export class ZonesDatabase {
-    constructor() {
-        this.zones = {};
-        this.loaded = false;
-        this.stats = {
-            totalZones: 0,
-            safe: 0,
-            yellow: 0,
-            red: 0,
-            black: 0,
-            loadTimeMs: 0
-        };
+  constructor() {
+    this.zones = {};
+    this.loaded = false;
+    this.stats = {
+      totalZones: 0,
+      safe: 0,
+      yellow: 0,
+      red: 0,
+      black: 0,
+      loadTimeMs: 0,
+    };
+  }
+
+  async load(jsonPath = "/ao-bin-dumps/zones.json") {
+    const startTime = performance.now();
+
+    try {
+      window.logger?.info(CATEGORIES.SYSTEM, "ZonesDatabaseLoading", {
+        path: jsonPath,
+      });
+
+      const response = await fetch(jsonPath);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch zones.json: ${response.status}`);
+      }
+
+      this.zones = await response.json();
+      this.loaded = true;
+
+      // Calculate stats
+      for (const zone of Object.values(this.zones)) {
+        this.stats.totalZones++;
+        if (zone.pvpType === "safe") this.stats.safe++;
+        else if (zone.pvpType === "yellow") this.stats.yellow++;
+        else if (zone.pvpType === "red") this.stats.red++;
+        else if (zone.pvpType === "black") this.stats.black++;
+      }
+
+      this.stats.loadTimeMs = Math.round(performance.now() - startTime);
+
+      window.logger?.info(CATEGORIES.SYSTEM, "ZonesDatabaseLoaded", {
+        totalZones: this.stats.totalZones,
+        safe: this.stats.safe,
+        yellow: this.stats.yellow,
+        red: this.stats.red,
+        black: this.stats.black,
+        loadTimeMs: this.stats.loadTimeMs,
+      });
+    } catch (error) {
+      window.logger?.error(CATEGORIES.SYSTEM, "ZonesDatabaseLoadError", {
+        error: error.message,
+        stack: error.stack,
+        path: jsonPath,
+      });
+      throw error;
     }
+  }
 
-    async load(jsonPath = '/ao-bin-dumps/zones.json') {
-        const startTime = performance.now();
+  getZone(zoneId) {
+    if (!zoneId) return null;
+    const id = String(zoneId);
+    // Try exact match first (handles TNL-XXX, YOURNAME-HIDEOUT, etc.)
+    if (this.zones[id]) return this.zones[id];
+    // Fallback: try base ID for compound numeric IDs like "1234-5"
+    const baseId = id.split("-")[0];
+    return this.zones[baseId] || null;
+  }
 
-        try {
-            window.logger?.info(
-                CATEGORIES.SYSTEM,
-                'ZonesDatabaseLoading',
-                {path: jsonPath}
-            );
+  getPvpType(zoneId) {
+    return this.getZone(zoneId)?.pvpType || "safe";
+  }
 
-            const response = await fetch(jsonPath);
-            if (!response.ok) {
-                throw new Error(`Failed to fetch zones.json: ${response.status}`);
-            }
+  isBlackZone(zoneId) {
+    return this.getPvpType(zoneId) === "black";
+  }
 
-            this.zones = await response.json();
-            this.loaded = true;
+  isRedZone(zoneId) {
+    return this.getPvpType(zoneId) === "red";
+  }
 
-            // Calculate stats
-            for (const zone of Object.values(this.zones)) {
-                this.stats.totalZones++;
-                if (zone.pvpType === 'safe') this.stats.safe++;
-                else if (zone.pvpType === 'yellow') this.stats.yellow++;
-                else if (zone.pvpType === 'red') this.stats.red++;
-                else if (zone.pvpType === 'black') this.stats.black++;
-            }
+  isYellowZone(zoneId) {
+    return this.getPvpType(zoneId) === "yellow";
+  }
 
-            this.stats.loadTimeMs = Math.round(performance.now() - startTime);
+  isSafeZone(zoneId) {
+    return this.getPvpType(zoneId) === "safe";
+  }
 
-            window.logger?.info(
-                CATEGORIES.SYSTEM,
-                'ZonesDatabaseLoaded',
-                {
-                    totalZones: this.stats.totalZones,
-                    safe: this.stats.safe,
-                    yellow: this.stats.yellow,
-                    red: this.stats.red,
-                    black: this.stats.black,
-                    loadTimeMs: this.stats.loadTimeMs
-                }
-            );
+  isDangerousZone(zoneId) {
+    const pvp = this.getPvpType(zoneId);
+    return pvp === "black" || pvp === "red";
+  }
 
-        } catch (error) {
-            window.logger?.error(
-                CATEGORIES.SYSTEM,
-                'ZonesDatabaseLoadError',
-                {
-                    error: error.message,
-                    stack: error.stack,
-                    path: jsonPath
-                }
-            );
-            throw error;
-        }
-    }
+  getZoneName(zoneId) {
+    return this.getZone(zoneId)?.name || zoneId;
+  }
 
-    getZone(zoneId) {
-        if (!zoneId) return null;
-        // Handle compound IDs like "1234-5" by taking the base ID
-        const id = String(zoneId).split('-')[0];
-        return this.zones[id] || null;
-    }
+  getZoneTier(zoneId) {
+    return this.getZone(zoneId)?.tier || 0;
+  }
 
-    getPvpType(zoneId) {
-        return this.getZone(zoneId)?.pvpType || 'safe';
-    }
+  getZoneFile(zoneId) {
+    return this.getZone(zoneId)?.file || null;
+  }
 
-    isBlackZone(zoneId) {
-        return this.getPvpType(zoneId) === 'black';
-    }
-
-    isRedZone(zoneId) {
-        return this.getPvpType(zoneId) === 'red';
-    }
-
-    isYellowZone(zoneId) {
-        return this.getPvpType(zoneId) === 'yellow';
-    }
-
-    isSafeZone(zoneId) {
-        return this.getPvpType(zoneId) === 'safe';
-    }
-
-    isDangerousZone(zoneId) {
-        const pvp = this.getPvpType(zoneId);
-        return pvp === 'black' || pvp === 'red';
-    }
-
-    getZoneName(zoneId) {
-        return this.getZone(zoneId)?.name || zoneId;
-    }
-
-    getZoneTier(zoneId) {
-        return this.getZone(zoneId)?.tier || 0;
-    }
-
-    getZoneFile(zoneId) {
-        return this.getZone(zoneId)?.file || null;
-    }
-
-    getZoneType(zoneId) {
-        return this.getZone(zoneId)?.type || '';
-    }
+  getZoneType(zoneId) {
+    return this.getZone(zoneId)?.type || "";
+  }
 }
 
 const zonesDatabase = new ZonesDatabase();


### PR DESCRIPTION
## Description

Fixes the sound alert not triggering in Roads of Avalon (Avalon Roads).

## Root Cause

The `getZone()` method was splitting all zone IDs by `-` and taking only the first part:
- `"1234-5"` → `"1234"` ✅ (correct for compound numeric IDs)
- `"TNL-078"` → `"TNL"` ❌ (incorrect key in zones.json is `TNL-078`)

Since `"TNL"` doesn't exist in zones.json, `getPvpType()` returned the default `'safe'` instead of `'black'`.

## Fix

Try exact match first, then fall back to base ID lookup for compound numeric IDs:

```javascript
getZone(zoneId) {
    if (!zoneId) return null;
    const id = String(zoneId);
    // Try exact match first (handles TNL-XXX, YOURNAME-HIDEOUT, etc.)
    if (this.zones[id]) return this.zones[id];
    // Fallback: try base ID for compound numeric IDs like "1234-5"
    const baseId = id.split('-')[0];
    return this.zones[baseId] || null;
}
```

## Test Results

| Zone ID | Before | After | Expected |
|---------|--------|-------|----------|
| TNL-078 | safe | black | black ✅ |
| TNL-001 | safe | safe | safe ✅ (TUNNEL_ROYAL) |
| 1305 | black | black | black ✅ |
| 1000-HellDen | safe | safe | safe ✅ |

Closes #26