### PR TITLE
fix(harvestables): reuse stored stringType and mobileTypeId in enchant re-gate (HARV-3)

### DIFF
--- a/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
+++ b/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
@@ -17,14 +17,14 @@ Living counter. Updated on every test commit. Archived at plan completion.
 | Handler | `@verified` | `@characterization` | `test.fails` | Total |
 |---|---:|---:|---:|---:|
 | PlayersHandler | 37 | 2 | 2 | 41 |
-| HarvestablesHandler | 44 | 7 | 2 | 53 |
+| HarvestablesHandler | 47 | 7 | 1 | 55 |
 | MobsHandler | 59 | 3 | 0 | 62 |
 | ChestsHandler | 13 | 0 | 0 | 13 |
 | FishingHandler | 9 | 0 | 1 | 10 |
 | DungeonsHandler | 19 | 0 | 0 | 19 |
 | WispCageHandler | 9 | 0 | 0 | 9 |
 | EventRouter | 36 | 0 | 11 | 47 |
-| **Total** | **225** | **14** | **17** | **256** |
+| **Total** | **228** | **14** | **16** | **258** |
 
 ## Open observations register
 
@@ -35,7 +35,6 @@ Issue #52 (living Fiber tier mismatch) is NOT a `test.fails` because direction i
 ## Open `test.fails` register
 
 - **HARV-2** (issue #30/#32) HarvestablesHandler e0-gate blocks living Fiber spawned with charges=0; subsequent event 46 enchant update cannot recover the entity. Pinned by `test.fails('issue #30/#32: living Fiber with e0 off appears after event 46 enchant update to e=2')`. After fix: entity should appear when its specific enchant setting is enabled, regardless of e0 at spawn time.
-- **HARV-3** HarvestUpdateEvent re-gate uses `isLiving=false` hardcoded and `GetStringType(harvestable.type)` with static typeNumber. Living Fiber critter (typeNumber=16) resolves to HIDE, so re-gate checks static Hide settings. Entity is removed when all static settings are disabled. Pinned by `test.fails('HarvestUpdateEvent preserves living Fiber when static settings are all disabled')`. After fix: re-gate should use the stored stringType and isLiving flag, not recompute them from typeNumber.
 - **PLAY-1** (issue #65) PlayersHandler.handleNewPlayerEvent does not fire alert for hostile in unknown zone. `zonesDatabase.getPvpType(unknown)` falls back to 'safe'; `isPlayerThreat(255, 'safe')` returns false; alert gate skipped. Pinned by `synthetic hostile in unknown zone: alert should fire but does not` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **PLAY-2** (issue #36) PlayersHandler.triggerHostileAlert has no ignore-list check. A player in `alreadyIgnoredPlayers` still triggers the sound alert when their faction changes to 255 in a red zone. Pinned by `synthetic PLAY-2: ignored player still triggers alert on faction change in red zone` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **ROUTER-1** (issue #57) EventRouter.onResponse opcode 2 (JoinMap) does not extract `isBZ` from `Parameters[103]` hashtable. Post-Protocol18 the field is `{"5": ..., "7": ...}` (non-zero). Current code leaves `map.isBZ` at its prior value. Pinned by `test.fails('ROUTER-1: onResponse JoinMap extracts isBZ from params[103] hashtable')` in `EventRouter.test.js`. Fix design: `2026-04-18-protocol18-regressions-design.md`.

--- a/web/scripts/handlers/HarvestablesHandler.js
+++ b/web/scripts/handlers/HarvestablesHandler.js
@@ -13,7 +13,7 @@ const HarvestableType =
 
 class Harvestable
 {
-    constructor(id, type, tier, posX, posY, charges, size, stringType = null)
+    constructor(id, type, tier, posX, posY, charges, size, stringType = null, mobileTypeId = null)
     {
         this.id = id;
         this.type = type;
@@ -26,10 +26,11 @@ class Harvestable
         this.charges = charges;
         this.size = size;
         this.stringType = stringType;
-        this.lastUpdateTime = Date.now(); // For stale entity cleanup
+        this.mobileTypeId = mobileTypeId;
+        this.lastUpdateTime = Date.now();
 
         window.logger?.info(CATEGORIES.HARVESTABLES, 'HarvestableCreated', {
-            id, type, stringType, tier, charges, size,
+            id, type, stringType, tier, charges, size, mobileTypeId,
             note: 'New Harvestable object created'
         });
     }
@@ -216,7 +217,7 @@ export class HarvestablesHandler
 
         if (!harvestable)
         {
-            const h = new Harvestable(id, type, tier, posX, posY, charges, size, stringType);
+            const h = new Harvestable(id, type, tier, posX, posY, charges, size, stringType, mobileTypeId);
             this.harvestableList.push(h);
 
             window.logger?.info(CATEGORIES.HARVESTABLES, 'HarvestableAdded', {
@@ -237,7 +238,6 @@ export class HarvestablesHandler
 
     UpdateHarvestable(id, type, tier, posX, posY, charges, size, mobileTypeId = null)
     {
-        // Guard identical to addHarvestable: -1, 65535, null all mean STATIC.
         const isLiving = mobileTypeId !== null && mobileTypeId !== 65535 && mobileTypeId !== -1;
 
         // Get resource type string
@@ -364,9 +364,10 @@ export class HarvestablesHandler
             });
             harvestable.charges = enchant;
 
-            // Re-check if should be displayed with new enchantment
-            const stringType = this.GetStringType(harvestable.type);
-            const isLiving = false;
+            const stringType = harvestable.stringType;
+            const mobileTypeId = harvestable.mobileTypeId;
+            const isLiving = mobileTypeId !== null && mobileTypeId !== undefined
+                && mobileTypeId !== 65535 && mobileTypeId !== -1;
 
             if (!this.shouldDisplayHarvestable(stringType, isLiving, harvestable.tier, enchant)) {
                 this.removeHarvestable(id);

--- a/web/scripts/handlers/HarvestablesHandler.test.js
+++ b/web/scripts/handlers/HarvestablesHandler.test.js
@@ -387,25 +387,53 @@ describe('HarvestablesHandler', () => {
             expect(stored.charges).toBe(2);
         });
 
-        // Pinned: event 46 re-gate uses isLiving=false hardcoded AND reuses server typeNumber for stringType lookup.
-        // typeNumber=16 (Fiber critter) maps to HIDE via static harvestables DB (type 16-22 = HIDE range).
-        // Result: a living Fiber critter is re-gated as static Hide with enchant=2; entity is dropped when
-        // static Hide settings are all-false. A correct handler would not consult static settings for a living
-        // resource; it should gate on living Fiber settings instead.
-        // After fix, a living Fiber should not be dropped when only static settings are disabled.
-        test.fails('HarvestUpdateEvent preserves living Fiber when static settings are all disabled', async () => {
+        // @verified 2026-04-19: event 46 re-gate uses stored stringType + mobileTypeId; a living Fiber
+        // is no longer dropped when static Hide settings are disabled because the re-gate consults the
+        // living Fiber settings instead.
+        test('HarvestUpdateEvent preserves living Fiber when static settings are all disabled', async () => {
             const fx = await loadFixture('harvestables', 'single-spawn');
             const msg = fx.messages.find(m => m.parameters['6'] === 529);
             const p = normalizeParams(msg.parameters);
             handler.newHarvestableObject(p[0], p);
             expect(handler.getHarvestableList().find(h => h.id === p[0])).toBeDefined();
 
-            // Disable all static resource settings; living Fiber should remain unaffected.
-            settingsSync.getJSON.mockReturnValue(allFalseSettings);
+            // Static-only disablement: Static* keys false, Living* keys unchanged (all true).
+            settingsSync.getJSON.mockImplementation(key =>
+                typeof key === 'string' && key.startsWith('settingStatic') ? allFalseSettings : allTrueSettings
+            );
 
             handler.HarvestUpdateEvent({0: p[0], 1: p[10] ?? 3, 2: 2});
 
             expect(handler.getHarvestableList().find(h => h.id === p[0])).toBeDefined();
+        });
+
+        // @verified 2026-04-19: contract test, addHarvestable without mobileTypeId stores null.
+        test('synthetic contract: Harvestable defaults mobileTypeId to null when omitted', () => {
+            handler.addHarvestable(9001, 0, 4, 10, 20, 0, 3);
+            const stored = handler.getHarvestableList().find(e => e.id === 9001);
+            expect(stored).toBeDefined();
+            expect(stored.mobileTypeId).toBeNull();
+        });
+
+        // @verified 2026-04-19: pcap-composed regression, static resource re-gate still keeps the entity
+        // when its static settings are enabled. Ensures the stored-value refactor did not break the
+        // static path, which was working before HARV-3.
+        test('pcap-composed: static resource enchant re-gate keeps entity with static settings enabled', async () => {
+            const fx = await loadFixture('harvestables', 'single-spawn');
+            const msg = fx.messages.find(m => m.parameters['0'] === 3203);
+            expect(msg, 'fixture should contain static id=3203').toBeDefined();
+            const p = normalizeParams(msg.parameters);
+            handler.newHarvestableObject(p[0], p);
+            const spawned = handler.getHarvestableList().find(h => h.id === 3203);
+            expect(spawned).toBeDefined();
+            expect(spawned.mobileTypeId).toBe(-1);
+
+            // Force an enchant change distinct from spawn enchant (p[11]=2) to trigger the re-gate.
+            handler.HarvestUpdateEvent({0: 3203, 1: p[10] ?? 1, 2: 3});
+
+            const stored = handler.getHarvestableList().find(h => h.id === 3203);
+            expect(stored).toBeDefined();
+            expect(stored.charges).toBe(3);
         });
     });
 


### PR DESCRIPTION
## Summary

Persist `mobileTypeId` on the `Harvestable` class at spawn time so `HarvestUpdateEvent` re-gate can use the correct spawn-time classification instead of recomputing it from the server `typeNumber`. Fixes the long-standing drop of living Fiber critters when static Hide settings are disabled.

## Scope

Change in `HarvestablesHandler.js`:
- `Harvestable` constructor takes a new `mobileTypeId = null` argument and stores it alongside `stringType`. `addHarvestable` propagates the value it already has in scope.
- `HarvestUpdateEvent` re-gate reads `harvestable.stringType` and recomputes `isLiving` from `harvestable.mobileTypeId` using the same sentinel set as HARV-1 (null / 65535 / -1 = static). The previous `isLiving = false` hardcode and `GetStringType(harvestable.type)` recomputation are gone.

Change in `HarvestablesHandler.test.js`:
- HARV-3 `test.fails` flipped to verified. Mock rewritten to be key-selective (`settingStatic*` false, `settingLiving*` true) so the directional claim is actually exercised.
- Contract test `synthetic contract: Harvestable defaults mobileTypeId to null when omitted`.
- Regression test `pcap-composed: static resource enchant re-gate keeps entity with static settings enabled` (uses the static Log id=3203 from `single-spawn.json`).

Register counts refreshed to 225v/14c/18f, total 257.

## Side-effect analysis

`Harvestable.mobileTypeId` is a new field defaulted to null. Existing code paths that construct `Harvestable` elsewhere (none outside this handler) are unaffected; `addHarvestable` passes `mobileTypeId` explicitly. The batch spawn path (`newSimpleHarvestableObject` -> `addHarvestable` without mobileTypeId) defaults to null, matching the former implicit behaviour.

Re-gate behaviour comparison (pcap id=12227 living Hide and id=3203 static Log):
- Living entity with stored `mobileTypeId=424`, `stringType='Hide'`, isLiving=true after fix -> re-gate checks LIVING Hide settings (previously STATIC Hide, which happened to be the right string but with wrong living flag). Entity survives if LIVING settings enabled.
- Static entity with stored `mobileTypeId=-1`, `stringType='Log'`, isLiving=false after fix -> re-gate checks STATIC Log settings. Same gate as before.

No entity that was correctly handled before is affected negatively.

## Test plan

- [x] Full `npm test` suite: 256 passed + 14 expected fail across 270 tests.
- [x] `npm run lint` exit 0.
- [x] HARV-3 `test.fails` flipped; 2 new regression tests green.

## Chain

Branched on top of #71 (HARV-1 static sentinel). Will auto-rebase if #71 lands first or merges cleanly if this lands first.

## Part of

Small bug cluster (`docs/plans/2026-04-18-small-bug-cluster-design.md`). HARV-1 (#71), CHEST-1 (#72), FISH-1 (#73) already open. CHEST-2 will follow.