### PR TITLE
fix(fishing): accept empty-string type in newFishEvent (FISH-1, #25)

### DIFF
--- a/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
+++ b/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
@@ -20,11 +20,11 @@ Living counter. Updated on every test commit. Archived at plan completion.
 | HarvestablesHandler | 44 | 7 | 2 | 53 |
 | MobsHandler | 59 | 3 | 0 | 62 |
 | ChestsHandler | 11 | 0 | 1 | 12 |
-| FishingHandler | 8 | 0 | 2 | 10 |
+| FishingHandler | 9 | 0 | 1 | 10 |
 | DungeonsHandler | 19 | 0 | 0 | 19 |
 | WispCageHandler | 9 | 0 | 0 | 9 |
 | EventRouter | 36 | 0 | 11 | 47 |
-| **Total** | **222** | **14** | **19** | **255** |
+| **Total** | **223** | **14** | **18** | **255** |
 
 ## Open observations register
 
@@ -39,8 +39,6 @@ Issue #52 (living Fiber tier mismatch) is NOT a `test.fails` because direction i
 - **PLAY-1** (issue #65) PlayersHandler.handleNewPlayerEvent does not fire alert for hostile in unknown zone. `zonesDatabase.getPvpType(unknown)` falls back to 'safe'; `isPlayerThreat(255, 'safe')` returns false; alert gate skipped. Pinned by `synthetic hostile in unknown zone: alert should fire but does not` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **PLAY-2** (issue #36) PlayersHandler.triggerHostileAlert has no ignore-list check. A player in `alreadyIgnoredPlayers` still triggers the sound alert when their faction changes to 255 in a red zone. Pinned by `synthetic PLAY-2: ignored player still triggers alert on faction change in red zone` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **CHEST-2** (issue #29 root cause at handler layer) ChestsHandler stores only id/pos/chestName on the Chest entity. Rarity (Parameters[5]) and related fields (Parameters[18], Parameters[23]) are discarded. The drawing layer cannot resolve chest colour because the data was never persisted. Pinned by `test.fails('pcap-derived spawn preserves Parameters[5] rarity on the stored Chest entity')` in `ChestsHandler.test.js`. Fix candidate: add rarity field to Chest class and populate from Parameters[5].
-- **FISH-1** (issue #25) FishingHandler.newFishEvent drops events where Parameters[4] is an empty string `""` because `!type` treats `""` as falsy. In the pcap corpus 3 of 5 spawn events carry `type=""` with valid coordinates and are silently discarded. Likely root of fishpool not showing. Pinned by `pcap-derived spawn: entries with type="" are dropped by !type guard` in `FishingHandler.test.js`. Fix candidate: replace `!type` with `type === null || type === undefined`.
-
 - **ROUTER-1** (issue #57) EventRouter.onResponse opcode 2 (JoinMap) does not extract `isBZ` from `Parameters[103]` hashtable. Post-Protocol18 the field is `{"5": ..., "7": ...}` (non-zero). Current code leaves `map.isBZ` at its prior value. Pinned by `test.fails('ROUTER-1: onResponse JoinMap extracts isBZ from params[103] hashtable')` in `EventRouter.test.js`. Fix design: `2026-04-18-protocol18-regressions-design.md`.
 
 - **ROUTER-2** (issue #53) EventCodes.ChangeFlaggingFinished stale (local 359, real 363). Router case 359 never fires for real game events carrying P[252]=363. Pinned by two `test.fails` in `EventRouter.test.js`. Will flip to pass when `EventCodes.js` is refreshed.

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -39,7 +39,7 @@ export class FishingHandler
         const sizeSpawned = Parameters[2];
         const sizeLeftToSpawn = Parameters[3];
 
-        if (!type) return;
+        if (type === null || type === undefined) return;
         if (!coor) return;
 
         const posX = coor[0];

--- a/web/scripts/handlers/FishingHandler.test.js
+++ b/web/scripts/handlers/FishingHandler.test.js
@@ -43,8 +43,8 @@ describe('FishingHandler', () => {
             expect(handler.fishes[0].totalSize).toBe(p[2] + p[3]);
         });
 
-        // @suspect 2026-04-18: fixture messages with type="" (empty string) are dropped by the !type guard even though they carry valid coordinates and sizes. 3 of 5 pcap events are silently discarded. Falsy guard on empty string likely causes fishpool to not show. See bug #25 (FISH-1).
-        test('pcap-derived spawn: entries with type="" are dropped by !type guard (FISH-1)', async () => {
+        // @verified 2026-04-19: empty-string type is valid data (3 of 5 pcap events), guard narrowed to null/undefined so fishpools no longer get discarded.
+        test('pcap-derived spawn: entries with type="" are added (FISH-1 fixed)', async () => {
             const fx = await loadFixture('fishing', 'spawn');
             const emptyTypeMsgs = fx.messages.filter(m => m.parameters['4'] === '');
             expect(emptyTypeMsgs).toHaveLength(3);
@@ -53,7 +53,10 @@ describe('FishingHandler', () => {
                 handler.newFishEvent(normalizeParams(msg.parameters));
             }
 
-            expect(handler.fishes).toHaveLength(0);
+            expect(handler.fishes).toHaveLength(3);
+            for (const fish of handler.fishes) {
+                expect(fish.type).toBe('');
+            }
         });
 
         // @verified 2026-04-18: second event for the same id updates position and size in place without adding a new entry.


### PR DESCRIPTION
## Summary

Narrow the `newFishEvent` type guard from `!type` to `type === null || type === undefined`. Empty-string type values are valid spawn events in the pcap corpus (3 of 5 carry `type=\"\"` with valid coordinates and sizes) and were being silently discarded. Likely root cause of fishpool detection missing entries per issue #25.

## Scope

- One-line guard change in `FishingHandler.newFishEvent`.
- The FISH-1 test in `FishingHandler.test.js` was previously a regular `test(...)` with an `@suspect` label asserting the broken behaviour (fishes = 0 after 3 empty-type messages). Rewritten to assert the correct outcome (fishes = 3 with `type === ''`) and relabelled `@verified`.
- FISH-1 removed from the suspect register, counts refreshed to 222v/14c/19f.

## Side-effect analysis

Before: `!type` dropped `\"\"`, `null`, `undefined`, `0`, `NaN`, `false`.
After: only `null` and `undefined` drop. Empty string, numeric `0`, `NaN`, `false` are now allowed through.

In practice the game data sends strings for this field. Empty string is the only observed non-falsy case. `null` still short-circuits (existing test line 92 passes). `undefined` still short-circuits. Other paths unchanged.

Downstream `upsertFish` and the `Fish` class accept any type value, so an empty-string `type` is persisted and later consumed by the drawing layer the same as a named type.

## Test plan

- [x] Full `npm test` suite: 252 passed + 16 expected fail, same total as main (fix did not move any other test).
- [x] `npm run lint` exit 0.

## Part of

Small bug cluster (`docs/plans/2026-04-18-small-bug-cluster-design.md`). Independent of #71 (HARV-1), #72 (CHEST-1), and upcoming HARV-3 / CHEST-2.