### PR TITLE
fix(shutdown): unblock pcap close + guard log viewport panic

### DIFF
--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -20,6 +21,8 @@ const (
 	AlbionPort  = 5056
 	SnapLen     = 65536
 	Promiscuous = false
+	// BlockForever deadlocks handle.Close() when idle; poll on timeout
+	ReadTimeout = 500 * time.Millisecond
 )
 
 // NetworkInterface represents a network interface with its details
@@ -155,7 +158,7 @@ func resolveAdapter(appDir, ipOverride string) (ip, device string, err error) {
 }
 
 func openDevice(device string) (*pcap.Handle, error) {
-	handle, err := pcap.OpenLive(device, SnapLen, Promiscuous, pcap.BlockForever)
+	handle, err := pcap.OpenLive(device, SnapLen, Promiscuous, ReadTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open device: %w", err)
 	}

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -288,6 +288,10 @@ func (d Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case LogMsg:
 		d.addLog(msg)
+		if !d.ready {
+			// unsized viewport → bubbles/viewport slice-bounds panic
+			return d, nil
+		}
 		d.viewport.SetContent(d.renderLogs())
 		if d.autoScroll {
 			d.viewport.GotoBottom()


### PR DESCRIPTION
## Summary

- `pcap.BlockForever` → 500ms read timeout so the capture loop can observe `ctx.Done()` when no Albion traffic is on the wire. `handle.Close()` was deadlocking inside libpcap when idle, leaving the main goroutine stuck after pressing `q`.
- Dashboard: drop `LogMsg` before the first `WindowSizeMsg` instead of calling `SetContent`/`GotoBottom` on an unsized `bubbles/viewport`, which panics with `slice bounds out of range`.

Reproduced on release 2.1.1 (`OpenRadar-linux-amd64`) with no game running: `sudo ./OpenRadar-linux-amd64`, wait, press `q` → hangs forever. With this patch → shuts down immediately.

Related: https://github.com/Nouuu/Albion-Online-OpenRadar/discussions/60

## Test plan

- [x] `go build ./...` + `go test ./...` green
- [x] manual: start radar, idle (no game), press `q` → exits cleanly
- [x] manual: start radar, game running, press `q` → exits cleanly
- [x] manual: small terminal that raced LogMsg before WindowSizeMsg no longer panics