### PR TITLE
fix(harvestables): treat mobileTypeId=-1 as static (HARV-1)

### DIFF
--- a/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
+++ b/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
@@ -17,14 +17,14 @@ Living counter. Updated on every test commit. Archived at plan completion.
 | Handler | `@verified` | `@characterization` | `test.fails` | Total |
 |---|---:|---:|---:|---:|
 | PlayersHandler | 37 | 2 | 2 | 41 |
-| HarvestablesHandler | 43 | 7 | 3 | 53 |
+| HarvestablesHandler | 44 | 7 | 2 | 53 |
 | MobsHandler | 59 | 3 | 0 | 62 |
 | ChestsHandler | 10 | 0 | 2 | 12 |
 | FishingHandler | 8 | 0 | 2 | 10 |
 | DungeonsHandler | 19 | 0 | 0 | 19 |
 | WispCageHandler | 9 | 0 | 0 | 9 |
 | EventRouter | 36 | 0 | 11 | 47 |
-| **Total** | **221** | **14** | **20** | **255** |
+| **Total** | **222** | **14** | **19** | **255** |
 
 ## Open observations register
 
@@ -34,7 +34,6 @@ Issue #52 (living Fiber tier mismatch) is NOT a `test.fails` because direction i
 
 ## Open `test.fails` register
 
