### PR TITLE
fix(chests): guard Parameters[3] type in addChestEvent (CHEST-1)

### DIFF
--- a/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
+++ b/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
@@ -19,12 +19,12 @@ Living counter. Updated on every test commit. Archived at plan completion.
 | PlayersHandler | 37 | 2 | 2 | 41 |
 | HarvestablesHandler | 43 | 7 | 3 | 53 |
 | MobsHandler | 59 | 3 | 0 | 62 |
-| ChestsHandler | 10 | 0 | 2 | 12 |
+| ChestsHandler | 11 | 0 | 1 | 12 |
 | FishingHandler | 8 | 0 | 2 | 10 |
 | DungeonsHandler | 19 | 0 | 0 | 19 |
 | WispCageHandler | 9 | 0 | 0 | 9 |
 | EventRouter | 36 | 0 | 11 | 47 |
-| **Total** | **221** | **14** | **20** | **255** |
+| **Total** | **222** | **14** | **19** | **255** |
 
 ## Open observations register
 
@@ -39,7 +39,6 @@ Issue #52 (living Fiber tier mismatch) is NOT a `test.fails` because direction i
 - **HARV-3** HarvestUpdateEvent re-gate uses `isLiving=false` hardcoded and `GetStringType(harvestable.type)` with static typeNumber. Living Fiber critter (typeNumber=16) resolves to HIDE, so re-gate checks static Hide settings. Entity is removed when all static settings are disabled. Pinned by `test.fails('HarvestUpdateEvent preserves living Fiber when static settings are all disabled')`. After fix: re-gate should use the stored stringType and isLiving flag, not recompute them from typeNumber.
 - **PLAY-1** (issue #65) PlayersHandler.handleNewPlayerEvent does not fire alert for hostile in unknown zone. `zonesDatabase.getPvpType(unknown)` falls back to 'safe'; `isPlayerThreat(255, 'safe')` returns false; alert gate skipped. Pinned by `synthetic hostile in unknown zone: alert should fire but does not` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **PLAY-2** (issue #36) PlayersHandler.triggerHostileAlert has no ignore-list check. A player in `alreadyIgnoredPlayers` still triggers the sound alert when their faction changes to 255 in a red zone. Pinned by `synthetic PLAY-2: ignored player still triggers alert on faction change in red zone` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
-- **CHEST-1** ChestsHandler.addChestEvent crashes on undefined Parameters[3] because it calls toLowerCase() without a guard. Pinned by `test.fails('pcap-derived spawn with Parameters[3]=undefined does not throw')` in `ChestsHandler.test.js`. Fix candidate: guard with `chestName ?? ''` before `.toLowerCase()`.
 - **CHEST-2** (issue #29 root cause at handler layer) ChestsHandler stores only id/pos/chestName on the Chest entity. Rarity (Parameters[5]) and related fields (Parameters[18], Parameters[23]) are discarded. The drawing layer cannot resolve chest colour because the data was never persisted. Pinned by `test.fails('pcap-derived spawn preserves Parameters[5] rarity on the stored Chest entity')` in `ChestsHandler.test.js`. Fix candidate: add rarity field to Chest class and populate from Parameters[5].
 - **FISH-1** (issue #25) FishingHandler.newFishEvent drops events where Parameters[4] is an empty string `""` because `!type` treats `""` as falsy. In the pcap corpus 3 of 5 spawn events carry `type=""` with valid coordinates and are silently discarded. Likely root of fishpool not showing. Pinned by `pcap-derived spawn: entries with type="" are dropped by !type guard` in `FishingHandler.test.js`. Fix candidate: replace `!type` with `type === null || type === undefined`.
 

--- a/web/scripts/handlers/ChestsHandler.js
+++ b/web/scripts/handlers/ChestsHandler.js
@@ -72,7 +72,7 @@ export class ChestsHandler {
         const chestsPosition = Parameters[1];
         let chestName = Parameters[3];
 
-        if (chestName.toLowerCase().includes("mist")) {
+        if (typeof chestName === 'string' && chestName.toLowerCase().includes("mist")) {
             chestName = Parameters[4];
         }
         this.addChest(chestId, chestsPosition[0], chestsPosition[1], chestName);

--- a/web/scripts/handlers/ChestsHandler.test.js
+++ b/web/scripts/handlers/ChestsHandler.test.js
@@ -59,8 +59,8 @@ describe('ChestsHandler', () => {
             expect(handler.chestsList[0].chestName).toBe('override');
         });
 
-        // CHEST-1: pinned bug, addChestEvent crashes on undefined Parameters[3] because it calls toLowerCase() without a guard.
-        test.fails('pcap-derived spawn with Parameters[3]=undefined does not throw', () => {
+        // @verified 2026-04-19: addChestEvent guards typeof Parameters[3] before toLowerCase; undefined no longer throws.
+        test('synthetic: addChestEvent with Parameters[3]=undefined does not throw', () => {
             const p = {0: 99, 1: [0, 0], 3: undefined};
             expect(() => handler.addChestEvent(p)).not.toThrow();
         });


### PR DESCRIPTION
## Summary

Guard `typeof Parameters[3] === 'string'` before calling `.toLowerCase()` in `ChestsHandler.addChestEvent`. Previously, undefined/non-string values crashed the handler with `toLowerCase is not a function`.

## Scope

- One-line guard in `addChestEvent`.
- CHEST-1 `test.fails` in `ChestsHandler.test.js` flipped to regular `test` with `@verified 2026-04-19` label. Provenance relabelled from `pcap-derived` (incorrect) to `synthetic` (accurate, the test constructs an inline param object).
- CHEST-1 removed from the suspect register, counts refreshed to 222v/14c/19f.

## Side-effect analysis

Before: non-string `Parameters[3]` (undefined, null, number) crashed on `.toLowerCase()`.
After: non-string `Parameters[3]` falls through; `chestName` keeps its original non-string value and is passed to `addChest`. `Chest` class does not validate name type, so it stores whatever comes. This is strictly additive: no previously-working path changes behavior.

Real pcap `chests/spawn.json` carries `Parameters[3]` as a string; the only test that hits the new guard path is the synthetic `undefined` case.

## Test plan

- [x] Full `npm test` suite: 253 passed + 15 expected fail, no regression.
- [x] `npm run lint` exit 0.

## Part of

Small bug cluster (`docs/plans/2026-04-18-small-bug-cluster-design.md`). Independent of #71 (HARV-1), #73+ (FISH-1, HARV-3, CHEST-2).