### PR TITLE
fix(chests): persist rarity from Parameters[5] on Chest entity (CHEST-2, #29)

### DIFF
--- a/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
+++ b/docs/plans/notes/2026-04-18-handlers-characterization-coverage.md
@@ -19,12 +19,12 @@ Living counter. Updated on every test commit. Archived at plan completion.
 | PlayersHandler | 37 | 2 | 2 | 41 |
 | HarvestablesHandler | 44 | 7 | 2 | 53 |
 | MobsHandler | 59 | 3 | 0 | 62 |
-| ChestsHandler | 11 | 0 | 1 | 12 |
+| ChestsHandler | 13 | 0 | 0 | 13 |
 | FishingHandler | 9 | 0 | 1 | 10 |
 | DungeonsHandler | 19 | 0 | 0 | 19 |
 | WispCageHandler | 9 | 0 | 0 | 9 |
 | EventRouter | 36 | 0 | 11 | 47 |
-| **Total** | **223** | **14** | **18** | **255** |
+| **Total** | **225** | **14** | **17** | **256** |
 
 ## Open observations register
 
@@ -38,7 +38,6 @@ Issue #52 (living Fiber tier mismatch) is NOT a `test.fails` because direction i
 - **HARV-3** HarvestUpdateEvent re-gate uses `isLiving=false` hardcoded and `GetStringType(harvestable.type)` with static typeNumber. Living Fiber critter (typeNumber=16) resolves to HIDE, so re-gate checks static Hide settings. Entity is removed when all static settings are disabled. Pinned by `test.fails('HarvestUpdateEvent preserves living Fiber when static settings are all disabled')`. After fix: re-gate should use the stored stringType and isLiving flag, not recompute them from typeNumber.
 - **PLAY-1** (issue #65) PlayersHandler.handleNewPlayerEvent does not fire alert for hostile in unknown zone. `zonesDatabase.getPvpType(unknown)` falls back to 'safe'; `isPlayerThreat(255, 'safe')` returns false; alert gate skipped. Pinned by `synthetic hostile in unknown zone: alert should fire but does not` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
 - **PLAY-2** (issue #36) PlayersHandler.triggerHostileAlert has no ignore-list check. A player in `alreadyIgnoredPlayers` still triggers the sound alert when their faction changes to 255 in a red zone. Pinned by `synthetic PLAY-2: ignored player still triggers alert on faction change in red zone` in `PlayersHandler.test.js`. Fix lives in `2026-04-18-alerts-and-ignore-list-design.md`.
-- **CHEST-2** (issue #29 root cause at handler layer) ChestsHandler stores only id/pos/chestName on the Chest entity. Rarity (Parameters[5]) and related fields (Parameters[18], Parameters[23]) are discarded. The drawing layer cannot resolve chest colour because the data was never persisted. Pinned by `test.fails('pcap-derived spawn preserves Parameters[5] rarity on the stored Chest entity')` in `ChestsHandler.test.js`. Fix candidate: add rarity field to Chest class and populate from Parameters[5].
 - **ROUTER-1** (issue #57) EventRouter.onResponse opcode 2 (JoinMap) does not extract `isBZ` from `Parameters[103]` hashtable. Post-Protocol18 the field is `{"5": ..., "7": ...}` (non-zero). Current code leaves `map.isBZ` at its prior value. Pinned by `test.fails('ROUTER-1: onResponse JoinMap extracts isBZ from params[103] hashtable')` in `EventRouter.test.js`. Fix design: `2026-04-18-protocol18-regressions-design.md`.
 
 - **ROUTER-2** (issue #53) EventCodes.ChangeFlaggingFinished stale (local 359, real 363). Router case 359 never fires for real game events carrying P[252]=363. Pinned by two `test.fails` in `EventRouter.test.js`. Will flip to pass when `EventCodes.js` is refreshed.

--- a/web/scripts/handlers/ChestsHandler.js
+++ b/web/scripts/handlers/ChestsHandler.js
@@ -1,11 +1,12 @@
 import {CATEGORIES} from "../constants/LoggerConstants.js";
 
 class Chest {
-    constructor(id, posX, posY, name) {
+    constructor(id, posX, posY, name, rarity = null) {
         this.id = id;
         this.posX = posX;
         this.posY = posY;
         this.chestName = name;
+        this.rarity = rarity;
         this.hX = 0;
         this.hY = 0;
         this.lastUpdateTime = Date.now();
@@ -21,13 +22,13 @@ export class ChestsHandler {
         this.chestsList = [];
     }
 
-    addChest(id, posX, posY, name) {
+    addChest(id, posX, posY, name, rarity = null) {
         const existing = this.chestsList.find(chest => chest.id === id);
         if (existing) {
             existing.touch();
             return;
         }
-        const h = new Chest(id, posX, posY, name);
+        const h = new Chest(id, posX, posY, name, rarity);
         this.chestsList.push(h);
     }
 
@@ -71,10 +72,11 @@ export class ChestsHandler {
         const chestId = Parameters[0];
         const chestsPosition = Parameters[1];
         let chestName = Parameters[3];
+        const rarity = Parameters[5] ?? null;
 
         if (typeof chestName === 'string' && chestName.toLowerCase().includes("mist")) {
             chestName = Parameters[4];
         }
-        this.addChest(chestId, chestsPosition[0], chestsPosition[1], chestName);
+        this.addChest(chestId, chestsPosition[0], chestsPosition[1], chestName, rarity);
     }
 }

--- a/web/scripts/handlers/ChestsHandler.test.js
+++ b/web/scripts/handlers/ChestsHandler.test.js
@@ -65,14 +65,21 @@ describe('ChestsHandler', () => {
             expect(() => handler.addChestEvent(p)).not.toThrow();
         });
 
-        // CHEST-2: pinned bug, handler stores chestName only and drops the rarity/type fields (Parameters[5], Parameters[18], Parameters[23]).
-        // Issue #29 reports drawing colour confusion; root cause at handler layer is that rarity is never persisted.
-        test.fails('pcap-derived spawn preserves Parameters[5] rarity on the stored Chest entity', async () => {
+        // @verified 2026-04-19: rarity persisted from Parameters[5] on the stored Chest entity (#29 handler-layer root cause).
+        test('pcap-derived spawn preserves Parameters[5] rarity on the stored Chest entity', async () => {
             const fx = await loadFixture('chests', 'spawn');
             const p = normalizeParams(fx.messages[0].parameters);
             handler.addChestEvent(p);
             const stored = handler.chestsList[0];
             expect(stored.rarity).toBe(p[5]);
+        });
+
+        // @verified 2026-04-19: contract test, addChest without rarity defaults to null on the stored Chest entity.
+        test('synthetic contract: addChest without rarity defaults to null', () => {
+            handler.addChest(42, 0, 0, 'any-chest');
+            const stored = handler.chestsList.find(c => c.id === 42);
+            expect(stored).toBeDefined();
+            expect(stored.rarity).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary

Persist `Parameters[5]` (rarity) on the `Chest` entity. Previously the handler discarded rarity at spawn time, leaving the drawing layer unable to resolve chest colour (handler-layer root cause of #29).

## Scope

`ChestsHandler.js`:
- `Chest` constructor takes a new `rarity = null` argument and stores it.
- `addChest` forwards the new argument (backward compatible, callers without the field keep working).
- `addChestEvent` reads `Parameters[5] ?? null` and passes it through.

`ChestsHandler.test.js`:
- CHEST-2 `test.fails` flipped to verified. The pcap fixture carries `Parameters[5] = 4` on the sole chest spawn, so the assertion matches real data.
- Contract test `synthetic contract: addChest without rarity defaults to null`.

Register counts: ChestsHandler reaches 13v/0c/0f (fully verified handler). Total 224v/14c/18f across 256 tests.

## Side-effect analysis

Every existing caller of `addChest` now omits the new parameter. The `rarity = null` default preserves prior behaviour exactly. No consumer currently reads `chest.rarity`; the drawing-layer resolution for #29 is a separate follow-up.

Edge: if a future chest event omits `Parameters[5]`, the `?? null` keeps the field null. Unlike the pre-change code, no crash or silent mishandling.

## Not in scope

Drawing-layer colour resolution based on `chest.rarity` belongs to a follow-up PR once CHEST-2 lands. This PR exposes the data; using it is separate work.

## Test plan

- [x] Full `npm test` suite: 255 passed + 14 expected fail across 269 tests.
- [x] `npm run lint` exit 0.

## Chain

Branched on top of #72 (CHEST-1 null guard). Both touch `ChestsHandler.js`; rebasing if #72 lands first is trivial.

## Part of

Small bug cluster (`docs/plans/2026-04-18-small-bug-cluster-design.md`). HARV-1 (#71), CHEST-1 (#72), FISH-1 (#73), HARV-3 (#74) open.