### PR TITLE
feat(players): add info banner explaining position limitation

### DIFF
--- a/internal/templates/pages/players.gohtml
+++ b/internal/templates/pages/players.gohtml
@@ -8,6 +8,18 @@
         </div>
     </div>
 
+    <!-- Position Limitation Info -->
+    <div role="alert" class="alert alert-info">
+        <i data-lucide="info" class="w-5 h-5"></i>
+        <div>
+            <h3 class="font-bold">Why can't I see players on the radar?</h3>
+            <p class="text-sm">The game only sends player names, not their positions. We can detect who enters your zone but cannot display them on the map.
+                <a href="https://github.com/Nouuu/Albion-Online-OpenRadar/blob/main/docs/technical/PLAYER_POSITIONS_MITM.md"
+                   target="_blank" rel="noopener noreferrer" class="link link-primary">Learn more</a>
+            </p>
+        </div>
+    </div>
+
     <!-- Show Section -->
     <div class="card bg-base-200">
         <div class="card-body">


### PR DESCRIPTION
## Summary
- Adds an info banner on the Players settings page explaining why players can't be displayed on the radar
- Links to technical documentation for curious users

Closes #34