-- **HARV-1** HarvestablesHandler.addHarvestable isLiving gate misses mobileTypeId=-1 sentinel. Current code: `isLiving = mobileTypeId !== null && mobileTypeId !== 65535`. Observed in pcap: static resources arrive with mobileTypeId=-1 (likely int16 decode of 0xFFFF). Effect: static resources routed through MobsDatabase.getResourceInfo(-1) before falling back. Pinned by `test.fails('pcap-derived single-spawn: static with mobileTypeId=-1 does not trigger mobsDatabase lookup')` in `HarvestablesHandler.test.js`. Fix candidate: extend guard to `mobileTypeId !== -1`, or canonicalize in the Go parser.
 - **HARV-2** (issue #30/#32) HarvestablesHandler e0-gate blocks living Fiber spawned with charges=0; subsequent event 46 enchant update cannot recover the entity. Pinned by `test.fails('issue #30/#32: living Fiber with e0 off appears after event 46 enchant update to e=2')`. After fix: entity should appear when its specific enchant setting is enabled, regardless of e0 at spawn time.
 - **HARV-3** HarvestUpdateEvent re-gate uses `isLiving=false` hardcoded and `GetStringType(harvestable.type)` with static typeNumber. Living Fiber critter (typeNumber=16) resolves to HIDE, so re-gate checks static Hide settings. Entity is removed when all static settings are disabled. Pinned by `test.fails('HarvestUpdateEvent preserves living Fiber when static settings are all disabled')`. After fix: re-gate should use the stored stringType and isLiving flag, not recompute them from typeNumber.
 - **PLAY-1** (issue #65) PlayersHandler.handleNewPlayerEvent does not fire alert for hostile in unknown zone. `zonesDatabase.getPvpType(unknown)` falls back to 'safe'; `isPlayerThreat(255, 'safe')` returns false; alert gate skipped. Pinned by `synthetic hostile in unknown zone: alert should fire but does not` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.

--- a/web/scripts/handlers/HarvestablesHandler.js
+++ b/web/scripts/handlers/HarvestablesHandler.js
@@ -157,12 +157,11 @@ export class HarvestablesHandler
 
     addHarvestable(id, type, tier, posX, posY, charges, size, mobileTypeId = null)
     {
-        // 🔍 Determine resource type: living (animals/creatures) vs static
-        // CORRECTED LOGIC (2025-12-09):
-        // - mobileTypeId === 65535 → STATIC enchanted resource (no creature, just a node)
-        // - mobileTypeId === null → STATIC resource from Event 38 (batch spawn)
-        // - mobileTypeId === real TypeID (425, 530, etc.) → LIVING creature (animal that drops resource)
-        const isLiving = mobileTypeId !== null && mobileTypeId !== 65535;
+        // Determine resource type: living (animals/creatures) vs static.
+        // - mobileTypeId === 65535 or -1 : STATIC (both are int16 decodes of 0xFFFF).
+        // - mobileTypeId === null        : STATIC from Event 38 batch spawn.
+        // - mobileTypeId === real TypeID : LIVING creature.
+        const isLiving = mobileTypeId !== null && mobileTypeId !== 65535 && mobileTypeId !== -1;
 
         // Get resource type string
         // Living resources: use MobsDatabase (typeNumber is WRONG for living!)
@@ -238,12 +237,8 @@ export class HarvestablesHandler
 
     UpdateHarvestable(id, type, tier, posX, posY, charges, size, mobileTypeId = null)
     {
-        // 🔍 Determine resource type: living (animals/creatures) vs static
-        // CORRECTED LOGIC (2025-12-09):
-        // - mobileTypeId === 65535 → STATIC enchanted resource (no creature, just a node)
-        // - mobileTypeId === null → STATIC resource from Event 38 (batch spawn)
-        // - mobileTypeId === real TypeID (425, 530, etc.) → LIVING creature (animal that drops resource)
-        const isLiving = mobileTypeId !== null && mobileTypeId !== 65535;
+        // Guard identical to addHarvestable: -1, 65535, null all mean STATIC.
+        const isLiving = mobileTypeId !== null && mobileTypeId !== 65535 && mobileTypeId !== -1;
 
         // Get resource type string
         // Living resources: use MobsDatabase (typeNumber is WRONG for living!)
@@ -407,8 +402,7 @@ export class HarvestablesHandler
             enchant,
             size,
             mobileTypeId,
-            // CORRECTED: 65535 = static, real TypeID = living
-            isLiving: mobileTypeId !== null && mobileTypeId !== 65535,
+            isLiving: mobileTypeId !== null && mobileTypeId !== 65535 && mobileTypeId !== -1,
             allParametersKeys: Object.keys(Parameters),
             allParameters: allParams40
         });

--- a/web/scripts/handlers/HarvestablesHandler.test.js
+++ b/web/scripts/handlers/HarvestablesHandler.test.js
@@ -351,10 +351,8 @@ describe('HarvestablesHandler', () => {
     });
 
     describe('newHarvestableObject pinned bugs', () => {
-        // Pinned: handler should not route mobileTypeId=-1 through MobsDatabase as living.
-        // Handler isLiving check: mobileTypeId !== null && mobileTypeId !== 65535.
-        // -1 passes both guards, so getResourceInfo(-1) is called. Expected: not called.
-        test.fails('pcap-derived single-spawn: static with mobileTypeId=-1 does not trigger mobsDatabase lookup', async () => {
+        // @verified 2026-04-19: mobileTypeId=-1 sentinel routes as static and skips the mobsDatabase lookup.
+        test('pcap-derived single-spawn: static with mobileTypeId=-1 does not trigger mobsDatabase lookup', async () => {
             const fx = await loadFixture('harvestables', 'single-spawn');
             const msg = fx.messages.find(m => m.parameters['6'] === -1);
             expect(msg).toBeDefined();


### PR DESCRIPTION
## Summary

Extend the `isLiving` guard in `HarvestablesHandler` to also exclude `mobileTypeId === -1`. The value is the int16 decode of `0xFFFF`, equivalent to `65535` on the wire but surfaced as `-1` by the Go parser. Previously `-1` passed the guard and routed static resources through `mobsDatabase.getResourceInfo(-1)` before falling back.

## Scope

- `addHarvestable`, `UpdateHarvestable`, and the `newHarvestableObject` debug log all get the same `!== -1` clause (three sites, identical pattern).
- HARV-1 `test.fails` in `HarvestablesHandler.test.js` flipped to regular `test` with `@verified 2026-04-19` label.
- HARV-1 removed from the open suspect register in `docs/plans/notes/2026-04-18-handlers-characterization-coverage.md`, counts refreshed to 222v/14c/19f.

## Side-effect analysis

Before: a pcap-derived static with `mobileTypeId=-1` was classified living, queried mobsDatabase, then fell back through `GetStringType`. The settings gate checked LIVING keys.
After: same entity is classified static, skips mobsDatabase, uses `GetStringType`. Settings gate checks STATIC keys.

The fixture corpus (`single-spawn.json` messages 0, 1, 19, 21) carries `-1` in `Parameters[6]` together with `Parameters[5]=undefined`, which matches the documented STATIC shape from Event 38 batch spawn. The `test.fails` directional claim says -1 IS static, so routing it through the STATIC path is correct.

No other call sites of `addHarvestable` / `UpdateHarvestable` pass `-1` as mobileTypeId (audited). `newSimpleHarvestableObject` (Event 38) does not pass `mobileTypeId`, defaulting to null, unaffected.

## Test plan

- [x] Full `npm test` suite: 253 passed + 15 expected fail (no regression, HARV-1 flipped from expected-fail to verified).
- [x] `npm run lint` exit 0.
- [ ] Live smoke test deferred, requires game launch.

## Part of

Small bug cluster (`docs/plans/2026-04-18-small-bug-cluster-design.md`). Four more bugs queued:
- CHEST-1 null guard, CHEST-2 rarity persist, FISH-1 empty-type: 3 other parallel PRs.
- HARV-3 re-gate logic: chained on top of this PR.