### PR TITLE
fix: settings coherence + filter-at-render (closes #81 #65 #25)

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -49,7 +49,7 @@ type Logger struct {
 func New(logsDir string) *Logger {
 	l := &Logger{
 		logsDir:          logsDir,
-		enabled:          true,
+		enabled:          false,
 		sessionStartTime: time.Now(),
 		buffer:           make([]interface{}, 0, MaxBufferSize),
 		stopFlush:        make(chan struct{}),

--- a/internal/templates/pages/enemies.gohtml
+++ b/internal/templates/pages/enemies.gohtml
@@ -161,6 +161,7 @@
         <div class="collapse-title text-xl font-semibold flex items-center gap-2">
             <i data-lucide="sparkles" class="w-5 h-5"></i>
             Other Enemies
+            <span class="badge bg-warning/20 border-warning/40 text-warning gap-1"><i data-lucide="flask-conical" class="w-3 h-3"></i>Not validated yet</span>
         </div>
         <div class="collapse-content">
             <div class="space-y-3 pt-2">

--- a/internal/templates/pages/enemies.gohtml
+++ b/internal/templates/pages/enemies.gohtml
@@ -112,7 +112,7 @@
         <div class="collapse-title text-xl font-semibold flex items-center gap-2">
             <i data-lucide="cloud-fog" class="w-5 h-5"></i>
             Mists Bosses
-            <span class="badge bg-warning/20 border-warning/40 text-warning gap-1"><i data-lucide="flask-conical" class="w-3 h-3"></i>Experimental</span>
+            <span class="badge bg-error/20 border-error/40 text-error gap-1"><i data-lucide="construction" class="w-3 h-3"></i>Not implemented yet</span>
         </div>
         <div class="collapse-content">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3 pt-2">
@@ -161,7 +161,6 @@
         <div class="collapse-title text-xl font-semibold flex items-center gap-2">
             <i data-lucide="sparkles" class="w-5 h-5"></i>
             Other Enemies
-            <span class="badge bg-warning/20 border-warning/40 text-warning gap-1"><i data-lucide="flask-conical" class="w-3 h-3"></i>Experimental</span>
         </div>
         <div class="collapse-content">
             <div class="space-y-3 pt-2">

--- a/internal/templates/pages/players.gohtml
+++ b/internal/templates/pages/players.gohtml
@@ -88,6 +88,14 @@
                         <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
                     </div>
                 </label>
+                <label class="flex items-center gap-3 p-3 rounded-lg bg-error/10 border border-error/20 cursor-pointer group hover:bg-error/20 transition-colors md:col-span-2">
+                    <input type="checkbox" id="settingFlashDangerousPlayer" class="checkbox checkbox-error">
+                    <i data-lucide="square-dashed" class="w-5 h-5 text-error"></i>
+                    <span class="text-base-content/80 group-hover:text-base-content transition-colors font-medium">Pulsating Border While Hostile Nearby</span>
+                    <div class="tooltip" data-tip="Draws a red pulsating border around the radar while hostile players are detected.">
+                        <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
+                    </div>
+                </label>
             </div>
         </div>
     </div>
@@ -183,7 +191,7 @@
             };
 
             ["settingShowPlayers", "settingItems", "settingShowSpells", "settingShowPlayerHealthBar",
-                "settingSound", "settingFlash", "settingPassivePlayers", "settingFactionPlayers",
+                "settingSound", "settingFlash", "settingFlashDangerousPlayer", "settingPassivePlayers", "settingFactionPlayers",
                 "settingDangerousPlayers"].forEach(bindCheckbox);
 
             const settingMaxPlayersDisplay = document.getElementById("settingMaxPlayersDisplay");

--- a/internal/templates/pages/resources.gohtml
+++ b/internal/templates/pages/resources.gohtml
@@ -95,9 +95,6 @@
             <label class="flex items-center gap-3 cursor-pointer group">
                 <input type="checkbox" id="settingFishing" class="checkbox checkbox-primary">
                 <span class="text-base-content/80 group-hover:text-base-content transition-colors">Show Fishing Pools</span>
-                <div class="tooltip" data-tip="This feature is still a work in progress.">
-                    <span class="badge bg-warning/20 border-warning/40 text-warning gap-1"><i data-lucide="flask-conical" class="w-3 h-3"></i>Experimental</span>
-                </div>
                 <div class="tooltip" data-tip="Display fishing zones on the radar.">
                     <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
                 </div>

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -270,24 +270,6 @@
                 </div>
             </div>
 
-            <!-- RAW Packet Debug (Warning box) -->
-            <div class="mt-4 p-3 rounded-lg bg-warning/10 border border-warning/20">
-                <h4 class="text-xs font-semibold text-warning mb-2 flex items-center gap-2">
-                    <i data-lucide="alert-triangle" class="w-4 h-4"></i>
-                    RAW Packet Debug (Very Verbose)
-                </h4>
-                <div class="flex flex-wrap gap-4">
-                    <label class="flex items-center gap-2 cursor-pointer group">
-                        <input type="checkbox" id="settingDebugRawPacketsConsole" class="checkbox checkbox-warning checkbox-xs">
-                        <span class="text-base-content/80 text-xs group-hover:text-base-content">Console</span>
-                    </label>
-                    <label class="flex items-center gap-2 cursor-pointer group">
-                        <input type="checkbox" id="settingDebugRawPacketsServer" class="checkbox checkbox-warning checkbox-xs">
-                        <span class="text-base-content/80 text-xs group-hover:text-base-content">Server</span>
-                    </label>
-                </div>
-            </div>
-
             <!-- Export -->
             <div class="mt-4 flex items-center gap-4">
                 <button id="downloadLogsBtn" class="btn btn-primary btn-sm">
@@ -402,8 +384,6 @@
             // Console & Server settings
             bindCheckbox("settingLogToConsole");
             bindCheckbox("settingLogToServer");
-            bindCheckbox("settingDebugRawPacketsConsole");
-            bindCheckbox("settingDebugRawPacketsServer");
 
             // WebSocket performance (default: enabled)
             if (settingsSync.get("settingWsCoalescing") === null) settingsSync.setBool("settingWsCoalescing", true);

--- a/web/scripts/drawings/FishingDrawing.js
+++ b/web/scripts/drawings/FishingDrawing.js
@@ -13,6 +13,7 @@ export class FishingDrawing extends DrawingUtils
 
     draw(ctx, fishes)
     {
+        if (!settingsSync.getBool("settingFishing")) return;
         const showCount = settingsSync.getBool("settingResourceCount");
         for (const fish of fishes)
         {

--- a/web/scripts/drawings/FishingDrawing.js
+++ b/web/scripts/drawings/FishingDrawing.js
@@ -3,6 +3,11 @@ import settingsSync from "../utils/SettingsSync.js";
 
 export class FishingDrawing extends DrawingUtils
 {
+    constructor() {
+        super();
+        this.lastVisibleCount = 0;
+    }
+
     interpolate(fishes, lpX, lpY, t)
     {
         for (const fish of fishes)
@@ -13,6 +18,7 @@ export class FishingDrawing extends DrawingUtils
 
     draw(ctx, fishes)
     {
+        this.lastVisibleCount = 0;
         if (!settingsSync.getBool("settingFishing")) return;
         const showCount = settingsSync.getBool("settingResourceCount");
         for (const fish of fishes)
@@ -23,6 +29,7 @@ export class FishingDrawing extends DrawingUtils
             if (showCount) {
                 this.drawText(point.x, point.y + this.getScaledSize(18), `${fish.sizeSpawned}/${fish.totalSize}`, ctx);
             }
+            this.lastVisibleCount++;
         }
     }
 }

--- a/web/scripts/drawings/FishingDrawing.js
+++ b/web/scripts/drawings/FishingDrawing.js
@@ -1,4 +1,5 @@
 import {DrawingUtils} from "../utils/DrawingUtils.js";
+import settingsSync from "../utils/SettingsSync.js";
 
 export class FishingDrawing extends DrawingUtils
 {
@@ -12,12 +13,15 @@ export class FishingDrawing extends DrawingUtils
 
     draw(ctx, fishes)
     {
+        const showCount = settingsSync.getBool("settingResourceCount");
         for (const fish of fishes)
         {
             const point = this.transformPoint(fish.hX, fish.hY);
 
             this.DrawCustomImage(ctx, point.x, point.y, "fish", "Resources", 18);
-            this.drawText(point.x, point.y + this.getScaledSize(18), `${fish.sizeSpawned}/${fish.totalSize}`, ctx)
+            if (showCount) {
+                this.drawText(point.x, point.y + this.getScaledSize(18), `${fish.sizeSpawned}/${fish.totalSize}`, ctx);
+            }
         }
     }
 }

--- a/web/scripts/drawings/FishingDrawing.test.js
+++ b/web/scripts/drawings/FishingDrawing.test.js
@@ -1,0 +1,60 @@
+// synthetic: render-time gate on settingFishing + settingResourceCount; filter logic is deterministic from entity + settings.
+import {describe, test, expect, beforeEach, vi} from 'vitest';
+
+vi.mock('../utils/SettingsSync.js', () => ({
+    default: {
+        getBool: vi.fn(() => true),
+        getJSON: vi.fn(() => null),
+        getNumber: vi.fn((_k, d) => d ?? 0),
+    },
+}));
+
+const {FishingDrawing} = await import('./FishingDrawing.js');
+const settingsSync = (await import('../utils/SettingsSync.js')).default;
+
+function makePool({id = 1, sizeSpawned = 1, total = 5} = {}) {
+    return {id, hX: 10, hY: 20, sizeSpawned, sizeLeftToSpawn: total - sizeSpawned, totalSize: total, type: 'FishingNodeSwarm'};
+}
+
+describe('FishingDrawing render-time filter', () => {
+    let drawing;
+    let ctx;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        drawing = new FishingDrawing();
+        drawing.DrawCustomImage = vi.fn();
+        drawing.transformPoint = vi.fn((x, y) => ({x, y}));
+        drawing.drawText = vi.fn();
+        drawing.getScaledSize = vi.fn(s => s);
+        ctx = {};
+    });
+
+    // @verified 2026-04-24: settingFishing=false hides every pool at render time.
+    test('settingFishing=false draws nothing', () => {
+        settingsSync.getBool.mockImplementation(() => false);
+        drawing.draw(ctx, [makePool({id: 1}), makePool({id: 2})]);
+        expect(drawing.DrawCustomImage).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: settingFishing=true renders pool icons.
+    test('settingFishing=true draws pool icons', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingFishing');
+        drawing.draw(ctx, [makePool({id: 1})]);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fish', 'Resources', 18);
+    });
+
+    // @verified 2026-04-24: settingResourceCount still independently gates the count text.
+    test('settingResourceCount=false does not call drawText even when fishing is on', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingFishing');
+        drawing.draw(ctx, [makePool({id: 1, sizeSpawned: 3, total: 5})]);
+        expect(drawing.drawText).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: settingResourceCount=true calls drawText with sizeSpawned/totalSize format.
+    test('settingResourceCount=true calls drawText with n/total', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingFishing' || key === 'settingResourceCount');
+        drawing.draw(ctx, [makePool({id: 1, sizeSpawned: 3, total: 5})]);
+        expect(drawing.drawText).toHaveBeenCalledWith(10, 38, '3/5', ctx);
+    });
+});

--- a/web/scripts/drawings/FishingDrawing.test.js
+++ b/web/scripts/drawings/FishingDrawing.test.js
@@ -57,4 +57,18 @@ describe('FishingDrawing render-time filter', () => {
         drawing.draw(ctx, [makePool({id: 1, sizeSpawned: 3, total: 5})]);
         expect(drawing.drawText).toHaveBeenCalledWith(10, 38, '3/5', ctx);
     });
+
+    // @verified 2026-04-24: lastVisibleCount reflects rendered pools; zero when settingFishing is off.
+    test('lastVisibleCount is zero when settingFishing is off', () => {
+        settingsSync.getBool.mockImplementation(() => false);
+        drawing.draw(ctx, [makePool({id: 1}), makePool({id: 2})]);
+        expect(drawing.lastVisibleCount).toBe(0);
+    });
+
+    // @verified 2026-04-24: lastVisibleCount equals rendered pool count when settingFishing is on.
+    test('lastVisibleCount equals rendered pool count when settingFishing is on', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingFishing');
+        drawing.draw(ctx, [makePool({id: 1}), makePool({id: 2}), makePool({id: 3})]);
+        expect(drawing.lastVisibleCount).toBe(3);
+    });
 });

--- a/web/scripts/drawings/HarvestablesDrawing.js
+++ b/web/scripts/drawings/HarvestablesDrawing.js
@@ -4,6 +4,11 @@ import {CATEGORIES} from "../constants/LoggerConstants.js";
 import {shouldRenderLivingResource, shouldRenderStaticResource} from '../utils/LivingResourceFilter.js';
 
 export class HarvestablesDrawing extends DrawingUtils  {
+    constructor() {
+        super();
+        this.lastVisibleCount = 0;
+    }
+
     interpolate(harvestables, lpX, lpY, t) {
         for (const harvestableOne of harvestables) {
             this.interpolateEntity(harvestableOne, lpX, lpY, t);
@@ -14,6 +19,7 @@ export class HarvestablesDrawing extends DrawingUtils  {
     {
         // Clusters are detected and drawn centrally in Utils.render when overlayCluster is enabled
         // (to merge static harvestables and living resources into the same clustering pass)
+        this.lastVisibleCount = 0;
 
         for (const harvestableOne of harvestables)
         {
@@ -97,6 +103,8 @@ export class HarvestablesDrawing extends DrawingUtils  {
             }
 
             const point = this.transformPoint(harvestableOne.hX, harvestableOne.hY);
+
+            this.lastVisibleCount++;
 
             // Draw resource icon (same size as living resources)
             this.DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 40);

--- a/web/scripts/drawings/HarvestablesDrawing.test.js
+++ b/web/scripts/drawings/HarvestablesDrawing.test.js
@@ -224,4 +224,26 @@ describe('HarvestablesDrawing render-time routing', () => {
         drawing.invalidate(ctx, [entity]);
         expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 1, 2, `${imagePrefix}_3_1`, 'Resources', 40);
     });
+
+    // @verified 2026-04-24: lastVisibleCount reflects only harvestables passing the render gate.
+    test('lastVisibleCount counts only rendered harvestables after filters', () => {
+        settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
+        const kept = {id: 1, hX: 1, hY: 2, size: 3, tier: 4, charges: 0, stringType: 'Fiber', mobileTypeId: -1, type: 14};
+        const dropped = {id: 2, hX: 3, hY: 4, size: 3, tier: 4, charges: 0, stringType: 'Hide', mobileTypeId: -1, type: 20};
+
+        drawing.invalidate(ctx, [kept, dropped]);
+
+        expect(drawing.lastVisibleCount).toBe(1);
+    });
+
+    // @verified 2026-04-24: lastVisibleCount resets on each invalidate call.
+    test('lastVisibleCount resets on each invalidate call', () => {
+        settingsSync.getJSON.mockReturnValue(allFalse());
+        drawing.invalidate(ctx, [{id: 1, hX: 1, hY: 2, size: 3, tier: 4, charges: 0, stringType: 'Fiber', mobileTypeId: -1, type: 14}]);
+        expect(drawing.lastVisibleCount).toBe(0);
+
+        settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
+        drawing.invalidate(ctx, [{id: 2, hX: 1, hY: 2, size: 3, tier: 4, charges: 0, stringType: 'Fiber', mobileTypeId: -1, type: 14}]);
+        expect(drawing.lastVisibleCount).toBe(1);
+    });
 });

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -48,6 +48,11 @@ export class MobsDrawing extends DrawingUtils
             }
             else if (mobOne.type >= EnemyType.Enemy && mobOne.type <= EnemyType.Boss)
             {
+                if (settingsSync.getBool("settingShowMinimumHealthEnemies")) {
+                    const threshold = settingsSync.getNumber("settingTextMinimumHealthEnemies", 0);
+                    if ((mobOne.maxHealth ?? 0) < threshold) continue;
+                }
+
                 // Use color-coded circles for hostile mobs (not images)
                 // imageName stays undefined to trigger the colored circle rendering below
                 // The color is determined by mob.type (Enemy=green, EnchantedEnemy=purple, MiniBoss=orange, Boss=red)

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -1,5 +1,5 @@
 import {DrawingUtils} from "../utils/DrawingUtils.js";
-import {EnemyType} from "../handlers/MobsHandler.js";
+import {EnemyType, getSettingNameForEnemyType} from "../handlers/MobsHandler.js";
 import {CATEGORIES} from "../constants/LoggerConstants.js";
 import settingsSync from "../utils/SettingsSync.js";
 import {shouldRenderLivingResource} from "../utils/LivingResourceFilter.js";
@@ -48,6 +48,13 @@ export class MobsDrawing extends DrawingUtils
             }
             else if (mobOne.type >= EnemyType.Enemy && mobOne.type <= EnemyType.Boss)
             {
+                if (!mobOne.identified) {
+                    if (settingsSync.getBool("settingShowUnmanagedEnemies") === false) continue;
+                } else {
+                    const settingName = getSettingNameForEnemyType(mobOne.type);
+                    if (settingName && settingsSync.getBool(settingName) === false) continue;
+                }
+
                 if (settingsSync.getBool("settingShowMinimumHealthEnemies")) {
                     const threshold = settingsSync.getNumber("settingTextMinimumHealthEnemies", 0);
                     if ((mobOne.maxHealth ?? 0) < threshold) continue;
@@ -61,6 +68,8 @@ export class MobsDrawing extends DrawingUtils
             }
             else if (mobOne.type == EnemyType.Drone)
             {
+                if (!settingsSync.getBool("settingAvaloneDrones")) continue;
+
                 // Use color-coded circles for drones (not images)
                 // imageName stays undefined to trigger the colored circle rendering below
 
@@ -79,6 +88,8 @@ export class MobsDrawing extends DrawingUtils
             }
             else if (mobOne.type == EnemyType.Events)
             {
+                if (!settingsSync.getBool("settingShowEventEnemies")) continue;
+
                 // Only set imageName if mob has been identified (has name from mobinfo)
                 // Otherwise leave undefined and fallback blue circle will be drawn
                 if (mobOne.name) {

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -6,6 +6,11 @@ import {shouldRenderLivingResource} from "../utils/LivingResourceFilter.js";
 
 export class MobsDrawing extends DrawingUtils
 {
+    constructor() {
+        super();
+        this.lastVisibleCount = 0;
+    }
+
     interpolate(mobs, lpX, lpY, t)
     {
         for (const mobOne of mobs)
@@ -17,6 +22,7 @@ export class MobsDrawing extends DrawingUtils
     invalidate(ctx, mobs)
     {
         // Note: cluster detection & drawing is handled centrally in Utils.render (merged static + living resources)
+        this.lastVisibleCount = 0;
 
         for (const mobOne of mobs)
         {
@@ -56,7 +62,7 @@ export class MobsDrawing extends DrawingUtils
                 }
 
                 if (settingsSync.getBool("settingShowMinimumHealthEnemies")) {
-                    const threshold = settingsSync.getNumber("settingTextMinimumHealthEnemies", 0);
+                    const threshold = settingsSync.getNumber("settingTextMinimumHealthEnemies", 2100);
                     if ((mobOne.maxHealth ?? 0) < threshold) continue;
                 }
 
@@ -99,6 +105,8 @@ export class MobsDrawing extends DrawingUtils
 
                 drawId = settingsSync.getBool("settingEnemiesID");
             }
+
+            this.lastVisibleCount++;
 
             if (imageName !== undefined && imageFolder !== undefined)
                 this.DrawCustomImage(ctx, point.x, point.y, imageName, imageFolder, 40); // Size scaled in DrawCustomImage

--- a/web/scripts/drawings/MobsDrawing.test.js
+++ b/web/scripts/drawings/MobsDrawing.test.js
@@ -240,7 +240,7 @@ describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHeal
     });
 
     function hostile({id = 1, maxHealth = 500, type = EnemyType.Enemy} = {}) {
-        return {id, typeId: 9000, hX: 10, hY: 20, tier: 4, enchantmentLevel: 0, name: 'Hostile', type, getCurrentHP: () => maxHealth, maxHealth};
+        return {id, typeId: 9000, hX: 10, hY: 20, tier: 4, enchantmentLevel: 0, name: 'Hostile', identified: true, type, getCurrentHP: () => maxHealth, maxHealth};
     }
 
     // @verified 2026-04-24: when the filter is off, hostile mob below any value renders normally.
@@ -265,7 +265,7 @@ describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHeal
 
     // @verified 2026-04-24: filter on, maxHealth above threshold renders normally.
     test('filter on: hostile with maxHealth=3000 above threshold=2100 renders', () => {
-        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar' || key === 'settingNormalEnemy');
         settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
 
         drawing.invalidate(ctx, [hostile({maxHealth: 3000})]);
@@ -275,7 +275,7 @@ describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHeal
 
     // @verified 2026-04-24: filter on, boss (high tier hostile) with high HP still renders.
     test('filter on: boss with maxHealth=50000 above threshold=2100 renders', () => {
-        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar' || key === 'settingBossEnemy');
         settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
 
         drawing.invalidate(ctx, [hostile({maxHealth: 50000, type: EnemyType.Boss})]);
@@ -293,5 +293,75 @@ describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHeal
         drawing.invalidate(ctx, [living]);
 
         expect(drawing.DrawCustomImage).toHaveBeenCalled();
+    });
+});
+
+describe('MobsDrawing hostile/drone/events filter at render (moved from spawn)', () => {
+    let drawing;
+    let ctx;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        settingsSync.getNumber.mockImplementation((_k, d) => d ?? 0);
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        drawing = new MobsDrawing();
+        drawing.DrawCustomImage = vi.fn();
+        drawing.transformPoint = vi.fn((x, y) => ({x, y}));
+        drawing.interpolateEntity = vi.fn();
+        drawing.drawTextItems = vi.fn();
+        drawing.drawFilledCircle = vi.fn();
+        drawing.drawDistanceIndicator = vi.fn();
+        drawing.drawHealthBar = vi.fn();
+        drawing.getEnemyColor = vi.fn(() => '#ffffff');
+        drawing.getEnemyTypeName = vi.fn(() => 'unknown');
+        drawing.getScaledSize = vi.fn(s => s);
+        drawing.getScaledFontSize = vi.fn(s => s);
+        ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
+    });
+
+    function hostile({id = 1, type = EnemyType.Enemy, identified = true, maxHealth = 500} = {}) {
+        return {id, typeId: 9000, hX: 10, hY: 20, tier: 4, enchantmentLevel: 0, name: identified ? 'Known' : null, identified, type, getCurrentHP: () => maxHealth, maxHealth};
+    }
+
+    // @verified 2026-04-24: identified Enemy is skipped at render when settingNormalEnemy is off.
+    test('identified Enemy with settingNormalEnemy=false is not drawn', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingNormalEnemy');
+        drawing.invalidate(ctx, [hostile({type: EnemyType.Enemy})]);
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: identified Boss is skipped when settingBossEnemy is off.
+    test('identified Boss with settingBossEnemy=false is not drawn', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingBossEnemy');
+        drawing.invalidate(ctx, [hostile({type: EnemyType.Boss})]);
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: identified EnchantedEnemy is drawn when settingEnchantedEnemy is on.
+    test('identified EnchantedEnemy with settingEnchantedEnemy=true is drawn', () => {
+        settingsSync.getBool.mockImplementation(() => true);
+        drawing.invalidate(ctx, [hostile({type: EnemyType.EnchantedEnemy})]);
+        expect(drawing.drawFilledCircle).toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: unidentified mob uses settingShowUnmanagedEnemies gate.
+    test('unidentified mob with settingShowUnmanagedEnemies=false is not drawn', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingShowUnmanagedEnemies');
+        drawing.invalidate(ctx, [hostile({identified: false})]);
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: Drone gated by settingAvaloneDrones.
+    test('Drone with settingAvaloneDrones=false is not drawn', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingAvaloneDrones');
+        drawing.invalidate(ctx, [hostile({type: EnemyType.Drone})]);
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: Events type gated by settingShowEventEnemies.
+    test('Events enemy with settingShowEventEnemies=false is not drawn', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingShowEventEnemies');
+        drawing.invalidate(ctx, [hostile({type: EnemyType.Events, identified: true})]);
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
     });
 });

--- a/web/scripts/drawings/MobsDrawing.test.js
+++ b/web/scripts/drawings/MobsDrawing.test.js
@@ -9,6 +9,7 @@ vi.mock('../utils/SettingsSync.js', () => ({
     default: {
         getBool: vi.fn(() => true),
         getJSON: vi.fn(() => null),
+        getNumber: vi.fn((_k, d) => d ?? 0),
     },
 }));
 
@@ -213,5 +214,84 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
         };
         drawing.invalidate(ctx, [dead]);
         expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_7_2', 'Resources', 40);
+    });
+});
+
+describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHealthEnemies + settingTextMinimumHealthEnemies)', () => {
+    let drawing;
+    let ctx;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        drawing = new MobsDrawing();
+        drawing.DrawCustomImage = vi.fn();
+        drawing.transformPoint = vi.fn((x, y) => ({x, y}));
+        drawing.interpolateEntity = vi.fn();
+        drawing.drawTextItems = vi.fn();
+        drawing.drawFilledCircle = vi.fn();
+        drawing.drawDistanceIndicator = vi.fn();
+        drawing.drawHealthBar = vi.fn();
+        drawing.getEnemyColor = vi.fn(() => '#ffffff');
+        drawing.getEnemyTypeName = vi.fn(() => 'unknown');
+        drawing.getScaledSize = vi.fn(s => s);
+        drawing.getScaledFontSize = vi.fn(s => s);
+        ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
+    });
+
+    function hostile({id = 1, maxHealth = 500, type = EnemyType.Enemy} = {}) {
+        return {id, typeId: 9000, hX: 10, hY: 20, tier: 4, enchantmentLevel: 0, name: 'Hostile', type, getCurrentHP: () => maxHealth, maxHealth};
+    }
+
+    // @verified 2026-04-24: when the filter is off, hostile mob below any value renders normally.
+    test('filter off: hostile with maxHealth=100 still renders', () => {
+        settingsSync.getBool.mockImplementation(key => key !== 'settingShowMinimumHealthEnemies');
+        settingsSync.getNumber.mockReturnValue(2100);
+
+        drawing.invalidate(ctx, [hostile({maxHealth: 100})]);
+
+        expect(drawing.drawFilledCircle).toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: filter on, maxHealth below threshold skips the mob (no circle drawn).
+    test('filter on: hostile with maxHealth=1000 below threshold=2100 is skipped', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
+
+        drawing.invalidate(ctx, [hostile({maxHealth: 1000})]);
+
+        expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: filter on, maxHealth above threshold renders normally.
+    test('filter on: hostile with maxHealth=3000 above threshold=2100 renders', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
+
+        drawing.invalidate(ctx, [hostile({maxHealth: 3000})]);
+
+        expect(drawing.drawFilledCircle).toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: filter on, boss (high tier hostile) with high HP still renders.
+    test('filter on: boss with maxHealth=50000 above threshold=2100 renders', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
+
+        drawing.invalidate(ctx, [hostile({maxHealth: 50000, type: EnemyType.Boss})]);
+
+        expect(drawing.drawFilledCircle).toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: filter applies only to hostile types; living resource is unaffected.
+    test('filter on: living resource is not gated by min HP filter', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingShowMinimumHealthEnemies' || key === 'settingEnemiesHealthBar');
+        settingsSync.getJSON.mockImplementation(key => key === 'settingLivingFiberEnchants' ? {e0: Array(8).fill(true), e1: Array(8).fill(true), e2: Array(8).fill(true), e3: Array(8).fill(true), e4: Array(8).fill(true)} : null);
+        settingsSync.getNumber.mockImplementation((key, d) => key === 'settingTextMinimumHealthEnemies' ? 2100 : (d ?? 0));
+
+        const living = {id: 20, typeId: 529, hX: 10, hY: 20, tier: 4, enchantmentLevel: 0, name: 'Fiber', type: EnemyType.LivingHarvestable, getCurrentHP: () => 100, maxHealth: 100};
+        drawing.invalidate(ctx, [living]);
+
+        expect(drawing.DrawCustomImage).toHaveBeenCalled();
     });
 });

--- a/web/scripts/drawings/MobsDrawing.test.js
+++ b/web/scripts/drawings/MobsDrawing.test.js
@@ -97,9 +97,10 @@ describe('MobsDrawing living resource filter at render', () => {
     // @verified 2026-04-24: hostile enemy (non-living) is not subject to living filter; circle rendering path.
     test('hostile enemy (non-living) is not subject to living filter', () => {
         settingsSync.getJSON.mockReturnValue(null);
+        settingsSync.getBool.mockImplementation(key => key !== 'settingShowMinimumHealthEnemies');
         const hostile = {
             id: 2, typeId: 2067, hX: 10, hY: 20, tier: 5, enchantmentLevel: 0,
-            name: 'T5_MOB_ROAMING_KEEPER_CAMP_UNPROVEN_MALE',
+            name: 'T5_MOB_ROAMING_KEEPER_CAMP_UNPROVEN_MALE', identified: true,
             type: EnemyType.Enemy,
             getCurrentHP: () => 100, maxHealth: 100,
         };
@@ -339,7 +340,7 @@ describe('MobsDrawing hostile/drone/events filter at render (moved from spawn)',
 
     // @verified 2026-04-24: identified EnchantedEnemy is drawn when settingEnchantedEnemy is on.
     test('identified EnchantedEnemy with settingEnchantedEnemy=true is drawn', () => {
-        settingsSync.getBool.mockImplementation(() => true);
+        settingsSync.getBool.mockImplementation(key => key !== 'settingShowMinimumHealthEnemies');
         drawing.invalidate(ctx, [hostile({type: EnemyType.EnchantedEnemy})]);
         expect(drawing.drawFilledCircle).toHaveBeenCalled();
     });
@@ -363,5 +364,25 @@ describe('MobsDrawing hostile/drone/events filter at render (moved from spawn)',
         settingsSync.getBool.mockImplementation(key => key !== 'settingShowEventEnemies');
         drawing.invalidate(ctx, [hostile({type: EnemyType.Events, identified: true})]);
         expect(drawing.drawFilledCircle).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-04-24: lastVisibleCount reflects only mobs that passed the render gates.
+    test('lastVisibleCount counts only rendered mobs after filters', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingNormalEnemy');
+        const kept = hostile({id: 1, type: EnemyType.Enemy});
+        const dropped = hostile({id: 2, type: EnemyType.Boss});
+        drawing.invalidate(ctx, [kept, dropped]);
+        expect(drawing.lastVisibleCount).toBe(1);
+    });
+
+    // @verified 2026-04-24: lastVisibleCount resets at the start of every invalidate.
+    test('lastVisibleCount resets on each invalidate call', () => {
+        settingsSync.getBool.mockImplementation(() => false);
+        drawing.invalidate(ctx, [hostile({id: 1})]);
+        expect(drawing.lastVisibleCount).toBe(0);
+
+        settingsSync.getBool.mockImplementation(key => key === 'settingNormalEnemy' || key === 'settingEnemiesHealthBar');
+        drawing.invalidate(ctx, [hostile({id: 2})]);
+        expect(drawing.lastVisibleCount).toBe(1);
     });
 });

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -1,5 +1,4 @@
 import {CATEGORIES} from "../constants/LoggerConstants.js";
-import settingsSync from "../utils/SettingsSync.js";
 
 class Fish
 {

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -31,8 +31,6 @@ export class FishingHandler
 
     newFishEvent(Parameters)
     {
-        if (settingsSync.getBool("settingFishing") === false) return;
-
         const id = Parameters[0];
         const type = Parameters[4];
         const coor = Parameters[1];
@@ -79,8 +77,6 @@ export class FishingHandler
 
     fishingEnd(Parameters)
     {
-        if (settingsSync.getBool("settingFishing") === false) return;
-
         window.logger?.debug(CATEGORIES.FISHING, 'fishing_end', {
             parameters: Parameters
         });

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -39,7 +39,7 @@ export class FishingHandler
         const sizeSpawned = Parameters[2];
         const sizeLeftToSpawn = Parameters[3];
 
-        if (type === null || type === undefined) return;
+        if (!type) return;
         if (!coor) return;
 
         const posX = coor[0];

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -45,6 +45,11 @@ export class FishingHandler
         const posX = coor[0];
         const posY = coor[1];
 
+        window.logger?.debug(CATEGORIES.FISHING, 'fish_spawn', {
+            id, type, posX, posY, sizeSpawned, sizeLeftToSpawn,
+            total: sizeSpawned + sizeLeftToSpawn
+        });
+
         this.upsertFish(
             id,
             posX,

--- a/web/scripts/handlers/FishingHandler.js
+++ b/web/scripts/handlers/FishingHandler.js
@@ -31,7 +31,7 @@ export class FishingHandler
 
     newFishEvent(Parameters)
     {
-        if (settingsSync.getBool("settingShowFish") === false) return;
+        if (settingsSync.getBool("settingFishing") === false) return;
 
         const id = Parameters[0];
         const type = Parameters[4];
@@ -74,7 +74,7 @@ export class FishingHandler
 
     fishingEnd(Parameters)
     {
-        if (settingsSync.getBool("settingShowFish") === false) return;
+        if (settingsSync.getBool("settingFishing") === false) return;
 
         window.logger?.debug(CATEGORIES.FISHING, 'fishing_end', {
             parameters: Parameters

--- a/web/scripts/handlers/FishingHandler.test.js
+++ b/web/scripts/handlers/FishingHandler.test.js
@@ -81,8 +81,8 @@ describe('FishingHandler', () => {
             expect(handler.fishes[0].totalSize).toBe(9);
         });
 
-        // @verified 2026-04-18: settingShowFish=false causes newFishEvent to return early; nothing added.
-        test('synthetic: settingShowFish=false skips spawn', () => {
+        // @verified 2026-04-24: settingFishing=false causes newFishEvent to return early; nothing added.
+        test('synthetic: settingFishing=false skips spawn', () => {
             settingsSync.getBool.mockReturnValue(false);
 
             handler.newFishEvent({0: 1, 1: [0, 0], 2: 5, 3: 0, 4: 'FishingNodeFish'});
@@ -124,8 +124,8 @@ describe('FishingHandler', () => {
             expect(handler.fishes).toHaveLength(1);
         });
 
-        // @verified 2026-04-18: fishingEnd with settingShowFish=false returns early; fish is not removed.
-        test('synthetic: fishingEnd with settingShowFish=false does not remove fish', () => {
+        // @verified 2026-04-24: fishingEnd with settingFishing=false returns early; fish is not removed.
+        test('synthetic: fishingEnd with settingFishing=false does not remove fish', () => {
             handler.fishes.push({id: 55, posX: 0, posY: 0, type: 'FishingNodeFish', sizeSpawned: 1, sizeLeftToSpawn: 0, totalSize: 1, hX: 0, hY: 0, lastUpdateTime: Date.now(), touch() {}});
             settingsSync.getBool.mockReturnValue(false);
 

--- a/web/scripts/handlers/FishingHandler.test.js
+++ b/web/scripts/handlers/FishingHandler.test.js
@@ -43,20 +43,20 @@ describe('FishingHandler', () => {
             expect(handler.fishes[0].totalSize).toBe(p[2] + p[3]);
         });
 
-        // @verified 2026-04-19: empty-string type is valid data (3 of 5 pcap events), guard narrowed to null/undefined so fishpools no longer get discarded.
-        test('pcap-derived spawn: entries with type="" are added (FISH-1 fixed)', async () => {
+        // @verified 2026-04-24: empty-string type entries are phantom/zone-level broadcasts, not real pools.
+        // Live session log session_2026-04-24T19-35-04 showed every type="" entry has total=15 and is placed
+        // on land; real pools carry FishingNodeFish (total=1), FishingNodeSwarm (total=5), or FishingNodeChest
+        // (total=1). Reverting the FISH-1 narrowing: empty type is now filtered out again.
+        test('pcap-derived spawn: entries with type="" are filtered out', async () => {
             const fx = await loadFixture('fishing', 'spawn');
             const emptyTypeMsgs = fx.messages.filter(m => m.parameters['4'] === '');
-            expect(emptyTypeMsgs).toHaveLength(3);
+            expect(emptyTypeMsgs.length).toBeGreaterThan(0);
 
             for (const msg of emptyTypeMsgs) {
                 handler.newFishEvent(normalizeParams(msg.parameters));
             }
 
-            expect(handler.fishes).toHaveLength(3);
-            for (const fish of handler.fishes) {
-                expect(fish.type).toBe('');
-            }
+            expect(handler.fishes).toHaveLength(0);
         });
 
         // @verified 2026-04-18: second event for the same id updates position and size in place without adding a new entry.

--- a/web/scripts/handlers/FishingHandler.test.js
+++ b/web/scripts/handlers/FishingHandler.test.js
@@ -81,13 +81,13 @@ describe('FishingHandler', () => {
             expect(handler.fishes[0].totalSize).toBe(9);
         });
 
-        // @verified 2026-04-24: settingFishing=false causes newFishEvent to return early; nothing added.
-        test('synthetic: settingFishing=false skips spawn', () => {
+        // @verified 2026-04-24: settingFishing=false no longer gates spawn; filter is applied at render so toggles take effect instantly.
+        test('synthetic: settingFishing=false still adds pool to list (render-time filter only)', () => {
             settingsSync.getBool.mockReturnValue(false);
 
             handler.newFishEvent({0: 1, 1: [0, 0], 2: 5, 3: 0, 4: 'FishingNodeFish'});
 
-            expect(handler.fishes).toHaveLength(0);
+            expect(handler.fishes).toHaveLength(1);
         });
 
         // @verified 2026-04-18: missing Parameters[4] (null) is falsy; newFishEvent returns early.
@@ -124,14 +124,14 @@ describe('FishingHandler', () => {
             expect(handler.fishes).toHaveLength(1);
         });
 
-        // @verified 2026-04-24: fishingEnd with settingFishing=false returns early; fish is not removed.
-        test('synthetic: fishingEnd with settingFishing=false does not remove fish', () => {
+        // @verified 2026-04-24: fishingEnd now removes fish regardless of settingFishing, mirroring the render-time filter migration.
+        test('synthetic: fishingEnd removes fish even when settingFishing=false', () => {
             handler.fishes.push({id: 55, posX: 0, posY: 0, type: 'FishingNodeFish', sizeSpawned: 1, sizeLeftToSpawn: 0, totalSize: 1, hX: 0, hY: 0, lastUpdateTime: Date.now(), touch() {}});
             settingsSync.getBool.mockReturnValue(false);
 
             handler.fishingEnd({0: 55});
 
-            expect(handler.fishes).toHaveLength(1);
+            expect(handler.fishes).toHaveLength(0);
         });
     });
 

--- a/web/scripts/handlers/FishingHandler.test.js
+++ b/web/scripts/handlers/FishingHandler.test.js
@@ -43,10 +43,7 @@ describe('FishingHandler', () => {
             expect(handler.fishes[0].totalSize).toBe(p[2] + p[3]);
         });
 
-        // @verified 2026-04-24: empty-string type entries are phantom/zone-level broadcasts, not real pools.
-        // Live session log session_2026-04-24T19-35-04 showed every type="" entry has total=15 and is placed
-        // on land; real pools carry FishingNodeFish (total=1), FishingNodeSwarm (total=5), or FishingNodeChest
-        // (total=1). Reverting the FISH-1 narrowing: empty type is now filtered out again.
+        // @verified 2026-04-24: empty-string type entries are phantom zone broadcasts, not real pools; filter drops them.
         test('pcap-derived spawn: entries with type="" are filtered out', async () => {
             const fx = await loadFixture('fishing', 'spawn');
             const emptyTypeMsgs = fx.messages.filter(m => m.parameters['4'] === '');

--- a/web/scripts/handlers/MobsHandler.js
+++ b/web/scripts/handlers/MobsHandler.js
@@ -16,6 +16,16 @@ export const EnemyType =
         Events: 9,
     };
 
+export function getSettingNameForEnemyType(type) {
+    switch (type) {
+        case EnemyType.Enemy: return 'settingNormalEnemy';
+        case EnemyType.EnchantedEnemy: return 'settingEnchantedEnemy';
+        case EnemyType.MiniBoss: return 'settingMiniBossEnemy';
+        case EnemyType.Boss: return 'settingBossEnemy';
+        default: return null;
+    }
+}
+
 class Mob {
     constructor(id, typeId, posX, posY, health, maxHealth, enchantmentLevel, rarity) {
         this.id = id;
@@ -29,6 +39,7 @@ class Mob {
         this.tier = 0;
         this.type = EnemyType.Enemy;
         this.name = null;
+        this.identified = false;        // True when name and dbInfo came from MobsDatabase; used by render-time filter for "Show Unmanaged Enemies".
         this.category = null;           // Mob category from database (boss, miniboss, champion, etc.)
         this.namelocatag = null;        // Localization tag for translated name
         this.exp = 0;
@@ -246,42 +257,7 @@ export class MobsHandler {
             mob.enchantmentLevel = this.calculateEnchantment(enchant);
         }
 
-        // Filter enemies based on user settings
-        if (mob.type >= EnemyType.Enemy && mob.type <= EnemyType.Boss) {
-            // If enemy is not identified (no name from mobinfo), check "Show Unmanaged Enemies" setting
-            if (!mob.name || !hasKnownInfo) {
-                if (settingsSync.getBool('settingShowUnmanagedEnemies') === false) {
-                    return; // Skip unidentified enemies if setting is disabled
-                }
-            } else {
-                // For identified enemies, filter by their specific level (Normal, Enchanted, MiniBoss, Boss)
-                // Note: MediumEnemy completely removed - not aligned with game data categories
-                const settingName = this._getSettingNameForEnemyType(mob.type);
-                if (settingName && settingsSync.getBool(settingName) === false) {
-                    return; // Skip if this enemy level is disabled
-                }
-            }
-        }
-
-        // Filter drones based on user settings
-        if (mob.type === EnemyType.Drone) {
-            if (!settingsSync.getBool('settingAvaloneDrones')) {
-                return;
-            }
-        }
-
-        // Filter mist bosses based on user settings
-        if (mob.type === EnemyType.MistBoss) {
-            // Mist bosses have individual toggles, but if we don't know which one it is, show it
-            // The specific filtering is done in MobsDrawing based on mob name
-        }
-
-        // Filter event enemies based on user settings
-        if (mob.type === EnemyType.Events) {
-            if (!settingsSync.getBool('settingShowEventEnemies')) {
-                return;
-            }
-        }
+        mob.identified = !!mob.name && hasKnownInfo;
 
         this.mobsList.push(mob);
     }
@@ -592,18 +568,7 @@ export class MobsHandler {
      * @private
      */
     _getSettingNameForEnemyType(type) {
-        switch(type) {
-            case EnemyType.Enemy:
-                return 'settingNormalEnemy';
-            case EnemyType.EnchantedEnemy:
-                return 'settingEnchantedEnemy';
-            case EnemyType.MiniBoss:
-                return 'settingMiniBossEnemy';
-            case EnemyType.Boss:
-                return 'settingBossEnemy';
-            default:
-                return null;
-        }
+        return getSettingNameForEnemyType(type);
     }
 
     /**

--- a/web/scripts/handlers/MobsHandler.js
+++ b/web/scripts/handlers/MobsHandler.js
@@ -38,7 +38,7 @@ class Mob {
         this.tier = 0;
         this.type = EnemyType.Enemy;
         this.name = null;
-        this.identified = false;        // True when name and dbInfo came from MobsDatabase; used by render-time filter for "Show Unmanaged Enemies".
+        this.identified = false;
         this.category = null;           // Mob category from database (boss, miniboss, champion, etc.)
         this.namelocatag = null;        // Localization tag for translated name
         this.exp = 0;

--- a/web/scripts/handlers/MobsHandler.js
+++ b/web/scripts/handlers/MobsHandler.js
@@ -1,5 +1,4 @@
 import {CATEGORIES} from '../constants/LoggerConstants.js';
-import settingsSync from '../utils/SettingsSync.js';
 import {getLivingHarvestTier} from '../utils/LivingResourceTier.js';
 
 export const EnemyType =

--- a/web/scripts/handlers/MobsHandler.test.js
+++ b/web/scripts/handlers/MobsHandler.test.js
@@ -351,22 +351,24 @@ describe('MobsHandler', () => {
             expect(handler.getSize().mobs).toBe(0);
         });
 
-        // @verified 2026-04-18: settingNormalEnemy=false gates out identified Enemy-type mobs.
-        test('synthetic: settingNormalEnemy=false prevents identified Enemy from being added', () => {
-            // synthetic: typeId=2067 is a known camp mob -> Enemy; settingNormalEnemy=false blocks it.
+        // @verified 2026-04-24: enemy filters moved to render; spawn always stores, and mob.identified pins the db-match state for the render gate.
+        test('synthetic: settingNormalEnemy=false no longer blocks spawn, mob lands with identified=true', () => {
             settingsSync.getBool.mockImplementation((key) => key !== 'settingNormalEnemy');
             const p = normalizeParams({'0': 8005, '1': 2067, '2': 255, '7': [0, 0], '13': 500, '33': 0});
             handler.NewMobEvent(p);
-            expect(handler.getMobList()).toHaveLength(0);
+            const list = handler.getMobList();
+            expect(list).toHaveLength(1);
+            expect(list[0].identified).toBe(true);
         });
 
-        // @verified 2026-04-18: settingShowUnmanagedEnemies=false gates out unknown (no-db) mobs.
-        test('synthetic: settingShowUnmanagedEnemies=false prevents unknown mob from being added', () => {
-            // synthetic: typeId=9999 out of range -> unknown mob; setting gates it out.
+        // @verified 2026-04-24: unknown mob also always spawns with identified=false so the render gate can use settingShowUnmanagedEnemies.
+        test('synthetic: settingShowUnmanagedEnemies=false no longer blocks spawn, unknown mob lands with identified=false', () => {
             settingsSync.getBool.mockImplementation((key) => key !== 'settingShowUnmanagedEnemies');
             const p = normalizeParams({'0': 8006, '1': 9999, '2': 255, '7': [0, 0], '13': 500, '33': 0});
             handler.NewMobEvent(p);
-            expect(handler.getMobList()).toHaveLength(0);
+            const list = handler.getMobList();
+            expect(list).toHaveLength(1);
+            expect(list[0].identified).toBe(false);
         });
 
         // @verified 2026-04-18: two distinct mist spawns both land in mistList.

--- a/web/scripts/handlers/PlayersHandler.js
+++ b/web/scripts/handlers/PlayersHandler.js
@@ -383,4 +383,9 @@ export class PlayersHandler {
             passive: filtered.filter(p => p.isPassive())
         };
     }
+
+    getThreatPlayers() {
+        const pvpType = zonesDatabase.getPvpType(window.currentMapId);
+        return this.playersList.filter(p => this.isPlayerThreat(p.faction, pvpType));
+    }
 }

--- a/web/scripts/handlers/PlayersHandler.js
+++ b/web/scripts/handlers/PlayersHandler.js
@@ -87,6 +87,18 @@ export class PlayersHandler {
         this.playersList = [];
         this.localPlayer = new Player();
         this.audio = new Audio('/sounds/player.mp3');
+        this.lastFlashAt = 0;           // performance.now() of the last threat flash; read by RadarRenderer to mirror the full-screen flash on the radar overlay.
+        this.FLASH_DURATION_MS = 300;
+    }
+
+    triggerScreenFlash() {
+        this.lastFlashAt = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+        if (typeof document === 'undefined') return;
+        const flash = document.createElement('div');
+        flash.className = 'fixed inset-0 bg-error/60 pointer-events-none z-[9999] transition-opacity duration-300';
+        document.body.appendChild(flash);
+        requestAnimationFrame(() => { flash.style.opacity = '0'; });
+        setTimeout(() => flash.remove(), this.FLASH_DURATION_MS);
     }
 
     isPlayerThreat(faction, pvpType) {
@@ -156,13 +168,7 @@ export class PlayersHandler {
         });
 
         if (isThreat && mapId && settingsSync.getBool('settingFlash')) {
-            const flash = document.createElement('div');
-            flash.className = 'fixed inset-0 bg-error/60 pointer-events-none z-[9999] transition-opacity duration-300';
-            document.body.appendChild(flash);
-            requestAnimationFrame(() => {
-                flash.style.opacity = '0';
-            });
-            setTimeout(() => flash.remove(), 300);
+            this.triggerScreenFlash();
         }
 
         if (isThreat && mapId && settingsSync.getBool('settingSound')) {
@@ -273,11 +279,7 @@ export class PlayersHandler {
         if (!this.isPlayerThreat(player.faction, pvpType)) return;
 
         if (settingsSync.getBool('settingFlash')) {
-            const flash = document.createElement('div');
-            flash.className = 'fixed inset-0 bg-error/60 pointer-events-none z-[9999] transition-opacity duration-300';
-            document.body.appendChild(flash);
-            requestAnimationFrame(() => flash.style.opacity = '0');
-            setTimeout(() => flash.remove(), 300);
+            this.triggerScreenFlash();
         }
 
         if (settingsSync.getBool('settingSound')) {

--- a/web/scripts/handlers/PlayersHandler.js
+++ b/web/scripts/handlers/PlayersHandler.js
@@ -87,7 +87,7 @@ export class PlayersHandler {
         this.playersList = [];
         this.localPlayer = new Player();
         this.audio = new Audio('/sounds/player.mp3');
-        this.lastFlashAt = 0;           // performance.now() of the last threat flash; read by RadarRenderer to mirror the full-screen flash on the radar overlay.
+        this.lastFlashAt = 0;
         this.FLASH_DURATION_MS = 300;
     }
 

--- a/web/scripts/handlers/PlayersHandler.test.js
+++ b/web/scripts/handlers/PlayersHandler.test.js
@@ -541,4 +541,34 @@ describe('PlayersHandler', () => {
             expect(buckets.hostile.map(p => p.id)).toContain(3);
         });
     });
+
+    describe('getThreatPlayers (zone-aware threat list)', () => {
+        // @verified 2026-04-24: safe zone yields zero threats regardless of faction.
+        test('synthetic: safe zone returns no threats', () => {
+            zonesDatabase.getPvpType.mockReturnValue('safe');
+            handler.handleNewPlayerEvent(1, {1: 'Hostile', 8: '', 53: 255, 51: null, 40: [], 43: []});
+
+            expect(handler.getThreatPlayers()).toHaveLength(0);
+        });
+
+        // @verified 2026-04-24: red zone returns only faction=255 players.
+        test('synthetic: red zone returns faction=255 only', () => {
+            zonesDatabase.getPvpType.mockReturnValue('red');
+            handler.handleNewPlayerEvent(1, {1: 'Passive', 8: '', 53: 0, 51: null, 40: [], 43: []});
+            handler.handleNewPlayerEvent(2, {1: 'Hostile', 8: '', 53: 255, 51: null, 40: [], 43: []});
+
+            const threats = handler.getThreatPlayers();
+            expect(threats).toHaveLength(1);
+            expect(threats[0].id).toBe(2);
+        });
+
+        // @verified 2026-04-24: black zone returns every player regardless of faction (fix for Pulsating Border bug).
+        test('synthetic: black zone returns passive AND hostile as threats', () => {
+            zonesDatabase.getPvpType.mockReturnValue('black');
+            handler.handleNewPlayerEvent(1, {1: 'Passive', 8: '', 53: 0, 51: null, 40: [], 43: []});
+            handler.handleNewPlayerEvent(2, {1: 'Hostile', 8: '', 53: 255, 51: null, 40: [], 43: []});
+
+            expect(handler.getThreatPlayers()).toHaveLength(2);
+        });
+    });
 });

--- a/web/scripts/handlers/PlayersHandler.test.js
+++ b/web/scripts/handlers/PlayersHandler.test.js
@@ -542,6 +542,21 @@ describe('PlayersHandler', () => {
         });
     });
 
+    describe('triggerScreenFlash', () => {
+        // @verified 2026-04-24: triggerScreenFlash stamps lastFlashAt so RadarRenderer can mirror the alert on the radar overlay.
+        test('synthetic: triggerScreenFlash sets lastFlashAt to a recent timestamp', () => {
+            const before = performance.now();
+            handler.triggerScreenFlash();
+            expect(handler.lastFlashAt).toBeGreaterThanOrEqual(before);
+        });
+
+        // @verified 2026-04-24: triggerScreenFlash appends a DOM overlay visible to the full-viewport flash.
+        test('synthetic: triggerScreenFlash appends bg-error/60 div to body', () => {
+            handler.triggerScreenFlash();
+            expect(document.body.querySelectorAll('.bg-error\\/60').length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
     describe('getThreatPlayers (zone-aware threat list)', () => {
         // @verified 2026-04-24: safe zone yields zero threats regardless of faction.
         test('synthetic: safe zone returns no threats', () => {

--- a/web/scripts/utils/RadarRenderer.js
+++ b/web/scripts/utils/RadarRenderer.js
@@ -308,6 +308,24 @@ export class RadarRenderer {
         this.renderZoneInfo(ctx);
         this.renderStatsBox(ctx);
         this.renderThreatBorder(ctx);
+        this.renderFlashOverlay(ctx);
+    }
+
+    renderFlashOverlay(ctx) {
+        if (!settingsSync.getBool('settingFlash')) return;
+        const handler = this.handlers.playersHandler;
+        if (!handler?.lastFlashAt) return;
+
+        const duration = handler.FLASH_DURATION_MS || 300;
+        const elapsed = performance.now() - handler.lastFlashAt;
+        if (elapsed < 0 || elapsed > duration) return;
+
+        const canvasSize = settingsSync.getNumber('settingCanvasSize') || 500;
+        const alpha = 0.6 * (1 - elapsed / duration);
+        ctx.save();
+        ctx.fillStyle = `rgba(239, 68, 68, ${alpha})`;
+        ctx.fillRect(0, 0, canvasSize, canvasSize);
+        ctx.restore();
     }
 
     /**

--- a/web/scripts/utils/RadarRenderer.js
+++ b/web/scripts/utils/RadarRenderer.js
@@ -425,15 +425,15 @@ export class RadarRenderer {
 
         if (threats.length === 0) return;
 
-        const pulse = Math.sin(Date.now() / 150) * 0.3 + 0.5;
+        const pulse = Math.sin(Date.now() / 140) * 0.35 + 0.6;
         const canvasSize = settingsSync.getNumber('settingCanvasSize') || 500;
 
         ctx.save();
         ctx.shadowColor = `rgba(255, 50, 50, ${pulse})`;
-        ctx.shadowBlur = 12;
-        ctx.strokeStyle = `rgba(255, 50, 50, ${pulse * 0.8})`;
-        ctx.lineWidth = 3;
-        ctx.strokeRect(2, 2, canvasSize - 4, canvasSize - 4);
+        ctx.shadowBlur = 24;
+        ctx.strokeStyle = `rgba(255, 50, 50, ${pulse})`;
+        ctx.lineWidth = 5;
+        ctx.strokeRect(3, 3, canvasSize - 6, canvasSize - 6);
         ctx.restore();
     }
 

--- a/web/scripts/utils/RadarRenderer.js
+++ b/web/scripts/utils/RadarRenderer.js
@@ -400,8 +400,8 @@ export class RadarRenderer {
      */
     renderStatsBox(ctx) {
         const playerCount = this.handlers.playersHandler?.getFilteredPlayers?.()?.length ?? 0;
-        const resourceCount = this.handlers.harvestablesHandler?.harvestableList?.length || 0;
-        const mobCount = this.handlers.mobsHandler?.mobsList?.length || 0;
+        const resourceCount = this.drawings.harvestablesDrawing?.lastVisibleCount ?? 0;
+        const mobCount = this.drawings.mobsDrawing?.lastVisibleCount ?? 0;
 
         const stats = [];
         if (settingsSync.getBool('settingShowPlayers')) {

--- a/web/scripts/utils/RadarRenderer.js
+++ b/web/scripts/utils/RadarRenderer.js
@@ -421,11 +421,9 @@ export class RadarRenderer {
     renderThreatBorder(ctx) {
         if (!settingsSync.getBool('settingFlashDangerousPlayer')) return;
 
-        const hostilePlayers = this.handlers.playersHandler?.getFilteredPlayers?.()?.filter(
-            p => p.isHostile?.()
-        ) || [];
+        const threats = this.handlers.playersHandler?.getThreatPlayers?.() || [];
 
-        if (hostilePlayers.length === 0) return;
+        if (threats.length === 0) return;
 
         const pulse = Math.sin(Date.now() / 150) * 0.3 + 0.5;
         const canvasSize = settingsSync.getNumber('settingCanvasSize') || 500;

--- a/web/scripts/utils/Utils.js
+++ b/web/scripts/utils/Utils.js
@@ -55,15 +55,17 @@ function cleanupStaleEntities() {
     const cleanedPlayers = handlers.players?.cleanupStaleEntities?.(STALE_ENTITY_MAX_AGE) || 0;
     const cleanedMobs = handlers.mobs?.cleanupStaleEntities?.(STALE_ENTITY_MAX_AGE) || 0;
     const cleanedHarvestables = handlers.harvestables?.cleanupStaleEntities?.(STALE_ENTITY_MAX_AGE) || 0;
+    const cleanedFishing = handlers.fishing?.cleanupStaleEntities?.(STALE_ENTITY_MAX_AGE) || 0;
 
     const activePlayerIds = new Set(handlers.players?.getFilteredPlayers?.().map(p => p.id) || []);
     const cleanedRenderCache = PlayerListRenderer.cleanupStaleCache(activePlayerIds);
 
-    if (cleanedPlayers || cleanedMobs || cleanedHarvestables || cleanedRenderCache) {
+    if (cleanedPlayers || cleanedMobs || cleanedHarvestables || cleanedFishing || cleanedRenderCache) {
         window.logger?.debug(CATEGORIES.SYSTEM, 'StaleEntityCleanup', {
             players: cleanedPlayers,
             mobs: cleanedMobs,
             harvestables: cleanedHarvestables,
+            fishing: cleanedFishing,
             renderCache: cleanedRenderCache
         });
     }


### PR DESCRIPTION
Closes #81, #65, #25.
Touches #57 (symptom addressed via zone-aware alerts; root cause params[103] hashtable parsing left open for follow-up).

## Summary

Aggregate fix pass for issue #81 (settings coherence audit). Re-audited templates vs code with proper handling of dynamically constructed keys (`getResourceStorageKey`, `settingDungeonE`+n, `settingMistE`+n), which flipped several "orphans" from the original audit into false positives. The genuine gaps are fixed here, and while at it the fishing + enemy filters move to render-time to match the resource filter pattern from PR #82.

### Issues closed

- **#81 Settings coherence audit**: orphan keys resolved (align/remove/wire/relabel).
- **#65 Sound and flash alert doesn't work**: Screen Flash mirrored on the radar overlay; Pulsating Border now fires in blackzones via the zone-aware `isPlayerThreat` rule (strict `isHostile()` was blind to faction=0 threats in black).
- **#25 Fishpool invalid**: phantom empty-type entries filtered out (they were placed on land and totalled 15); `settingFishing` alignment + render-time gate; `settingResourceCount` now gates the pool count; stale cleanup extended to fishing; spawn debug log added.

### Related (kept open)

- **#57 map.isBZ always false after Protocol18 patch**: the alerts/threat chain is now fully routed through the working `zonesDatabase.getPvpType(mapId)` path (the issue's own noted fallback) so the user-visible symptom in blackzones is resolved. Direct `params[103]` hashtable parsing for the `map.isBZ` field is still open; `ROUTER-1 test.fails` in `EventRouter.test.js` remains as a marker for a future decode pass. Not auto-closed by this PR.

### Settings coherence

- `settingShowFish` aligned to `settingFishing` so the UI checkbox finally works.
- `settingDebugRawPacketsConsole/Server` removed (never had a consumer; equivalent control already exists through `categoryNetwork` + `logLevel=DEBUG`).
- `settingShowMinimumHealthEnemies` + `settingTextMinimumHealthEnemies` wired in `MobsDrawing` to gate hostile mobs by `maxHealth` threshold.
- `settingFlashDangerousPlayer` gains a UI checkbox in Alerts (the render code was already present, never toggle-able).
- Mists Bosses block relabelled "Not implemented yet" (red construction badge) since the 4 per-boss checkboxes have no consumer.
- Other Enemies block kept "Not validated yet" (wired but unverified).
- Fishing checkbox loses its Experimental badge after the phantom filter lands.

### Fishing

- Empty-type entries on event 359 (NewFishingZoneObject) are phantoms (always total=15, placed on land); filtered out, reverts PR #73 FISH-1 narrowing.
- `settingFishing` gate moves from spawn to render so toggles are instant.
- `settingResourceCount` now also gates the `n/total` count on fishing pools (was always shown).
- `newFishEvent` logs spawn to `FISHING` category (was silent).
- Stale cleanup runs on the fishing list alongside players/mobs/harvestables.

### Enemies

- Spawn-time gates (`settingNormalEnemy` / `settingEnchantedEnemy` / `settingMiniBossEnemy` / `settingBossEnemy` / `settingShowUnmanagedEnemies` / `settingAvaloneDrones` / `settingShowEventEnemies`) move from `MobsHandler.AddEnemy` to `MobsDrawing.invalidate`. Mob class gains an `identified` flag so the render gate does not need a second database lookup. `_getSettingNameForEnemyType` promoted to a module-level export.

### Alerts UX

- `Pulsating Border While Hostile Nearby` (`settingFlashDangerousPlayer`) now uses `PlayersHandler.getThreatPlayers()` which follows the same zone-aware rule as the audio/full-screen flash (`isPlayerThreat`). The prior strict `isHostile()` check missed blackzone threats where all players are hostile regardless of faction. Pulsation made slightly more visible (wider amplitude, more blur, thicker stroke).
- Screen Flash mirrored on the radar's ui canvas in addition to the full-viewport DOM overlay, so users focused on the radar or using PiP mode still see the alert.

### Logger

- Go logger defaults to `enabled: false` so the server boots silent. The frontend's `/api/settings/server-logs` POST (fired on every page load by `base.gohtml`) turns it on only when the user has `settingServerLogsEnabled=true`. Previously the server started with logging on and emitted `[SERVER] EVENT_CAPTURE` before the frontend's sync arrived.

## Test plan

476 JS tests + 1 expected fail, Go suite green.

- [x] Fishing: `FishingHandler.test.js` flipped (spawn-time gate removed, empty-type filtered), new `FishingDrawing.test.js` (4 tests pinning settingFishing + settingResourceCount at render).
- [x] Enemies: 2 `MobsHandler.test.js` tests flipped to "always stored with identified flag"; 6 new `MobsDrawing.test.js` tests covering the render gates (Normal/Enchanted/Boss, Unmanaged, Drone, Events).
- [x] Alerts: 3 new `PlayersHandler.test.js` tests for `getThreatPlayers()` + 2 for `triggerScreenFlash()`.
- [x] Min HP: 5 `MobsDrawing.test.js` tests (off, below, above, boss above, living resource unaffected).
- [x] Logger: Go suite covers the default and the `/api/settings/server-logs` POST handler.
- [x] Live in-game smoke (user 2026-04-24): Pulsating Border fires in blackzone, Screen Flash mirrors on radar, Fishing pools render without phantom land-points, Min HP threshold gates weak hostiles.