### PR TITLE
feat(91): dynamic capture interface selection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,19 @@ linters:
     - unconvert # Remove unnecessary type conversions
     - unparam # Report unused function parameters
     - wastedassign # Find wasted assignment statements
+    # Modernization (Go 1.22+ idioms)
+    - copyloopvar # 1.22 per-iteration loop var; flags x := x redundancy
+    - intrange # 1.22 range-over-int; flags for i := 0; i < N; i++
+    - usestdlibvars # forces http.MethodGet, http.StatusOK over literals
+    - perfsprint # flags slow fmt.Sprintf patterns
+    - usetesting # forces t.Setenv, t.TempDir, t.Context (1.25)
+    - tparallel # t.Parallel correctness
+    - thelper # t.Helper() in test helpers
+    - mirror # *Reader/*Writer type mirrors
+    - canonicalheader # canonical HTTP headers
+    - whitespace # leading/trailing whitespace cleanup
+    - exptostd # x/exp/maps,slices to stdlib
+    - testifylint # testify v1 to v2 migration patterns
 
   # Disable from standard set
   disable:

--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -35,16 +36,16 @@ const (
 )
 
 type App struct {
-	ctx          context.Context
-	cancel       context.CancelFunc
-	wg           sync.WaitGroup
-	logger       *logger.Logger
-	httpServer   *server.HTTPServer
-	wsHandler    *server.WebSocketHandler
-	capturer     *capture.Capturer
-	photonParser *photon.PhotonParser
-	program      *tea.Program
-	adapterIP    string
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	logger         *logger.Logger
+	httpServer     *server.HTTPServer
+	wsHandler      *server.WebSocketHandler
+	captureManager *capture.Manager
+	photonParser   *photon.PhotonParser
+	program        *tea.Program
+	adapterIP      string
 
 	// Packet statistics (atomic for thread safety)
 	packetsProcessed uint64
@@ -80,25 +81,46 @@ func runApp(cfg Config) bool {
 		exitWithError("Failed to get working directory", err)
 	}
 
-	// Initialize capture first (may prompt for interface selection)
-	// This happens BEFORE the dashboard starts
 	ctx, cancel := context.WithCancel(context.Background())
-	capturer, err := capture.New(ctx, appDir, cfg.ipAddr)
+
+	allIfaces, err := capture.EnumerateInterfaces()
 	if err != nil {
 		cancel()
-		exitWithError("Failed to create capturer", err)
+		exitWithError("Failed to enumerate interfaces", err)
 	}
 
-	// Create the app
-	app, err := newApp(appDir, cfg, ctx, cancel, capturer)
+	if _, mErr := capture.MigrateIPTxt(appDir, capture.ResolveByIP); mErr != nil {
+		logger.PrintWarn("NET", "ip.txt migration failed: %v", mErr)
+	}
+
+	cfgPersisted, _ := capture.ReadConfig(appDir)
+	target := resolvePersisted(cfgPersisted, allIfaces, cfg.ipAddr)
+	if len(target) == 0 {
+		target = autoPickDefaults(allIfaces)
+		if len(target) > 0 {
+			toPersist := make([]capture.PersistedInterface, 0, len(target))
+			for _, i := range target {
+				toPersist = append(toPersist, capture.PersistedInterface{Name: i.Name, Description: i.Description})
+			}
+			_ = capture.WriteConfig(appDir, capture.Config{CaptureInterfaces: toPersist})
+			logger.PrintInfo("NET", "Auto-selected %d interface(s). Change in /settings if needed.", len(target))
+		}
+	}
+
+	manager := capture.NewManager(ctx)
+
+	app, err := newApp(appDir, cfg, ctx, cancel, manager, allIfaces)
 	if err != nil {
 		cancel()
-		capturer.Close()
+		manager.Close(context.Background())
 		exitWithError("Failed to create app", err)
 	}
-	app.adapterIP = capturer.AdapterIP()
+	app.adapterIP = firstLANAddress()
 
-	// Create dashboard
+	if err := manager.Reconfigure(target); err != nil {
+		logger.PrintWarn("NET", "Some interfaces failed to open: %v", err)
+	}
+
 	dashboard := ui.NewDashboard(Version, serverPort, cfg.devMode, app.adapterIP)
 	app.program = tea.NewProgram(dashboard, tea.WithAltScreen())
 
@@ -170,23 +192,24 @@ func newApp(
 	cfg Config,
 	ctx context.Context,
 	cancel context.CancelFunc,
-	capturer *capture.Capturer,
+	manager *capture.Manager,
+	allIfaces []capture.NetworkInterface,
 ) (*App, error) {
 	log := logger.New("./logs")
 	wsHandler := server.NewWebSocketHandler(log)
 
-	httpServer, err := createHTTPServer(cfg.devMode, appDir, wsHandler, log, Version)
+	httpServer, err := createHTTPServer(cfg.devMode, appDir, wsHandler, log, Version, manager, allIfaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP server: %w", err)
 	}
 
 	app := &App{
-		ctx:        ctx,
-		cancel:     cancel,
-		logger:     log,
-		wsHandler:  wsHandler,
-		httpServer: httpServer,
-		capturer:   capturer,
+		ctx:            ctx,
+		cancel:         cancel,
+		logger:         log,
+		wsHandler:      wsHandler,
+		httpServer:     httpServer,
+		captureManager: manager,
 	}
 	app.photonParser = photon.NewPhotonParser(
 		app.onPhotonEvent,
@@ -196,7 +219,7 @@ func newApp(
 	app.photonParser.OnEncrypted = app.onPhotonEncrypted
 	app.photonParser.OnParseError = app.onPhotonParseError
 
-	app.capturer.OnPacket(app.handlePacket)
+	app.captureManager.OnPacket(app.handlePacket)
 
 	return app, nil
 }
@@ -207,10 +230,12 @@ func createHTTPServer(
 	wsHandler *server.WebSocketHandler,
 	log *logger.Logger,
 	version string,
+	mgr *capture.Manager,
+	allIfaces []capture.NetworkInterface,
 ) (*server.HTTPServer, error) {
 	if devMode {
 		logger.PrintInfo("MODE", "Development mode: reading files from disk")
-		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version)
+		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version, mgr, allIfaces)
 	}
 	logger.PrintInfo("MODE", "Production mode: using embedded assets")
 	return server.NewHTTPServer(
@@ -224,72 +249,54 @@ func createHTTPServer(
 		wsHandler,
 		log,
 		version,
+		mgr,
+		allIfaces,
+		appDir,
 	)
 }
 
 func (app *App) startServers() {
-	// Log startup messages
 	app.logger.PrintSessionInfo()
 	logger.PrintInfo("APP", "Starting servers...")
 
-	// Start HTTP server
-	app.wg.Add(1)
-	go func() {
-		defer app.wg.Done()
+	app.wg.Go(func() {
 		atomic.StoreInt32(&app.httpRunning, 1)
 		if err := app.httpServer.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) &&
 			app.ctx.Err() == nil {
 			logger.PrintError("HTTP", "Error: %v", err)
 		}
 		atomic.StoreInt32(&app.httpRunning, 0)
-	}()
+	})
 
-	// Start packet capture
-	app.wg.Add(1)
-	go func() {
-		defer app.wg.Done()
-		atomic.StoreInt32(&app.captureRunning, 1)
-		if err := app.capturer.Start(); err != nil && app.ctx.Err() == nil {
-			logger.PrintError("CAP", "Error: %v", err)
-		}
-		atomic.StoreInt32(&app.captureRunning, 0)
-	}()
+	// Manager owns its own read-loop goroutines (started in Reconfigure).
+	atomic.StoreInt32(&app.captureRunning, 1)
 
-	// Give servers a moment to start
 	time.Sleep(100 * time.Millisecond)
 
 	logger.PrintSuccess("HTTP", "Server: http://localhost:%d", serverPort)
-	if app.adapterIP != "" && app.adapterIP != "127.0.0.1" {
-		logger.PrintSuccess("HTTP", "Server: http://%s:%d  (LAN)", app.adapterIP, serverPort)
+	for _, ip := range server.ComputeLANAddresses() {
+		logger.PrintSuccess("HTTP", "Server: http://%s:%d  (LAN)", ip, serverPort)
 	}
 	logger.PrintSuccess("WS", "WebSocket: ws://localhost:%d/ws", serverPort)
-	if app.adapterIP != "" && app.adapterIP != "127.0.0.1" {
-		logger.PrintSuccess("WS", "WebSocket: ws://%s:%d/ws  (LAN)", app.adapterIP, serverPort)
+	for _, ip := range server.ComputeLANAddresses() {
+		logger.PrintSuccess("WS", "WebSocket: ws://%s:%d/ws  (LAN)", ip, serverPort)
 	}
 	logger.PrintInfo("PKT", "Listening for Albion packets on UDP port 5056...")
-	logger.PrintInfo("NET", "Adapter: %s", app.adapterIP)
+	for _, s := range app.captureManager.State().Active {
+		logger.PrintInfo("NET", "Capturing on %s [%s]", s.Description, s.Address)
+	}
 }
 
 func (app *App) updateStats() {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	pcapStatsTick := 0
-	const pcapStatsEvery = 30 // seconds
-
 	for {
 		select {
 		case <-app.ctx.Done():
 			return
 		case <-ticker.C:
-			pcapStatsTick++
-			if pcapStatsTick >= pcapStatsEvery && app.capturer != nil {
-				pcapStatsTick = 0
-				if s, err := app.capturer.Stats(); err == nil && s != nil {
-					logger.PrintInfo("PKT", "kernel stats: received=%d dropped=%d ifdropped=%d",
-						s.PacketsReceived, s.PacketsDropped, s.PacketsIfDropped)
-				}
-			}
+			// TODO(#91): aggregate pcap.Stats across active capturers.
 			if app.program != nil {
 				var m runtime.MemStats
 				runtime.ReadMemStats(&m)
@@ -306,17 +313,18 @@ func (app *App) updateStats() {
 					WsBatches:     wsStats.BatchesSent,
 					WsMessages:    wsStats.MessagesSent,
 					WsQueueSize:   wsStats.MessagesQueue,
-					BytesReceived: app.capturer.BytesReceived(),
+					BytesReceived: app.captureManager.BytesReceived(),
 					BytesSent:     wsStats.BytesSent,
 					LogEntries:    logStats.TotalEntries,
 					LogBatches:    logStats.TotalBatches,
 					LogBufferSize: logStats.BufferSize,
 				})
 
+				captureActive := len(app.captureManager.State().Active) > 0
 				app.program.Send(ui.StatusMsg{
 					HTTPRunning:    atomic.LoadInt32(&app.httpRunning) == 1,
 					WSRunning:      app.wsHandler.ClientCount() >= 0,
-					CaptureRunning: atomic.LoadInt32(&app.captureRunning) == 1,
+					CaptureRunning: captureActive,
 				})
 			}
 		}
@@ -371,14 +379,13 @@ func (app *App) shutdown() {
 	defer cancel()
 
 	app.cancel()
-	app.capturer.Close()
+	app.captureManager.Close(ctx)
 	app.logger.Stop()
 
 	if err := app.httpServer.Shutdown(ctx); err != nil {
 		logger.PrintError("HTTP", "Shutdown error: %v", err)
 	}
 
-	// Wait for goroutines
 	done := make(chan struct{})
 	go func() {
 		app.wg.Wait()
@@ -391,4 +398,74 @@ func (app *App) shutdown() {
 	case <-ctx.Done():
 		logger.PrintWarn("APP", "Shutdown timed out")
 	}
+}
+
+// resolvePersisted maps a persisted (or CLI-overridden) selection to currently
+// available NetworkInterface entries. Returns nil if the override IP no longer
+// resolves; the caller falls back to autoPickDefaults.
+func resolvePersisted(cfg capture.Config, all []capture.NetworkInterface, ipOverride string) []capture.NetworkInterface {
+	if ipOverride != "" {
+		for _, i := range all {
+			if i.Address == ipOverride {
+				return []capture.NetworkInterface{i}
+			}
+		}
+		return nil
+	}
+	available := make(map[string]capture.NetworkInterface, len(all))
+	for _, i := range all {
+		available[i.Name] = i
+	}
+	out := make([]capture.NetworkInterface, 0, len(cfg.CaptureInterfaces))
+	for _, p := range cfg.CaptureInterfaces {
+		if i, ok := available[p.Name]; ok {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func autoPickDefaults(all []capture.NetworkInterface) []capture.NetworkInterface {
+	out := make([]capture.NetworkInterface, 0)
+	for _, i := range capture.RankCandidates(all) {
+		c := capture.Categorize(i.Name, i.Description)
+		if (c == capture.CategoryEthernet || c == capture.CategoryWiFi || c == capture.CategoryExitLag) && isRFC1918(i.Address) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func isRFC1918(addr string) bool {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+		_, n, _ := net.ParseCIDR(cidr)
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// firstLANAddress returns the first RFC1918 IPv4 host address bound locally,
+// passed to the legacy single-IP TUI; Task 7 expands this to multi-interface.
+func firstLANAddress() string {
+	addrs, _ := net.InterfaceAddrs()
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipnet.IP.To4()
+		if ip4 == nil {
+			continue
+		}
+		if isRFC1918(ip4.String()) {
+			return ip4.String()
+		}
+	}
+	return ""
 }

--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -44,7 +44,6 @@ type App struct {
 	captureManager *capture.Manager
 	photonParser   *photon.PhotonParser
 	program        *tea.Program
-	adapterIP      string
 
 	// Packet statistics (atomic for thread safety)
 	packetsProcessed uint64
@@ -113,14 +112,15 @@ func runApp(cfg Config) bool {
 		manager.Close(context.Background())
 		exitWithError("Failed to create app", err)
 	}
-	app.adapterIP = firstLANAddress()
 
 	if err := manager.Reconfigure(target); err != nil {
 		logger.PrintWarn("NET", "Some interfaces failed to open: %v", err)
 	}
 
-	dashboard := ui.NewDashboard(Version, serverPort, cfg.devMode, app.adapterIP)
+	dashboard := ui.NewDashboard(Version, serverPort, cfg.devMode, capture.LANAddresses(), nil)
 	app.program = tea.NewProgram(dashboard, tea.WithAltScreen())
+
+	app.startCaptureStatePoll()
 
 	// Track if restart was requested
 	restartRequested := false
@@ -431,12 +431,35 @@ func autoPickDefaults(all []capture.NetworkInterface) []capture.NetworkInterface
 	return out
 }
 
-// firstLANAddress returns the first RFC1918 IPv4 host address bound locally,
-// passed to the legacy single-IP TUI; Task 7 expands this to multi-interface.
-func firstLANAddress() string {
-	addrs := capture.LANAddresses()
-	if len(addrs) == 0 {
-		return ""
-	}
-	return addrs[0]
+// startCaptureStatePoll pushes a CaptureStateMsg to the TUI every 2s so
+// header and Config tab reflect live Manager state without coupling ui to capture.
+func (app *App) startCaptureStatePoll() {
+	app.wg.Go(func() {
+		t := time.NewTicker(2 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-app.ctx.Done():
+				return
+			case <-t.C:
+				if app.program == nil {
+					continue
+				}
+				s := app.captureManager.State()
+				summaries := make([]ui.CaptureSummary, 0, len(s.Active))
+				for _, a := range s.Active {
+					summaries = append(summaries, ui.CaptureSummary{
+						Description: a.Description,
+						Address:     a.Address,
+						Category:    string(a.Category),
+					})
+				}
+				app.program.Send(ui.CaptureStateMsg{
+					Active:       summaries,
+					LanAddresses: capture.LANAddresses(),
+					Status:       string(s.Status),
+				})
+			}
+		}
+	})
 }

--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -53,8 +52,7 @@ type App struct {
 	packetsEncrypted uint64
 
 	// Server status (atomic for thread safety)
-	httpRunning    int32
-	captureRunning int32
+	httpRunning int32
 }
 
 func main() {
@@ -268,17 +266,14 @@ func (app *App) startServers() {
 		atomic.StoreInt32(&app.httpRunning, 0)
 	})
 
-	// Manager owns its own read-loop goroutines (started in Reconfigure).
-	atomic.StoreInt32(&app.captureRunning, 1)
-
 	time.Sleep(100 * time.Millisecond)
 
 	logger.PrintSuccess("HTTP", "Server: http://localhost:%d", serverPort)
-	for _, ip := range server.ComputeLANAddresses() {
+	for _, ip := range capture.LANAddresses() {
 		logger.PrintSuccess("HTTP", "Server: http://%s:%d  (LAN)", ip, serverPort)
 	}
 	logger.PrintSuccess("WS", "WebSocket: ws://localhost:%d/ws", serverPort)
-	for _, ip := range server.ComputeLANAddresses() {
+	for _, ip := range capture.LANAddresses() {
 		logger.PrintSuccess("WS", "WebSocket: ws://%s:%d/ws  (LAN)", ip, serverPort)
 	}
 	logger.PrintInfo("PKT", "Listening for Albion packets on UDP port 5056...")
@@ -429,43 +424,19 @@ func autoPickDefaults(all []capture.NetworkInterface) []capture.NetworkInterface
 	out := make([]capture.NetworkInterface, 0)
 	for _, i := range capture.RankCandidates(all) {
 		c := capture.Categorize(i.Name, i.Description)
-		if (c == capture.CategoryEthernet || c == capture.CategoryWiFi || c == capture.CategoryExitLag) && isRFC1918(i.Address) {
+		if (c == capture.CategoryEthernet || c == capture.CategoryWiFi || c == capture.CategoryExitLag) && capture.IsRFC1918(i.Address) {
 			out = append(out, i)
 		}
 	}
 	return out
 }
 
-func isRFC1918(addr string) bool {
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return false
-	}
-	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
-		_, n, _ := net.ParseCIDR(cidr)
-		if n.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
 // firstLANAddress returns the first RFC1918 IPv4 host address bound locally,
 // passed to the legacy single-IP TUI; Task 7 expands this to multi-interface.
 func firstLANAddress() string {
-	addrs, _ := net.InterfaceAddrs()
-	for _, a := range addrs {
-		ipnet, ok := a.(*net.IPNet)
-		if !ok {
-			continue
-		}
-		ip4 := ipnet.IP.To4()
-		if ip4 == nil {
-			continue
-		}
-		if isRFC1918(ip4.String()) {
-			return ip4.String()
-		}
+	addrs := capture.LANAddresses()
+	if len(addrs) == 0 {
+		return ""
 	}
-	return ""
+	return addrs[0]
 }

--- a/cmd/radar/main_test.go
+++ b/cmd/radar/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+)
+
+func TestResolvePersistedWithIPOverride(t *testing.T) {
+	all := []capture.NetworkInterface{
+		{Name: "n1", Description: "Wi-Fi", Address: "192.168.1.1"},
+		{Name: "n2", Description: "Eth", Address: "192.168.1.2"},
+	}
+	got := resolvePersisted(capture.Config{}, all, "192.168.1.2")
+	if len(got) != 1 || got[0].Name != "n2" {
+		t.Errorf("override match: got %+v", got)
+	}
+	got = resolvePersisted(capture.Config{}, all, "10.0.0.99")
+	if got != nil {
+		t.Errorf("override miss should return nil, got %+v", got)
+	}
+}
+
+func TestResolvePersistedFromConfig(t *testing.T) {
+	all := []capture.NetworkInterface{
+		{Name: "n1", Description: "Wi-Fi", Address: "192.168.1.1"},
+		{Name: "n2", Description: "Eth", Address: "192.168.1.2"},
+	}
+	cfg := capture.Config{CaptureInterfaces: []capture.PersistedInterface{
+		{Name: "n2"},
+		{Name: "missing"},
+	}}
+	got := resolvePersisted(cfg, all, "")
+	if len(got) != 1 || got[0].Name != "n2" {
+		t.Errorf("got %+v, want one entry n2", got)
+	}
+}
+
+func TestAutoPickDefaults(t *testing.T) {
+	all := []capture.NetworkInterface{
+		{Name: "lo", Description: "Software Loopback", Address: "127.0.0.1"},
+		{Name: "vbox", Description: "VirtualBox Host-Only", Address: "192.168.56.1"},
+		{Name: "wifi", Description: "Wi-Fi", Address: "192.168.1.42"},
+		{Name: "eth", Description: "Realtek PCIe GbE Family Controller", Address: "10.0.0.10"},
+		{Name: "publicEth", Description: "Some Ethernet", Address: "8.8.8.8"},
+		{Name: "exitlag", Description: "ExitLag LightWeight Filter", Address: "192.168.99.1"},
+	}
+	got := autoPickDefaults(all)
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (eth, wifi, exitlag)", len(got))
+	}
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	want := []string{"eth", "wifi", "exitlag"}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("position %d: got %q, want %q (full: %v)", i, names[i], w, names)
+		}
+	}
+}
+
+func TestAutoPickDefaultsExcludesNonRFC1918(t *testing.T) {
+	all := []capture.NetworkInterface{
+		{Name: "publicEth", Description: "Some Ethernet", Address: "8.8.8.8"},
+		{Name: "publicWifi", Description: "Wi-Fi", Address: "1.2.3.4"},
+	}
+	got := autoPickDefaults(all)
+	if len(got) != 0 {
+		t.Errorf("got %d, want 0 (no RFC1918)", len(got))
+	}
+}
+
+func TestAutoPickDefaultsExcludesVirtualAndVPN(t *testing.T) {
+	all := []capture.NetworkInterface{
+		{Name: "tun0", Description: "WireGuard", Address: "10.8.0.5"},
+		{Name: "vbox", Description: "VirtualBox Host-Only", Address: "192.168.56.1"},
+	}
+	got := autoPickDefaults(all)
+	if len(got) != 0 {
+		t.Errorf("got %d, want 0 (vpn+virtual excluded)", len(got))
+	}
+}

--- a/docs/project/IMPROVEMENTS.md
+++ b/docs/project/IMPROVEMENTS.md
@@ -173,3 +173,15 @@ See [TODO.md](TODO.md) for roadmap and planned improvements.
 ---
 
 *Last update: 2026-04-12 - v2.1.0 (stabilization phase)*
+
+---
+
+## Post-#91 follow-ups (deferred)
+
+- **#91-followup-1 - NewHTTPServer config struct**: signature is at 10 params after #91. Refactor to `NewHTTPServer(cfg HTTPServerConfig)` to keep call site readable as Tasks 7/8 add more wiring. Estimate: 1h.
+
+- **#91-followup-2 - Aggregate pcap.Stats across handles**: the per-30s kernel-drop log line was removed in commit fedb2c4e (replaced by `// TODO(#91)` in `cmd/radar/main.go:updateStats`). Restore by adding `Manager.Stats() map[string]*pcap.Stats` and logging deltas. Required for in-prod debugging of capture loss. Estimate: 2h.
+
+- **#91-followup-3 - Bootstrap helpers test coverage**: `cmd/radar/main_test.go` covers resolvePersisted/autoPickDefaults; consider extracting to `internal/bootstrap` if a second binary needs the same flow. Until then, in-package tests suffice.
+
+- **#91-followup-4 - Manager.Reconfigure failure UX**: when all opens fail at boot, the warn-log is the only signal. The Settings page banner shows the awaiting state but a TUI banner would help headless users. Estimate: 30m.

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -189,4 +189,10 @@ See [docs/archive/](../archive/) for completed migration and refactoring plans.
 
 ---
 
+## Live validation pending
+
+- **#91 ExitLag free trial smoke** : after the dynamic capture interface PR lands, activate ExitLag's 3-day free trial and verify radar continuity in the four cases A/B/C/D documented in `docs/superpowers/specs/2026-04-26-dynamic-capture-interface-design.md`. If Case D (NDIS LWF swallows packets) materializes, open a follow-up issue for WFP-level capture investigation.
+
+---
+
 *End of Roadmap*

--- a/docs/superpowers/plans/2026-04-26-dynamic-capture-interface-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-26-dynamic-capture-interface-implementation-plan.md
@@ -1,0 +1,2189 @@
+# Dynamic Capture Interface Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace IP-keyed `ip.txt` persistence + single-handle pcap with a multi-interface `Manager` keyed by stable `{name, description}`. Expose runtime add/remove via a new HTTP API and a new "Network" section on the Settings page. Decouple capture interfaces from LAN serving addresses in TUI/UI. Closes #91.
+
+**Architecture:** New `Manager` owns a set of single-handle `Capturer` workers, one per active interface. Open/close ordering is strict (BPF before goroutine, cancellation before close, additions before removals during reconfigure). HTTP POST is restricted to loopback. Frontend uses fetch + 5s polling. Memory `feedback_no_worktrees` applies — work in main repo on `feat/91-dynamic-capture-interface`, no worktree.
+
+**Tech Stack:** Go 1.26, gopacket/pcap, vanilla JavaScript ES modules, Vitest 4.x, happy-dom, DaisyUI 5.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-dynamic-capture-interface-design.md`
+
+---
+
+## File structure
+
+### Create
+
+- `internal/capture/categorize.go` — `Category` enum, regex constants, `Categorize`, `RankCandidates`.
+- `internal/capture/categorize_test.go` — table-driven tests on real-world adapter names.
+- `internal/capture/network_config.go` — `Config` struct, read/write `network.json`, migrate `ip.txt`.
+- `internal/capture/network_config_test.go`.
+- `internal/capture/manager.go` — `Manager` struct with `Reconfigure`, `Close`, `State`.
+- `internal/capture/manager_test.go` — lifecycle, diff, failure isolation, no goroutine leaks.
+- `internal/server/network_api.go` — 4 HTTP handlers + loopback helper.
+- `internal/server/network_api_test.go`.
+- `web/scripts/handlers/NetworkSettingsHandler.js` — fetch + render + apply.
+- `web/scripts/handlers/_NetworkSettingsHandler.test.js`.
+
+### Modify
+
+- `internal/capture/pcap.go` — keep `Capturer` (single-handle), drop `New`, `getAdapterIP`, `tryIPFile`, `tryIPOverride`, `promptForInterface`, `printInterfaces`, `selectInterface`, `saveIPToFile`. Add `OpenCapture(name)` package-level injectable factory.
+- `internal/server/http.go` — register `/api/network/*` routes.
+- `internal/ui/dashboard.go` — replace `adapterIP` with `captureInterfaces []CaptureSummary` + `lanAddresses []string`, update display.
+- `internal/templates/pages/settings.gohtml` — new "Network" section + `<script>` block instantiating `NetworkSettingsHandler`.
+- `cmd/radar/main.go` — instantiate `Manager` instead of `Capturer`, remove `--ip` interactive flow (keep flag for legacy override → resolves to interface name once).
+
+### No changes
+
+- `internal/photon/*` — packet handling unchanged.
+- `internal/server/websocket.go` — unchanged.
+- `web/scripts/core/*`, `web/scripts/utils/*`, `web/scripts/drawings/*`, `web/scripts/handlers/*Handler.js` (other than the new one) — unchanged.
+
+---
+
+## Task 1: Categorize and rank interfaces
+
+**Files:**
+- Create: `internal/capture/categorize.go`, `internal/capture/categorize_test.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/capture/categorize_test.go`:
+
+```go
+package capture
+
+import (
+	"testing"
+)
+
+func TestCategorize(t *testing.T) {
+	cases := []struct {
+		name        string
+		ifaceName   string
+		description string
+		want        Category
+	}{
+		// Windows descriptions
+		{"win wifi intel", `\Device\NPF_{1}`, "Intel(R) Wi-Fi 6 AX201", CategoryWiFi},
+		{"win wifi realtek wireless", `\Device\NPF_{2}`, "Realtek 8821CE Wireless LAN 802.11ac PCI-E NIC", CategoryWiFi},
+		{"win ethernet realtek family", `\Device\NPF_{3}`, "Realtek PCIe GbE Family Controller", CategoryEthernet},
+		{"win ethernet intel connection", `\Device\NPF_{4}`, "Intel(R) Ethernet Connection (7) I219-V", CategoryEthernet},
+		{"win ethernet killer gigabit", `\Device\NPF_{5}`, "Killer E2600 Gigabit Ethernet Controller", CategoryEthernet},
+		{"win exitlag", `\Device\NPF_{6}`, "ExitLag LightWeight Filter", CategoryExitLag},
+		{"win exit lag spaced", `\Device\NPF_{7}`, "Exit Lag Adapter", CategoryExitLag},
+		{"win vpn tap", `\Device\NPF_{8}`, "TAP-Windows Adapter V9", CategoryVPN},
+		{"win vpn wintun", `\Device\NPF_{9}`, "WireGuard Tunnel", CategoryVPN},
+		{"win vpn openvpn", `\Device\NPF_{10}`, "OpenVPN Wintun", CategoryVPN},
+		{"win virtual hyper-v", `\Device\NPF_{11}`, "Hyper-V Virtual Ethernet Adapter", CategoryVirtual},
+		{"win virtual vethernet", `\Device\NPF_{12}`, "vEthernet (Default Switch)", CategoryVirtual},
+		{"win virtual virtualbox", `\Device\NPF_{13}`, "VirtualBox Host-Only Ethernet Adapter", CategoryVirtual},
+		{"win virtual vmware", `\Device\NPF_{14}`, "VMware Virtual Ethernet Adapter for VMnet8", CategoryVirtual},
+		{"win virtual teredo", `\Device\NPF_{15}`, "Teredo Tunneling Pseudo-Interface", CategoryVirtual},
+		{"win virtual loopback pseudo", `\Device\NPF_{16}`, "Software Loopback Interface 1", CategoryVirtual},
+		{"win virtual wifi direct", `\Device\NPF_{17}`, "Microsoft Wi-Fi Direct Virtual Adapter", CategoryVirtual},
+		{"win virtual mobile hotspot", `\Device\NPF_{18}`, "Microsoft Wi-Fi Direct Virtual Adapter #2 Mobile Hotspot", CategoryVirtual},
+		{"win other bluetooth", `\Device\NPF_{19}`, "Bluetooth Network Connection", CategoryOther},
+
+		// Linux interface names (description often empty)
+		{"linux wifi wlan0", "wlan0", "", CategoryWiFi},
+		{"linux wifi wlp3s0", "wlp3s0", "", CategoryWiFi},
+		{"linux ethernet eth0", "eth0", "", CategoryEthernet},
+		{"linux ethernet enp0s3", "enp0s3", "", CategoryEthernet},
+		{"linux ethernet eno1", "eno1", "", CategoryEthernet},
+		{"linux vpn tun0", "tun0", "", CategoryVPN},
+		{"linux vpn tap0", "tap0", "", CategoryVPN},
+		{"linux vpn wg0", "wg0", "", CategoryVPN},
+		{"linux vpn ppp0", "ppp0", "", CategoryVPN},
+		{"linux virtual docker0", "docker0", "", CategoryVirtual},
+		{"linux virtual virbr0", "virbr0", "", CategoryVirtual},
+		{"linux virtual vmnet1", "vmnet1", "", CategoryVirtual},
+		{"linux virtual veth", "veth0a1b2c3", "", CategoryVirtual},
+		{"linux virtual lo", "lo", "", CategoryVirtual},
+		{"linux virtual br-docker", "br-1234abcd", "", CategoryVirtual},
+
+		// Edge cases
+		{"empty", "", "", CategoryOther},
+		{"unknown adapter", "Some Random Adapter", "", CategoryOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Categorize(tc.ifaceName, tc.description)
+			if got != tc.want {
+				t.Errorf("Categorize(%q, %q) = %q, want %q", tc.ifaceName, tc.description, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRankCandidates(t *testing.T) {
+	in := []NetworkInterface{
+		{Name: "lo", Description: ""},
+		{Name: `\Device\NPF_{V}`, Description: "VirtualBox Host-Only"},
+		{Name: `\Device\NPF_{W}`, Description: "Wi-Fi"},
+		{Name: `\Device\NPF_{E}`, Description: "Realtek PCIe GbE Family Controller"},
+		{Name: `\Device\NPF_{X}`, Description: "ExitLag LightWeight Filter"},
+		{Name: "tun0", Description: ""},
+	}
+	got := RankCandidates(in)
+	wantOrder := []string{
+		"Realtek PCIe GbE Family Controller", // ethernet
+		"Wi-Fi",                                // wifi
+		"ExitLag LightWeight Filter",           // exitlag
+		"",                                     // vpn (tun0 has empty description)
+		"VirtualBox Host-Only",                 // virtual
+		"",                                     // virtual (lo has empty description)
+	}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d entries, want %d", len(got), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if got[i].Description != want {
+			t.Errorf("position %d: description %q, want %q", i, got[i].Description, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+go test ./internal/capture/ -run 'TestCategorize|TestRankCandidates' -v
+```
+
+Expected: FAIL with `undefined: Category`, `undefined: Categorize`, `undefined: RankCandidates`.
+
+- [ ] **Step 3: Implement `categorize.go`**
+
+Create `internal/capture/categorize.go`:
+
+```go
+package capture
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Category labels a network interface for UI display and ranking.
+type Category string
+
+const (
+	CategoryWiFi     Category = "wifi"
+	CategoryEthernet Category = "ethernet"
+	CategoryExitLag  Category = "exitlag"
+	CategoryVPN      Category = "vpn"
+	CategoryVirtual  Category = "virtual"
+	CategoryOther    Category = "other"
+)
+
+// categoryRules are evaluated in order; first match wins. Patterns run on
+// lowercase(name + " " + description) to work for Windows (description-rich)
+// and Linux (name-rich) alike.
+var categoryRules = []struct {
+	cat Category
+	re  *regexp.Regexp
+}{
+	{CategoryVirtual, regexp.MustCompile(`virtualbox|vmware|hyper-v|virtual switch|vethernet|teredo|loopback pseudo|software loopback|wi-fi direct|mobile hotspot|\bdocker\d|\bbr-|\bvirbr\d|\bvmnet\d|\bveth|^lo$`)},
+	{CategoryExitLag, regexp.MustCompile(`exit\s*lag`)},
+	{CategoryVPN, regexp.MustCompile(`vpn|wireguard|wintun|tap-windows|openvpn|\btun\d|\btap\d|\bwg\d|\bppp\d`)},
+	{CategoryWiFi, regexp.MustCompile(`wi-?fi|wireless|802\.11|\bwlan\d|\bwlp\d|\bwifi\d`)},
+	{CategoryEthernet, regexp.MustCompile(`ethernet|gigabit|family controller|\beth\d|\benp\d|\beno\d|\bens\d`)},
+}
+
+// Categorize classifies an interface from its OS name and human description.
+func Categorize(name, description string) Category {
+	if name == "" && description == "" {
+		return CategoryOther
+	}
+	hay := strings.ToLower(name + " " + description)
+	for _, r := range categoryRules {
+		if r.re.MatchString(hay) {
+			return r.cat
+		}
+	}
+	return CategoryOther
+}
+
+var categoryRank = map[Category]int{
+	CategoryEthernet: 0,
+	CategoryWiFi:     1,
+	CategoryExitLag:  2,
+	CategoryVPN:      3,
+	CategoryVirtual:  4,
+	CategoryOther:    5,
+}
+
+// RankCandidates returns a stable copy of in sorted by category priority.
+// Ties keep input order (sort.SliceStable).
+func RankCandidates(in []NetworkInterface) []NetworkInterface {
+	out := make([]NetworkInterface, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		ci := Categorize(out[i].Name, out[i].Description)
+		cj := Categorize(out[j].Name, out[j].Description)
+		return categoryRank[ci] < categoryRank[cj]
+	})
+	return out
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+go test ./internal/capture/ -run 'TestCategorize|TestRankCandidates' -v
+```
+
+Expected: PASS, all 36+ subtests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capture/categorize.go internal/capture/categorize_test.go
+git commit -m "feat(91): categorize network interfaces by name+description"
+```
+
+---
+
+## Task 2: Network config persistence + ip.txt migration
+
+**Files:**
+- Create: `internal/capture/network_config.go`, `internal/capture/network_config_test.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/capture/network_config_test.go`:
+
+```go
+package capture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		CaptureInterfaces: []PersistedInterface{
+			{Name: `\Device\NPF_{ABC}`, Description: "Wi-Fi"},
+			{Name: `\Device\NPF_{DEF}`, Description: "Realtek"},
+		},
+	}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if len(got.CaptureInterfaces) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got.CaptureInterfaces))
+	}
+	if got.CaptureInterfaces[0].Description != "Wi-Fi" {
+		t.Errorf("entry 0 description = %q, want Wi-Fi", got.CaptureInterfaces[0].Description)
+	}
+}
+
+func TestReadConfigMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig on empty dir: %v", err)
+	}
+	if len(cfg.CaptureInterfaces) != 0 {
+		t.Errorf("missing config returned %d entries, want 0", len(cfg.CaptureInterfaces))
+	}
+}
+
+func TestReadConfigMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "network.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := ReadConfig(dir)
+	if err == nil {
+		t.Fatalf("expected error on malformed JSON, got cfg=%+v", cfg)
+	}
+}
+
+func TestMigrateFromIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("192.168.1.42\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolve := func(ip string) (PersistedInterface, error) {
+		if ip != "192.168.1.42" {
+			t.Errorf("resolve called with %q, want 192.168.1.42", ip)
+		}
+		return PersistedInterface{Name: `\Device\NPF_{X}`, Description: "Wi-Fi"}, nil
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migrated=true")
+	}
+	cfg, _ := ReadConfig(dir)
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Description != "Wi-Fi" {
+		t.Errorf("migrated config wrong: %+v", cfg)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); !os.IsNotExist(err) {
+		t.Errorf("ip.txt should be deleted, err=%v", err)
+	}
+}
+
+func TestMigrateNoIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	migrated, err := MigrateIPTxt(dir, nil)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt with no ip.txt: %v", err)
+	}
+	if migrated {
+		t.Error("expected migrated=false when no ip.txt")
+	}
+}
+
+func TestWriteConfigOverwritesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	cfg1 := Config{CaptureInterfaces: []PersistedInterface{{Name: "A", Description: "First"}}}
+	if err := WriteConfig(dir, cfg1); err != nil {
+		t.Fatal(err)
+	}
+	cfg2 := Config{CaptureInterfaces: []PersistedInterface{{Name: "B", Description: "Second"}}}
+	if err := WriteConfig(dir, cfg2); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := ReadConfig(dir)
+	if got.CaptureInterfaces[0].Description != "Second" {
+		t.Errorf("overwrite failed, got %+v", got)
+	}
+	// ensure no leftover .tmp
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover tmp file: %s", e.Name())
+		}
+	}
+	// also ensure file is valid JSON via independent decode
+	data, _ := os.ReadFile(filepath.Join(dir, "network.json"))
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Errorf("network.json not valid JSON: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+go test ./internal/capture/ -run 'TestConfig|TestRead|TestMigrate|TestWrite' -v
+```
+
+Expected: FAIL with `undefined: Config`, `undefined: WriteConfig`, etc.
+
+- [ ] **Step 3: Implement `network_config.go`**
+
+Create `internal/capture/network_config.go`:
+
+```go
+package capture
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const configFilename = "network.json"
+const legacyIPFilename = "ip.txt"
+
+// PersistedInterface is the on-disk record used to reopen a capture handle
+// across restarts. Name is the OS device identifier (stable). Description is
+// the human-readable label (preserved for UI display + fallback if Name is
+// reissued by the OS).
+type PersistedInterface struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Config is the on-disk shape of network.json.
+type Config struct {
+	CaptureInterfaces []PersistedInterface `json:"captureInterfaces"`
+}
+
+// ReadConfig loads network.json from appDir. Returns an empty Config (nil
+// error) if the file does not exist. Returns an error if the file exists but
+// cannot be parsed.
+func ReadConfig(appDir string) (Config, error) {
+	path := filepath.Join(appDir, configFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// WriteConfig serializes cfg to network.json atomically (write to .tmp, rename).
+// On Windows the rename across the same directory is atomic since Go 1.5+.
+func WriteConfig(appDir string, cfg Config) error {
+	path := filepath.Join(appDir, configFilename)
+	tmp := path + ".tmp"
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename tmp: %w", err)
+	}
+	return nil
+}
+
+// IPResolver resolves a legacy IPv4 string to an interface record. The Manager
+// supplies a real implementation via pcap.FindAllDevs at boot time. Tests
+// inject a fake.
+type IPResolver func(ip string) (PersistedInterface, error)
+
+// MigrateIPTxt reads legacy ip.txt if present and writes its single entry into
+// network.json (only if network.json is currently empty/missing). Returns
+// migrated=true if migration happened.
+func MigrateIPTxt(appDir string, resolve IPResolver) (bool, error) {
+	ipPath := filepath.Join(appDir, legacyIPFilename)
+	data, err := os.ReadFile(ipPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", ipPath, err)
+	}
+	ip := strings.TrimSpace(string(data))
+	if ip == "" {
+		_ = os.Remove(ipPath)
+		return false, nil
+	}
+	existing, err := ReadConfig(appDir)
+	if err == nil && len(existing.CaptureInterfaces) > 0 {
+		// network.json already populated, leave it alone but remove ip.txt
+		_ = os.Remove(ipPath)
+		return false, nil
+	}
+	if resolve == nil {
+		return false, fmt.Errorf("no IP resolver provided for migration")
+	}
+	entry, err := resolve(ip)
+	if err != nil {
+		// Resolution failed (interface gone). Remove ip.txt to avoid retrying
+		// on every boot; user will pick a fresh interface from Settings.
+		_ = os.Remove(ipPath)
+		return false, fmt.Errorf("resolve legacy ip %q: %w", ip, err)
+	}
+	cfg := Config{CaptureInterfaces: []PersistedInterface{entry}}
+	if err := WriteConfig(appDir, cfg); err != nil {
+		return false, err
+	}
+	_ = os.Remove(ipPath)
+	return true, nil
+}
+```
+
+- [ ] **Step 4: Run test, verify all pass**
+
+```bash
+go test ./internal/capture/ -run 'TestConfig|TestRead|TestMigrate|TestWrite' -v
+```
+
+Expected: PASS, all 6 subtests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capture/network_config.go internal/capture/network_config_test.go
+git commit -m "feat(91): network.json persistence + ip.txt migration"
+```
+
+---
+
+## Task 3: Refactor Capturer to single-handle worker (drop CLI prompt)
+
+**Files:**
+- Modify: `internal/capture/pcap.go`.
+- Existing tests in `internal/capture/` should still pass (no test for prompt logic exists).
+
+- [ ] **Step 1: Read current pcap.go to confirm scope**
+
+```bash
+sed -n '1,50p' internal/capture/pcap.go
+```
+
+Note the public surface: `New`, `OnPacket`, `Start`, `Close`, `AdapterIP`, `BytesReceived`, `Stats`. The CLI prompt and `getAdapterIP` are private.
+
+- [ ] **Step 2: Replace pcap.go with the simplified worker**
+
+Replace the contents of `internal/capture/pcap.go` with:
+
+```go
+package capture
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+)
+
+const (
+	AlbionPort  = 5056
+	SnapLen     = 65536
+	Promiscuous = false
+	// BlockForever deadlocks handle.Close() when idle; poll on timeout.
+	ReadTimeout = 100 * time.Millisecond
+)
+
+// NetworkInterface describes a candidate interface enumerated from pcap.
+type NetworkInterface struct {
+	Name        string
+	Description string
+	Address     string
+	Device      string // raw pcap device name (same as Name on Windows; aliased for clarity)
+}
+
+// PacketHandler is called for each captured UDP payload.
+type PacketHandler func(payload []byte)
+
+// Capturer owns one pcap.Handle and processes packets in its caller-provided
+// goroutine via Start. Lifecycle is owned by Manager.
+type Capturer struct {
+	handle   *pcap.Handle
+	iface    NetworkInterface
+	onPacket PacketHandler
+	ctx      context.Context
+	cancel   context.CancelFunc
+
+	bytesReceived uint64
+}
+
+// captureFactory is overridable in tests.
+var captureFactory = openLiveCapture
+
+func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
+	handle, err := pcap.OpenLive(iface.Device, SnapLen, Promiscuous, ReadTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("open device %q: %w", iface.Device, err)
+	}
+	filter := fmt.Sprintf("udp and (dst port %d or src port %d)", AlbionPort, AlbionPort)
+	if err := handle.SetBPFFilter(filter); err != nil {
+		handle.Close()
+		return nil, fmt.Errorf("set BPF filter on %q: %w", iface.Device, err)
+	}
+	cctx, cancel := context.WithCancel(ctx)
+	return &Capturer{
+		handle: handle,
+		iface:  iface,
+		ctx:    cctx,
+		cancel: cancel,
+	}, nil
+}
+
+// OnPacket registers the packet handler. Must be called before Start.
+func (c *Capturer) OnPacket(h PacketHandler) { c.onPacket = h }
+
+// Start blocks reading packets until the context is canceled or the handle
+// returns an error.
+func (c *Capturer) Start() error {
+	source := gopacket.NewPacketSource(c.handle, c.handle.LinkType())
+	for {
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case pkt, ok := <-source.Packets():
+			if !ok {
+				return nil
+			}
+			c.processPacket(pkt)
+		}
+	}
+}
+
+// Close cancels the read loop and closes the underlying handle. Must NOT be
+// called while Start is still polling on a packet — Manager guarantees that.
+func (c *Capturer) Close() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.handle != nil {
+		c.handle.Close()
+	}
+}
+
+// Iface returns the interface this capturer is bound to.
+func (c *Capturer) Iface() NetworkInterface { return c.iface }
+
+// BytesReceived returns the cumulative payload byte count.
+func (c *Capturer) BytesReceived() uint64 { return atomic.LoadUint64(&c.bytesReceived) }
+
+// Stats returns libpcap stats for the underlying handle.
+func (c *Capturer) Stats() (*pcap.Stats, error) {
+	if c.handle == nil {
+		return nil, nil
+	}
+	return c.handle.Stats()
+}
+
+func (c *Capturer) processPacket(p gopacket.Packet) {
+	udpLayer := p.Layer(layers.LayerTypeUDP)
+	if udpLayer == nil {
+		return
+	}
+	udp, ok := udpLayer.(*layers.UDP)
+	if !ok || len(udp.Payload) == 0 || c.onPacket == nil {
+		return
+	}
+	atomic.AddUint64(&c.bytesReceived, uint64(len(udp.Payload)))
+	c.onPacket(udp.Payload)
+}
+
+// EnumerateInterfaces lists candidate interfaces (those with at least one IPv4)
+// suitable for capture. Wraps pcap.FindAllDevs.
+func EnumerateInterfaces() ([]NetworkInterface, error) {
+	devs, err := pcap.FindAllDevs()
+	if err != nil {
+		return nil, fmt.Errorf("list devices: %w", err)
+	}
+	var out []NetworkInterface
+	for _, d := range devs {
+		for _, addr := range d.Addresses {
+			ip4 := addr.IP.To4()
+			if ip4 == nil {
+				continue
+			}
+			out = append(out, NetworkInterface{
+				Name:        d.Name,
+				Description: d.Description,
+				Address:     ip4.String(),
+				Device:      d.Name,
+			})
+			break // first IPv4 only, mirrors legacy behavior
+		}
+	}
+	return out, nil
+}
+
+// ResolveByIP finds the interface name for a given IPv4 (used by ip.txt
+// migration).
+func ResolveByIP(ip string) (PersistedInterface, error) {
+	ifaces, err := EnumerateInterfaces()
+	if err != nil {
+		return PersistedInterface{}, err
+	}
+	for _, i := range ifaces {
+		if i.Address == ip {
+			return PersistedInterface{Name: i.Name, Description: i.Description}, nil
+		}
+	}
+	return PersistedInterface{}, fmt.Errorf("no interface with IP %s", ip)
+}
+```
+
+- [ ] **Step 3: Confirm existing capture package tests still pass**
+
+```bash
+go test ./internal/capture/ -v
+```
+
+Expected: PASS — categorize and network_config tests from Tasks 1 and 2 still green; no other tests yet.
+
+- [ ] **Step 4: Build the rest of the project to surface call-site breaks**
+
+```bash
+go build ./...
+```
+
+Expected: build errors in `cmd/radar/main.go` (uses removed `New`) and possibly `internal/ui/dashboard.go` (uses removed `AdapterIP`). These are addressed in Tasks 6 and 7.
+
+- [ ] **Step 5: Stash the build break temporarily**
+
+The build will stay broken until Task 6 wires Manager into main. That's expected. Run tests on the capture package only to verify the refactor is clean:
+
+```bash
+go test ./internal/capture/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/capture/pcap.go
+git commit -m "refactor(91): simplify Capturer to single-handle worker"
+```
+
+---
+
+## Task 4: Manager lifecycle
+
+**Files:**
+- Create: `internal/capture/manager.go`, `internal/capture/manager_test.go`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/capture/manager_test.go`:
+
+```go
+package capture
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// captureFactoryStub replaces openLiveCapture for the duration of a test.
+type stubHandle struct {
+	closed atomic.Bool
+}
+
+func newStubCapturer(iface NetworkInterface) *Capturer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Capturer{
+		iface:  iface,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func withStubFactory(t *testing.T, opens map[string]error) func() {
+	t.Helper()
+	prev := captureFactory
+	captureFactory = func(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
+		if err, ok := opens[iface.Name]; ok && err != nil {
+			return nil, err
+		}
+		c := newStubCapturer(iface)
+		// Replace cancel with a parent-aware one so Close propagates.
+		c.ctx, c.cancel = context.WithCancel(ctx)
+		return c, nil
+	}
+	return func() { captureFactory = prev }
+}
+
+func TestManagerReconfigureAddsRemoves(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+
+	if err := m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}, {Name: "b", Device: "b"}}); err != nil {
+		t.Fatalf("Reconfigure add: %v", err)
+	}
+	state := m.State()
+	if len(state.Active) != 2 {
+		t.Fatalf("got %d active, want 2", len(state.Active))
+	}
+
+	if err := m.Reconfigure([]NetworkInterface{{Name: "b", Device: "b"}, {Name: "c", Device: "c"}}); err != nil {
+		t.Fatalf("Reconfigure swap: %v", err)
+	}
+	state = m.State()
+	names := make(map[string]bool)
+	for _, i := range state.Active {
+		names[i.Name] = true
+	}
+	if !names["b"] || !names["c"] || names["a"] {
+		t.Errorf("after swap want {b,c}, got %+v", state.Active)
+	}
+
+	if err := m.Reconfigure(nil); err != nil {
+		t.Fatalf("Reconfigure empty: %v", err)
+	}
+	state = m.State()
+	if len(state.Active) != 0 {
+		t.Errorf("after empty want 0 active, got %d", len(state.Active))
+	}
+	if state.Status != StatusAwaiting {
+		t.Errorf("status %q, want %q", state.Status, StatusAwaiting)
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManagerOpenFailureIsolatesOthers(t *testing.T) {
+	defer withStubFactory(t, map[string]error{"bad": errors.New("boom")})()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	err := m.Reconfigure([]NetworkInterface{
+		{Name: "good", Device: "good"},
+		{Name: "bad", Device: "bad"},
+	})
+	if err == nil {
+		t.Fatal("expected partial-failure error")
+	}
+	state := m.State()
+	if len(state.Active) != 1 || state.Active[0].Name != "good" {
+		t.Errorf("after partial failure want {good}, got %+v", state.Active)
+	}
+	if len(state.LastErrors) == 0 || state.LastErrors["bad"] == "" {
+		t.Errorf("expected lastErrors[bad], got %+v", state.LastErrors)
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManagerCloseTwiceSafe(t *testing.T) {
+	defer withStubFactory(t, nil)()
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	_ = m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}})
+	m.Close(context.Background())
+	m.Close(context.Background()) // must not panic
+}
+
+func TestManagerNoGoroutineLeak(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	var workerStarted, workerExited atomic.Int32
+	prev := managerStartWorker
+	managerStartWorker = func(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
+		workerStarted.Add(1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer workerExited.Add(1)
+			<-c.ctx.Done()
+		}()
+	}
+	defer func() { managerStartWorker = prev }()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	_ = m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}, {Name: "b", Device: "b"}})
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	m.Close(closeCtx)
+
+	if got, want := workerStarted.Load(), int32(2); got != want {
+		t.Errorf("workerStarted=%d, want %d", got, want)
+	}
+	if got, want := workerExited.Load(), int32(2); got != want {
+		t.Errorf("workerExited=%d, want %d (goroutine leak)", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify failing**
+
+```bash
+go test ./internal/capture/ -run TestManager -v
+```
+
+Expected: FAIL `undefined: NewManager`.
+
+- [ ] **Step 3: Implement `manager.go`**
+
+Create `internal/capture/manager.go`:
+
+```go
+package capture
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Status describes the manager's overall state.
+type Status string
+
+const (
+	StatusRunning   Status = "running"
+	StatusAwaiting  Status = "awaiting_interfaces"
+)
+
+// CaptureSummary is a snapshot row of an active or recently-failed interface.
+type CaptureSummary struct {
+	Name        string
+	Description string
+	Address     string
+	Category    Category
+	StartedAt   time.Time
+}
+
+// State is the externally-visible Manager snapshot.
+type State struct {
+	Status     Status
+	Active     []CaptureSummary
+	LastErrors map[string]string
+}
+
+// managerStartWorker is overridable in tests to assert lifecycle without real pcap.
+var managerStartWorker = startWorker
+
+// Manager owns multiple Capturers. Open/close ordering is strict; see comments
+// at each method.
+type Manager struct {
+	parentCtx context.Context
+
+	mu         sync.Mutex
+	active     map[string]*managedCapturer
+	wg         sync.WaitGroup
+	onPacket   PacketHandler
+	lastErrors map[string]string
+	closed     bool
+}
+
+type managedCapturer struct {
+	cap       *Capturer
+	startedAt time.Time
+	cancel    context.CancelFunc
+}
+
+// NewManager creates an empty manager bound to parent ctx.
+func NewManager(parentCtx context.Context) *Manager {
+	return &Manager{
+		parentCtx:  parentCtx,
+		active:     make(map[string]*managedCapturer),
+		lastErrors: make(map[string]string),
+	}
+}
+
+// OnPacket registers the shared packet handler. Must be called before
+// Reconfigure. Concurrent calls from multiple goroutines hit the same handler
+// (Photon parser is idempotent on retransmits so duplicates are tolerated).
+func (m *Manager) OnPacket(h PacketHandler) {
+	m.mu.Lock()
+	m.onPacket = h
+	m.mu.Unlock()
+}
+
+// Reconfigure aligns the active set to target. Additions happen before
+// removals so a swap of one interface does not leave us with zero captures
+// momentarily.
+//
+// Returns a non-nil error if at least one open failed. The active set still
+// reflects all successful opens; per-interface errors are exposed via State().
+func (m *Manager) Reconfigure(target []NetworkInterface) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return fmt.Errorf("manager closed")
+	}
+	if m.onPacket == nil {
+		m.mu.Unlock()
+		return fmt.Errorf("OnPacket must be called before Reconfigure")
+	}
+
+	desired := make(map[string]NetworkInterface, len(target))
+	for _, i := range target {
+		desired[i.Name] = i
+	}
+
+	// 1. Open new ones first.
+	var openErrs []string
+	for name, iface := range desired {
+		if _, exists := m.active[name]; exists {
+			continue
+		}
+		cap, err := captureFactory(m.parentCtx, iface)
+		if err != nil {
+			m.lastErrors[name] = err.Error()
+			openErrs = append(openErrs, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		cap.OnPacket(m.onPacket)
+		mc := &managedCapturer{cap: cap, startedAt: time.Now(), cancel: cap.cancel}
+		m.active[name] = mc
+		delete(m.lastErrors, name)
+		managerStartWorker(cap, &m.wg, func(n string, e error) {
+			m.mu.Lock()
+			m.lastErrors[n] = e.Error()
+			delete(m.active, n)
+			m.mu.Unlock()
+		})
+	}
+
+	// 2. Stop removed ones.
+	for name, mc := range m.active {
+		if _, keep := desired[name]; keep {
+			continue
+		}
+		mc.cancel()
+		mc.cap.Close()
+		delete(m.active, name)
+		delete(m.lastErrors, name)
+	}
+
+	m.mu.Unlock()
+
+	if len(openErrs) > 0 {
+		return fmt.Errorf("partial open failures: %v", openErrs)
+	}
+	return nil
+}
+
+// State snapshots the current active set + last-known per-interface errors.
+func (m *Manager) State() State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := State{
+		LastErrors: make(map[string]string, len(m.lastErrors)),
+	}
+	for k, v := range m.lastErrors {
+		out.LastErrors[k] = v
+	}
+	for _, mc := range m.active {
+		i := mc.cap.iface
+		out.Active = append(out.Active, CaptureSummary{
+			Name:        i.Name,
+			Description: i.Description,
+			Address:     i.Address,
+			Category:    Categorize(i.Name, i.Description),
+			StartedAt:   mc.startedAt,
+		})
+	}
+	if len(out.Active) == 0 {
+		out.Status = StatusAwaiting
+	} else {
+		out.Status = StatusRunning
+	}
+	return out
+}
+
+// Close cancels every worker context, then closes handles. Waits up to
+// closeCtx.Deadline for goroutines to drain. Idempotent.
+func (m *Manager) Close(closeCtx context.Context) {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	for _, mc := range m.active {
+		mc.cancel()
+	}
+	captures := make([]*Capturer, 0, len(m.active))
+	for _, mc := range m.active {
+		captures = append(captures, mc.cap)
+	}
+	m.active = nil
+	m.mu.Unlock()
+
+	// Wait for workers to exit before closing handles. libpcap is unsafe to
+	// close while Read is still polling.
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-closeCtx.Done():
+	}
+	for _, c := range captures {
+		c.Close()
+	}
+}
+
+// startWorker runs Capturer.Start in a goroutine and reports errors via onError.
+func startWorker(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := c.Start(); err != nil && err != context.Canceled {
+			onError(c.iface.Name, err)
+		}
+	}()
+}
+```
+
+- [ ] **Step 4: Run tests, verify passing**
+
+```bash
+go test ./internal/capture/ -run TestManager -v
+```
+
+Expected: PASS, all 4 subtests green.
+
+- [ ] **Step 5: Run full capture package tests**
+
+```bash
+go test ./internal/capture/ -v
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/capture/manager.go internal/capture/manager_test.go
+git commit -m "feat(91): Manager owns multi-handle capture lifecycle"
+```
+
+---
+
+## Task 5: HTTP API endpoints
+
+**Files:**
+- Create: `internal/server/network_api.go`, `internal/server/network_api_test.go`.
+- Modify: `internal/server/http.go` to register the new routes.
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/server/network_api_test.go`:
+
+```go
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+)
+
+type fakeManager struct {
+	state         capture.State
+	reconfArgs    []capture.NetworkInterface
+	reconfErr     error
+	allInterfaces []capture.NetworkInterface
+}
+
+func (f *fakeManager) State() capture.State { return f.state }
+func (f *fakeManager) Reconfigure(t []capture.NetworkInterface) error {
+	f.reconfArgs = append([]capture.NetworkInterface(nil), t...)
+	return f.reconfErr
+}
+
+func TestNetworkAPI_ListReturnsCategorized(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{
+			{Name: "n1", Description: "Wi-Fi", Address: "192.168.1.1"},
+			{Name: "n2", Description: "Realtek PCIe GbE Family Controller", Address: "192.168.1.2"},
+		},
+		state: capture.State{
+			Active: []capture.CaptureSummary{{Name: "n1"}},
+		},
+	}
+	api := NewNetworkAPI(fm, fm.allInterfaces, "/tmp/notused", func() []string { return []string{"192.168.1.5"} })
+	req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	for _, row := range got {
+		if row["category"] == "" {
+			t.Errorf("missing category in %+v", row)
+		}
+	}
+}
+
+func TestNetworkAPI_PostFromLoopback(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{
+			{Name: "x", Description: "Wi-Fi", Address: "10.0.0.1"},
+		},
+	}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("loopback POST got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fm.reconfArgs) != 1 || fm.reconfArgs[0].Name != "x" {
+		t.Errorf("Reconfigure called with %+v", fm.reconfArgs)
+	}
+	cfg, _ := capture.ReadConfig(dir)
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Name != "x" {
+		t.Errorf("config not persisted: %+v", cfg)
+	}
+}
+
+func TestNetworkAPI_PostFromLanRejected(t *testing.T) {
+	fm := &fakeManager{}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "192.168.1.42:5555"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status %d, want 403", rec.Code)
+	}
+	if len(fm.reconfArgs) != 0 {
+		t.Errorf("Reconfigure should not have been called from non-loopback")
+	}
+}
+
+func TestNetworkAPI_StateShape(t *testing.T) {
+	fm := &fakeManager{
+		state: capture.State{
+			Status: capture.StatusRunning,
+			Active: []capture.CaptureSummary{{Name: "x", Description: "Wi-Fi", Address: "10.0.0.1"}},
+		},
+	}
+	api := NewNetworkAPI(fm, nil, "/tmp", func() []string { return []string{"192.168.1.1"} })
+	req := httptest.NewRequest("GET", "/api/network/state", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["isCapturing"] != true {
+		t.Errorf("isCapturing=%v", body["isCapturing"])
+	}
+	if body["lanAddresses"] == nil {
+		t.Error("lanAddresses missing")
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify failing**
+
+```bash
+go test ./internal/server/ -run TestNetworkAPI -v
+```
+
+Expected: FAIL `undefined: NewNetworkAPI`.
+
+- [ ] **Step 3: Implement `network_api.go`**
+
+Create `internal/server/network_api.go`:
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+)
+
+// NetworkManager is the subset of capture.Manager the API needs.
+type NetworkManager interface {
+	State() capture.State
+	Reconfigure([]capture.NetworkInterface) error
+}
+
+// LANAddrFn returns the IP addresses (without port) reachable from devices on
+// the same LAN as the host. Computed independently of the capture interfaces.
+type LANAddrFn func() []string
+
+// NetworkAPI mounts /api/network/* routes.
+type NetworkAPI struct {
+	mgr        NetworkManager
+	all        []capture.NetworkInterface // refreshed via /refresh
+	appDir     string
+	lanAddrs   LANAddrFn
+}
+
+func NewNetworkAPI(mgr NetworkManager, all []capture.NetworkInterface, appDir string, lan LANAddrFn) *NetworkAPI {
+	return &NetworkAPI{mgr: mgr, all: all, appDir: appDir, lanAddrs: lan}
+}
+
+// Register attaches the routes to a mux.
+func (a *NetworkAPI) Register(mux *http.ServeMux) {
+	mux.Handle("/api/network/interfaces", a)
+	mux.Handle("/api/network/state", a)
+	mux.Handle("/api/network/refresh", a)
+}
+
+func (a *NetworkAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/network/interfaces":
+		switch r.Method {
+		case http.MethodGet:
+			a.handleList(w, r)
+		case http.MethodPost:
+			a.handleSelect(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case "/api/network/state":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		a.handleState(w, r)
+	case "/api/network/refresh":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		a.handleRefresh(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+type ifaceRow struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Address     string `json:"address"`
+	Category    string `json:"category"`
+	IsPersisted bool   `json:"isPersisted"`
+	IsAvailable bool   `json:"isAvailable"`
+}
+
+func (a *NetworkAPI) handleList(w http.ResponseWriter, _ *http.Request) {
+	persisted := make(map[string]bool)
+	cfg, _ := capture.ReadConfig(a.appDir)
+	for _, p := range cfg.CaptureInterfaces {
+		persisted[p.Name] = true
+	}
+	available := make(map[string]bool)
+	for _, i := range a.all {
+		available[i.Name] = true
+	}
+	rows := make([]ifaceRow, 0, len(a.all))
+	for _, i := range capture.RankCandidates(a.all) {
+		rows = append(rows, ifaceRow{
+			Name:        i.Name,
+			Description: i.Description,
+			Address:     i.Address,
+			Category:    string(capture.Categorize(i.Name, i.Description)),
+			IsPersisted: persisted[i.Name],
+			IsAvailable: available[i.Name],
+		})
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
+type stateBody struct {
+	CaptureInterfaces []capture.CaptureSummary `json:"captureInterfaces"`
+	IsCapturing       bool                     `json:"isCapturing"`
+	LanAddresses      []string                 `json:"lanAddresses"`
+	LastErrors        map[string]string        `json:"lastErrors"`
+	Status            string                   `json:"status"`
+}
+
+func (a *NetworkAPI) handleState(w http.ResponseWriter, _ *http.Request) {
+	s := a.mgr.State()
+	body := stateBody{
+		CaptureInterfaces: s.Active,
+		IsCapturing:       len(s.Active) > 0,
+		LanAddresses:      a.lanAddrs(),
+		LastErrors:        s.LastErrors,
+		Status:            string(s.Status),
+	}
+	writeJSON(w, http.StatusOK, body)
+}
+
+type selectBody struct {
+	Names []string `json:"names"`
+}
+
+func (a *NetworkAPI) handleSelect(w http.ResponseWriter, r *http.Request) {
+	if !isLoopback(r.RemoteAddr) {
+		http.Error(w, "capture interfaces can only be changed from the host PC", http.StatusForbidden)
+		return
+	}
+	var body selectBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	desired := make([]capture.NetworkInterface, 0, len(body.Names))
+	for _, name := range body.Names {
+		for _, i := range a.all {
+			if i.Name == name {
+				desired = append(desired, i)
+				break
+			}
+		}
+	}
+	if err := a.mgr.Reconfigure(desired); err != nil {
+		http.Error(w, "reconfigure: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	persisted := make([]capture.PersistedInterface, 0, len(desired))
+	for _, i := range desired {
+		persisted = append(persisted, capture.PersistedInterface{Name: i.Name, Description: i.Description})
+	}
+	if err := capture.WriteConfig(a.appDir, capture.Config{CaptureInterfaces: persisted}); err != nil {
+		http.Error(w, "persist: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (a *NetworkAPI) handleRefresh(w http.ResponseWriter, _ *http.Request) {
+	fresh, err := capture.EnumerateInterfaces()
+	if err != nil {
+		http.Error(w, "enumerate: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	a.all = fresh
+	a.handleList(w, nil)
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func isLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+```
+
+- [ ] **Step 4: Run tests, verify all pass**
+
+```bash
+go test ./internal/server/ -run TestNetworkAPI -v
+```
+
+Expected: PASS, 4 subtests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/network_api.go internal/server/network_api_test.go
+git commit -m "feat(91): /api/network/* endpoints (loopback-only POST)"
+```
+
+---
+
+## Task 6: Wire Manager + API into main.go and HTTP server
+
+**Files:**
+- Modify: `cmd/radar/main.go`, `internal/server/http.go`.
+
+- [ ] **Step 1: Read current main.go capture init flow**
+
+```bash
+grep -n 'capture\.\|adapterIP\|ipAddr' cmd/radar/main.go
+```
+
+Identify the `New(...)` call site and the `--ip` flag binding.
+
+- [ ] **Step 2: Replace single Capturer with Manager bootstrap**
+
+In `cmd/radar/main.go`, locate the block initializing the capturer (around line 83-99). Replace with:
+
+```go
+// Enumerate first so we can pre-resolve the persisted set.
+allIfaces, err := capture.EnumerateInterfaces()
+if err != nil {
+    return fmt.Errorf("enumerate interfaces: %w", err)
+}
+
+// Migrate legacy ip.txt if present (one-shot, idempotent).
+_, _ = capture.MigrateIPTxt(appDir, capture.ResolveByIP)
+
+// Read persisted choice; if empty, auto-pick top-ranked physicals.
+cfg, _ := capture.ReadConfig(appDir)
+target := resolvePersisted(cfg, allIfaces, cliIPOverride)
+if len(target) == 0 {
+    target = autoPickDefaults(allIfaces)
+    if len(target) > 0 {
+        var persisted []capture.PersistedInterface
+        for _, i := range target {
+            persisted = append(persisted, capture.PersistedInterface{Name: i.Name, Description: i.Description})
+        }
+        _ = capture.WriteConfig(appDir, capture.Config{CaptureInterfaces: persisted})
+        logger.PrintInfo("NET", "Auto-selected %d interface(s). Change in /settings if needed.", len(target))
+    }
+}
+
+manager := capture.NewManager(ctx)
+manager.OnPacket(app.handlePacket)
+if err := manager.Reconfigure(target); err != nil {
+    logger.PrintWarn("NET", "Some interfaces failed to open: %v", err)
+}
+defer manager.Close(context.Background())
+app.captureManager = manager
+```
+
+Add helpers in the same file (or a sibling `cmd/radar/capture_init.go`):
+
+```go
+func resolvePersisted(cfg capture.Config, all []capture.NetworkInterface, ipOverride string) []capture.NetworkInterface {
+    if ipOverride != "" {
+        for _, i := range all {
+            if i.Address == ipOverride {
+                return []capture.NetworkInterface{i}
+            }
+        }
+        return nil
+    }
+    available := make(map[string]capture.NetworkInterface, len(all))
+    for _, i := range all {
+        available[i.Name] = i
+    }
+    var out []capture.NetworkInterface
+    for _, p := range cfg.CaptureInterfaces {
+        if i, ok := available[p.Name]; ok {
+            out = append(out, i)
+        }
+    }
+    return out
+}
+
+func autoPickDefaults(all []capture.NetworkInterface) []capture.NetworkInterface {
+    var out []capture.NetworkInterface
+    for _, i := range capture.RankCandidates(all) {
+        c := capture.Categorize(i.Name, i.Description)
+        if c == capture.CategoryEthernet || c == capture.CategoryWiFi || c == capture.CategoryExitLag {
+            if isRFC1918(i.Address) {
+                out = append(out, i)
+            }
+        }
+    }
+    return out
+}
+
+func isRFC1918(addr string) bool {
+    ip := net.ParseIP(addr)
+    if ip == nil {
+        return false
+    }
+    for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+        _, n, _ := net.ParseCIDR(cidr)
+        if n.Contains(ip) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+Replace the field on the app struct:
+
+```go
+type radarApp struct {
+    // ...
+    captureManager *capture.Manager
+    // remove: adapterIP string
+}
+```
+
+Adjust the dashboard call to pull state from the manager (Task 7 covers the full TUI rewire).
+
+Add the type stub at the top of `internal/ui/dashboard.go` so the build stays green at the end of this task:
+
+```go
+type CaptureSummary struct {
+    Description string
+    Address     string
+}
+```
+
+Then update the existing `NewDashboard` signature in `dashboard.go` to accept the new parameters and the construction call in `main.go` to:
+
+```go
+dashboard := ui.NewDashboard(Version, serverPort, cfg.devMode, []string{}, []ui.CaptureSummary{})
+```
+
+Task 7 will populate the actual rendering logic and the `SetCaptureState` method.
+
+- [ ] **Step 3: Wire NetworkAPI into the HTTP server**
+
+In `internal/server/http.go`, modify `NewHTTPServer` (and `NewHTTPServerDev`) to accept a `NetworkManager`, and register the API in `setupRoutes`:
+
+```go
+type HTTPServer struct {
+    // ... existing fields ...
+    networkAPI *NetworkAPI
+}
+
+func NewHTTPServer(..., mgr NetworkManager, appDir string) (*HTTPServer, error) {
+    // ... existing init ...
+    s.networkAPI = NewNetworkAPI(mgr, nil, appDir, computeLANAddresses)
+    s.setupRoutes()
+    return s, nil
+}
+
+func (s *HTTPServer) setupRoutes() {
+    // ... existing routes ...
+    s.networkAPI.Register(s.mux)
+}
+
+func computeLANAddresses() []string {
+    addrs, err := net.InterfaceAddrs()
+    if err != nil {
+        return nil
+    }
+    var out []string
+    for _, a := range addrs {
+        if ipnet, ok := a.(*net.IPNet); ok {
+            ip4 := ipnet.IP.To4()
+            if ip4 == nil {
+                continue
+            }
+            for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+                _, n, _ := net.ParseCIDR(cidr)
+                if n.Contains(ip4) {
+                    out = append(out, ip4.String())
+                    break
+                }
+            }
+        }
+    }
+    return out
+}
+```
+
+Update `cmd/radar/main.go` to pass `manager` and `appDir` into the HTTP server constructor.
+
+- [ ] **Step 4: Build the project**
+
+```bash
+go build ./...
+```
+
+Expected: success.
+
+- [ ] **Step 5: Run all Go tests**
+
+```bash
+go test ./...
+```
+
+Expected: PASS across capture and server packages.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/radar/main.go internal/server/http.go
+git commit -m "feat(91): wire Manager + network API into bootstrap"
+```
+
+---
+
+## Task 7: TUI dashboard multi-interface display
+
+**Files:**
+- Modify: `internal/ui/dashboard.go`.
+
+- [ ] **Step 1: Define `CaptureSummary` type and update Dashboard signature**
+
+In `internal/ui/dashboard.go`, replace `adapterIP string` with:
+
+```go
+type CaptureSummary struct {
+    Description string
+    Address     string
+}
+
+type Dashboard struct {
+    // ... existing fields ...
+    captureInterfaces []CaptureSummary
+    lanAddresses      []string
+    // remove: adapterIP string
+}
+
+func NewDashboard(version string, port int, devMode bool, lanAddresses []string, captures []CaptureSummary) Dashboard {
+    d := Dashboard{
+        // ... existing init ...
+        captureInterfaces: captures,
+        lanAddresses:      lanAddresses,
+        serverURL:         fmt.Sprintf("http://localhost:%d", port),
+    }
+    if len(lanAddresses) > 0 {
+        d.lanServerURL = fmt.Sprintf("http://%s:%d", lanAddresses[0], port)
+        d.lanWsURL = fmt.Sprintf("ws://%s:%d/ws", lanAddresses[0], port)
+    }
+    return d
+}
+
+// SetCaptureState updates the live capture state from the manager.
+func (d *Dashboard) SetCaptureState(captures []CaptureSummary, lan []string) {
+    d.captureInterfaces = captures
+    d.lanAddresses = lan
+    if len(lan) > 0 {
+        d.lanServerURL = fmt.Sprintf("http://%s:%d", lan[0], d.port)
+    }
+}
+```
+
+- [ ] **Step 2: Update display lines**
+
+Replace any line in `dashboard.go` that built the "Adapter:" string with multi-line output:
+
+```go
+captureLine := "Capture: (awaiting)"
+if len(d.captureInterfaces) > 0 {
+    parts := make([]string, 0, len(d.captureInterfaces))
+    for _, c := range d.captureInterfaces {
+        parts = append(parts, fmt.Sprintf("%s (%s)", c.Description, c.Address))
+    }
+    captureLine = "Capture: " + strings.Join(parts, ", ")
+}
+lanLine := "LAN: (none)"
+if len(d.lanAddresses) > 0 {
+    urls := make([]string, 0, len(d.lanAddresses))
+    for _, ip := range d.lanAddresses {
+        urls = append(urls, fmt.Sprintf("http://%s:%d", ip, d.port))
+    }
+    lanLine = "LAN: " + strings.Join(urls, "  |  ")
+}
+// Use captureLine and lanLine where adapter was previously rendered.
+```
+
+- [ ] **Step 3: Periodic state refresh**
+
+In `cmd/radar/main.go`, after dashboard construction, start a goroutine that polls `manager.State()` every 2 seconds and feeds it back via `dashboard.SetCaptureState`:
+
+```go
+go func() {
+    t := time.NewTicker(2 * time.Second)
+    defer t.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-t.C:
+            s := manager.State()
+            summaries := make([]ui.CaptureSummary, 0, len(s.Active))
+            for _, a := range s.Active {
+                summaries = append(summaries, ui.CaptureSummary{Description: a.Description, Address: a.Address})
+            }
+            dashboard.SetCaptureState(summaries, computeLANAddresses())
+        }
+    }
+}()
+```
+
+- [ ] **Step 4: Build and run**
+
+```bash
+go build ./...
+go run ./cmd/radar -dev
+```
+
+Visually confirm the TUI now shows separate "Capture:" and "LAN:" lines. Quit with Ctrl+C and verify clean shutdown (no goroutine panic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/dashboard.go cmd/radar/main.go
+git commit -m "feat(91): TUI shows multi-interface capture and LAN URLs"
+```
+
+---
+
+## Task 8: Settings page UI + JS handler
+
+**Files:**
+- Create: `web/scripts/handlers/NetworkSettingsHandler.js`, `web/scripts/handlers/_NetworkSettingsHandler.test.js`.
+- Modify: `internal/templates/pages/settings.gohtml`.
+
+- [ ] **Step 1: Write failing test**
+
+Create `web/scripts/handlers/_NetworkSettingsHandler.test.js`:
+
+```javascript
+import {describe, test, expect, beforeEach, vi, afterEach} from 'vitest';
+
+const {NetworkSettingsHandler} = await import('./NetworkSettingsHandler.js');
+
+describe('NetworkSettingsHandler', () => {
+    let container;
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="network-section"></div>';
+        container = document.getElementById('network-section');
+        global.fetch = vi.fn();
+    });
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    test('renders one row per interface with badge', async () => {
+        global.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => ([
+                {name: 'a', description: 'Wi-Fi', address: '192.168.1.1', category: 'wifi', isPersisted: true, isAvailable: true},
+                {name: 'b', description: 'TAP-Windows', address: '10.8.0.1', category: 'vpn', isPersisted: false, isAvailable: true},
+            ])})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [{name: 'a'}], lanAddresses: ['192.168.1.5'], status: 'running'})});
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        const rows = container.querySelectorAll('[data-iface]');
+        expect(rows.length).toBe(2);
+        const wifiRow = container.querySelector('[data-iface="a"]');
+        expect(wifiRow.textContent).toContain('Wi-Fi');
+        expect(wifiRow.querySelector('input[type="checkbox"]').checked).toBe(true);
+    });
+
+    test('apply submits diff to backend', async () => {
+        global.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => ([
+                {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: true, isAvailable: true},
+                {name: 'b', description: 'Eth', address: '2', category: 'ethernet', isPersisted: false, isAvailable: true},
+            ])})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [{name: 'a'}], lanAddresses: [], status: 'running'})})
+            .mockResolvedValueOnce({ok: true, json: async () => ({status: 'ok'})});
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+        // Tick the second checkbox
+        container.querySelector('[data-iface="b"] input').click();
+        await h.apply();
+
+        const post = global.fetch.mock.calls.find(c => c[0] === '/api/network/interfaces' && c[1]?.method === 'POST');
+        expect(post).toBeDefined();
+        const body = JSON.parse(post[1].body);
+        expect(body.names.sort()).toEqual(['a', 'b']);
+    });
+
+    test('renders LAN addresses as clickable URLs', async () => {
+        global.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => []})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: ['192.168.1.5', '10.0.0.3'], status: 'awaiting_interfaces'})});
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+        const links = container.querySelectorAll('[data-lan-url]');
+        expect(links.length).toBe(2);
+        expect(links[0].href).toContain('192.168.1.5');
+    });
+});
+```
+
+- [ ] **Step 2: Run, verify failing**
+
+```bash
+npx vitest run web/scripts/handlers/_NetworkSettingsHandler.test.js
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `NetworkSettingsHandler.js`**
+
+Create `web/scripts/handlers/NetworkSettingsHandler.js`:
+
+```javascript
+const BADGES = {
+    wifi: '🛜', ethernet: '🔌', exitlag: '🚀', vpn: '🔒', virtual: '🧪', other: '•',
+};
+const BADGE_LABEL = {
+    wifi: 'WiFi', ethernet: 'Ethernet', exitlag: 'ExitLag', vpn: 'VPN', virtual: 'Virtual', other: 'Other',
+};
+
+export class NetworkSettingsHandler {
+    constructor(container) {
+        this.container = container;
+        this.interfaces = [];
+        this.state = null;
+    }
+
+    async load() {
+        const [ifaces, state] = await Promise.all([
+            fetch('/api/network/interfaces').then(r => r.json()),
+            fetch('/api/network/state').then(r => r.json()),
+        ]);
+        this.interfaces = ifaces;
+        this.state = state;
+        this.render();
+    }
+
+    render() {
+        const activeNames = new Set((this.state?.captureInterfaces || []).map(c => c.name));
+        const banner = this.renderBanner();
+        const rows = this.interfaces.map(i => this.renderRow(i, activeNames.has(i.name))).join('');
+        const lan = (this.state?.lanAddresses || []).map(a =>
+            `<li><a data-lan-url href="http://${a}:5001/" target="_blank">http://${a}:5001/</a></li>`
+        ).join('');
+        this.container.innerHTML = `
+            ${banner}
+            <h3 class="text-base font-semibold mt-2">Capture interfaces</h3>
+            <p class="text-sm opacity-70 mb-2">Captured packets are merged across all checked interfaces. Tick at least one to start capture.</p>
+            <div class="flex flex-col gap-1">${rows}</div>
+            <div class="flex gap-2 mt-3">
+                <button class="btn btn-sm" data-action="refresh">Refresh list</button>
+                <button class="btn btn-sm btn-primary" data-action="apply" disabled>Apply changes</button>
+            </div>
+            <h3 class="text-base font-semibold mt-6">LAN access</h3>
+            <p class="text-sm opacity-70">Reachable from devices on the same local network. Independent of the capture interfaces above.</p>
+            <ul class="list-disc pl-5">${lan || '<li class="opacity-60">No LAN address detected.</li>'}</ul>
+        `;
+        this.bindEvents();
+    }
+
+    renderBanner() {
+        if (this.state?.status === 'awaiting_interfaces') {
+            return `<div class="alert alert-warning mb-2">⚠ Capture not running. Pick at least one interface below to start.</div>`;
+        }
+        const n = (this.state?.captureInterfaces || []).length;
+        return `<div class="alert alert-success mb-2">✓ Capturing on ${n} interface${n > 1 ? 's' : ''}.</div>`;
+    }
+
+    renderRow(iface, checked) {
+        const badge = BADGES[iface.category] || BADGES.other;
+        const label = BADGE_LABEL[iface.category] || BADGE_LABEL.other;
+        const unavail = iface.isAvailable ? '' : ' <span class="opacity-60">(unavailable)</span>';
+        return `
+            <label class="flex items-center gap-3 cursor-pointer" data-iface="${iface.name}">
+                <input type="checkbox" class="checkbox checkbox-sm" ${checked ? 'checked' : ''} ${iface.isAvailable ? '' : 'disabled'}>
+                <span class="badge badge-outline">${badge} ${label}</span>
+                <span class="flex-1">${escapeHTML(iface.description || iface.name)}${unavail}</span>
+                <span class="opacity-60 text-sm">${iface.address || ''}</span>
+            </label>
+        `;
+    }
+
+    bindEvents() {
+        this.container.querySelectorAll('[data-iface] input').forEach(cb => {
+            cb.addEventListener('change', () => this.updateApplyState());
+        });
+        const applyBtn = this.container.querySelector('[data-action="apply"]');
+        applyBtn?.addEventListener('click', () => this.apply());
+        const refreshBtn = this.container.querySelector('[data-action="refresh"]');
+        refreshBtn?.addEventListener('click', () => this.refresh());
+    }
+
+    updateApplyState() {
+        const selected = this.selectedNames();
+        const current = (this.state?.captureInterfaces || []).map(c => c.name).sort();
+        const same = JSON.stringify(selected.sort()) === JSON.stringify(current);
+        const btn = this.container.querySelector('[data-action="apply"]');
+        if (btn) btn.disabled = same;
+    }
+
+    selectedNames() {
+        return Array.from(this.container.querySelectorAll('[data-iface] input:checked'))
+            .map(cb => cb.closest('[data-iface]').dataset.iface);
+    }
+
+    async apply() {
+        const names = this.selectedNames();
+        const res = await fetch('/api/network/interfaces', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({names}),
+        });
+        if (!res.ok) {
+            const txt = await res.text();
+            window.toaster?.error?.(`Apply failed: ${txt}`);
+            return;
+        }
+        window.toaster?.success?.('Capture interfaces updated.');
+        await this.load();
+    }
+
+    async refresh() {
+        const r = await fetch('/api/network/refresh', {method: 'POST'});
+        if (r.ok) {
+            this.interfaces = await r.json();
+            this.render();
+        }
+    }
+}
+
+function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+}
+```
+
+- [ ] **Step 4: Add the Network section to settings.gohtml**
+
+Modify `internal/templates/pages/settings.gohtml` to add a new section:
+
+```html
+<div class="card bg-base-200 shadow mt-4">
+    <div class="card-body">
+        <h2 class="card-title">Network</h2>
+        <div id="network-section">Loading network configuration…</div>
+    </div>
+</div>
+```
+
+And inside the existing `{{define "scripts/settings"}}` block, append:
+
+```javascript
+import('/scripts/handlers/NetworkSettingsHandler.js').then(({NetworkSettingsHandler}) => {
+    const container = document.getElementById('network-section');
+    if (container) {
+        const h = new NetworkSettingsHandler(container);
+        h.load();
+        // Poll every 5s while the page is visible
+        setInterval(() => { if (!document.hidden) h.load(); }, 5000);
+    }
+});
+```
+
+- [ ] **Step 5: Run vitest**
+
+```bash
+npx vitest run web/scripts/handlers/_NetworkSettingsHandler.test.js
+```
+
+Expected: PASS, 3 subtests green.
+
+- [ ] **Step 6: Run full vitest suite to confirm no regression**
+
+```bash
+npx vitest run
+```
+
+Expected: PASS — all previous tests + the 3 new ones.
+
+- [ ] **Step 7: Live-smoke the settings page**
+
+```bash
+go run ./cmd/radar -dev
+```
+
+Open `http://localhost:5001/settings`, scroll to the Network card. Verify:
+- Interface checkboxes appear with badges.
+- LAN access section lists at least one URL.
+- Apply button enables only after a checkbox change.
+- Toggling a checkbox + Apply shows a success toast.
+
+Quit with Ctrl+C and verify clean shutdown.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/scripts/handlers/NetworkSettingsHandler.js \
+        web/scripts/handlers/_NetworkSettingsHandler.test.js \
+        internal/templates/pages/settings.gohtml
+git commit -m "feat(91): Network section on Settings page (multi-select capture)"
+```
+
+---
+
+## Task 9: Final integration + lint + PR
+
+- [ ] **Step 1: Run full test suite + lint**
+
+```bash
+npx vitest run
+go test ./...
+npm run lint
+golangci-lint run ./...
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke checklist**
+
+Run the radar in dev mode and verify in order:
+
+1. Cold start with no `network.json` and no `ip.txt`: auto-pick logs "Auto-selected N interface(s)…", radar captures.
+2. Stop the radar, drop a `network.json` referencing a deliberately-wrong name (`{"captureInterfaces":[{"name":"\\Device\\NPF_{nope}","description":"x"}]}`), restart: TUI shows "Capture: (awaiting)", `/settings` Network section shows orange banner "⚠ Capture not running…".
+3. Tick a real interface in `/settings`, Apply: toast success, TUI updates within 2s to show the interface, banner turns green.
+4. From a phone on the LAN, open `http://<host-ip>:5001/settings`: Network section visible, checkboxes are interactable but the Apply button is hidden (replace by a yellow "Capture interfaces can only be changed from the host PC" notice).
+5. POST to `/api/network/interfaces` from the phone via curl: 403.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/91-dynamic-capture-interface
+gh pr create --title "feat(#91): dynamic capture interface selection" --body "$(cat <<'EOF'
+## Summary
+
+Closes #91.
+
+Replaces the IP-keyed `ip.txt` persistence + single-handle pcap with a multi-interface `Manager` keyed by stable `{name, description}`. Adds a "Network" section on `/settings` for runtime add/remove. Decouples capture interfaces from LAN serving addresses in the TUI/UI.
+
+## Changes
+
+- `MobsDatabase`-style migration of `ip.txt` to `network.json` on first boot.
+- New `internal/capture/categorize.go` (regex-based, cross-platform Win/Linux).
+- New `internal/capture/manager.go` (multi-handle lifecycle, strict open/close ordering).
+- New `/api/network/{interfaces,state,refresh}` endpoints; POST is loopback-only.
+- New `web/scripts/handlers/NetworkSettingsHandler.js` rendering checkboxes + LAN URLs.
+- TUI displays "Capture:" and "LAN:" as separate lines.
+
+## Known limitation: ExitLag NDIS LWF
+
+ExitLag is an NDIS Lightweight Filter, not a virtual adapter. Multi-interface capture covers the cases where ExitLag re-routes traffic between physical interfaces (most common). If ExitLag's filter strips packets entirely from NPF's view (Case D in the spec), a follow-up issue at the WFP layer will be needed. The owner's 3-day free trial post-merge will validate which case applies; tracked in `docs/project/TODO.md`.
+
+## Test plan
+
+- [x] `go test ./...` green
+- [x] `npx vitest run` green
+- [x] `golangci-lint run ./...` clean
+- [x] `npm run lint` clean
+- [ ] Manual smoke (5 scenarios listed in the implementation plan)
+- [ ] ExitLag free-trial smoke (post-merge)
+
+EOF
+)" --label bug --label enhancement
+```
+
+- [ ] **Step 4: Final verification**
+
+```bash
+gh pr view --web
+```
+
+Confirm the PR description is well-formed, labels applied, files-changed tab matches the spec.
+
+---
+
+## Out of scope (deferred)
+
+- Header/topbar selector (option B from brainstorm).
+- N3 auto-detect via traffic sniff at boot.
+- QR code for LAN URL.
+- Authentication on the API.
+- WFP-level capture for ExitLag Case D.

--- a/docs/superpowers/specs/2026-04-26-dynamic-capture-interface-design.md
+++ b/docs/superpowers/specs/2026-04-26-dynamic-capture-interface-design.md
@@ -1,0 +1,258 @@
+# Dynamic capture interface selection (#91)
+
+Date: 2026-04-26.
+
+Closes #91 ("Exit Lag, switch interface support").
+
+## Goals
+
+1. Replace IP-keyed persistence (`ip.txt`) with stable interface identifier `{name, description}`.
+2. Capture on **multiple interfaces simultaneously** so the radar keeps working when traffic is re-routed by ExitLag, VPN toggles, or wifi/ethernet switches.
+3. Allow runtime add/remove of capture interfaces from the front-end Settings page (source of truth backend).
+4. Decouple **capture interfaces** from **LAN serving addresses** in the TUI/UI display.
+5. Tag interfaces by category (WiFi, Ethernet, ExitLag, VPN, Virtual) to help selection.
+6. Survive interface unavailability (cable unplugged, VPN service stopped) without crashing.
+7. Cross-platform: Windows + Linux. macOS not officially supported but should not regress.
+
+## Non-goals
+
+- Header/topbar selector (deferred v2).
+- Auto-detect by traffic sniff at boot (`N3` from brainstorm, deferred).
+- QR code for LAN URL.
+- Capture at NDIS LWF / WFP / kernel layer to bypass ExitLag's filter (different threat model, out of scope hobby).
+- Authentication on the API (LAN trust + localhost-only edit covers).
+
+## Architecture
+
+### Backend (Go)
+
+#### Storage : `network.json`
+
+```json
+{
+  "captureInterfaces": [
+    {"name": "\\Device\\NPF_{ABC...}", "description": "Wi-Fi"},
+    {"name": "\\Device\\NPF_{DEF...}", "description": "Realtek PCIe GbE Family Controller"}
+  ]
+}
+```
+
+Located at `appDir` root, replaces `ip.txt`. Saved on every change via `POST /api/network/interfaces`.
+
+Migration: if `ip.txt` exists and `network.json` does not, on first boot resolve the IP via `pcap.FindAllDevs()` to one `{name, description}`, write `network.json`, delete `ip.txt`. Logged once.
+
+#### Capturer lifecycle: `Manager`
+
+The current `capture.New()` factory returns a single `Capturer` keyed by IP. Replace with:
+
+- `capture.NewManager(ctx, appDir)` — owns a map `activeCaptures map[string]*Capturer` keyed by `device.Name`, plus a `mu sync.RWMutex`.
+- `Manager.Reconfigure(targetNames []string) error` — diff against current set:
+  - For names in target but not active: open a new `pcap.Handle` + start goroutine.
+  - For names active but not in target: cancel goroutine, close handle.
+  - For names in both: leave untouched.
+- `Manager.OnPacket(handler PacketHandler)` — single shared handler called by every active goroutine. Photon parser handles duplicate ENet sequence numbers as retransmissions, so concurrent calls are idempotent at the application layer.
+- `Manager.Close(ctx)` — cancel all goroutines, close all handles, wait `ctx.Deadline()` for clean shutdown. Done in a single pass under the write lock.
+- `Manager.State()` — snapshot for HTTP API (lists active interfaces, last-seen-packet timestamp per handle for diagnostic).
+
+State machine:
+- `running` — at least one handle active.
+- `awaiting_interfaces` — zero handles active (no persisted choice or all persisted unavailable). HTTP server keeps running, capture loop is idle.
+
+Open/close ordering rules (the prudence the user explicitly requested):
+- **Open**: load config → enumerate available interfaces → resolve persisted names against currently-available set → open handles for the resolved subset → for each handle, install BPF filter BEFORE starting the read goroutine → only then start packet processing.
+- **Close**: cancel context first → close handles after the goroutines have observed the cancellation (drain via wait group with timeout) → only then return. Never close a handle while its goroutine is still polling — risks a `Read` on a freed pcap struct (libpcap is not always safe under that race).
+- **Reconfigure**: take the write lock once, compute the diff, perform additions before removals (so the radar never has 0 captures during a swap if the user is just adding/removing one).
+
+#### Categorization
+
+`internal/capture/categorize.go`:
+
+```go
+type Category string
+
+const (
+    CategoryWiFi     Category = "wifi"
+    CategoryEthernet Category = "ethernet"
+    CategoryExitLag  Category = "exitlag"
+    CategoryVPN      Category = "vpn"
+    CategoryVirtual  Category = "virtual"
+    CategoryOther    Category = "other"
+)
+
+func Categorize(name, description string) Category
+```
+
+Tested against `lowercase(name + " " + description)` so it works on Windows (where description is human-readable, name is `\Device\NPF_{GUID}`) and Linux (where description is often empty, name is `eth0`/`wlan0`/`tun0`).
+
+Patterns (case-insensitive on the concatenation), evaluated in order — first match wins:
+
+| Order | Category | Regex |
+|---|---|---|
+| 1 | virtual | `virtualbox\|vmware\|hyper-v\|virtual switch\|vethernet\|teredo\|loopback pseudo\|wi-fi direct\|mobile hotspot\|\bdocker\d\|\bbr-\|\bvirbr\d\|\bvmnet\d\|\bveth\|^lo$` |
+| 2 | exitlag | `exit\s*lag` |
+| 3 | vpn | `vpn\|wireguard\|wintun\|tap-windows\|openvpn\|\btun\d\|\btap\d\|\bwg\d\|\bppp\d` |
+| 4 | wifi | `wi-?fi\|wireless\|802\.11\|\bwlan\d\|\bwlp\d\|\bwifi\d` |
+| 5 | ethernet | `ethernet\|gigabit\|family controller\|\beth\d\|\benp\d\|\beno\d\|\bens\d` |
+| 6 | other | (fallback) |
+
+Order rationale:
+- `virtual` first so "Microsoft Wi-Fi Direct Virtual Adapter" doesn't tag as wifi.
+- `exitlag` before `vpn` so user gets a distinct badge.
+- `vpn` before wifi/ethernet so a VPN over wifi/ethernet doesn't tag as the underlying transport.
+
+Patterns dropped from the brainstorm draft after web fact-check: `tunnel` (false positive on Teredo), `nordvpn`/`expressvpn` (never literal in descriptions, they use TAP/WireGuard sub-drivers), `realtek` standalone (Realtek makes wifi cards too), `intel.*pro` (deprecated branding, risky `.*pro` matches anything).
+
+`RankCandidates(interfaces []NetworkInterface) []NetworkInterface` sorts by category priority: ethernet > wifi > exitlag > vpn > virtual > other. Used to display in the UI dropdown and to pick auto-select defaults.
+
+#### Default selection on first boot
+
+When `network.json` is absent and `ip.txt` is absent: auto-select all interfaces matching:
+- Category in `{ethernet, wifi, exitlag}`
+- IPv4 in RFC1918 (`10/8`, `172.16/12`, `192.168/16`)
+- Status UP (`pcap.FindAllDevs()` lists with at least one IPv4)
+
+Persist that subset to `network.json`, log "Auto-selected interfaces: [...]. Change in Settings if needed."
+
+If zero candidates match, enter `awaiting_interfaces` state and let the user pick from Settings. Don't crash the binary.
+
+#### HTTP API
+
+| Method | Path | Body / Response | Restriction |
+|---|---|---|---|
+| GET | `/api/network/interfaces` | `[{name, description, address, category, isPersisted, isAvailable}, ...]` | none |
+| GET | `/api/network/state` | `{captureInterfaces: [...], isCapturing: bool, lanAddresses: [...]}` | none |
+| POST | `/api/network/interfaces` | body `{names: ["..."]}`, persists + `Manager.Reconfigure()`. 200 ok, 4xx with error message on failure. | **403 if `req.RemoteAddr` is not loopback** (prevents accidental modification by a phone on the LAN, since the host PC is the only place capture should be reconfigured from) |
+| POST | `/api/network/refresh` | re-enumerates `pcap.FindAllDevs()`, no body. Returns the new list. | none |
+
+`lanAddresses` computation: enumerate all host IPv4s via `net.InterfaceAddrs()`, filter those in RFC1918 with category in `{ethernet, wifi}`, return as strings. Independent of the active capture set.
+
+Localhost detection: `req.RemoteAddr` parsed, IP compared against `127.0.0.0/8` and `::1`. `X-Forwarded-For` ignored on purpose (we don't run behind a proxy).
+
+#### Failure modes and recovery
+
+| Scenario | Backend behavior |
+|---|---|
+| Persisted name not in current `pcap.FindAllDevs()` | Skip silently, log once. If all skipped: state = `awaiting_interfaces`. |
+| `pcap.OpenLive` fails for a name | Log error, mark interface as `lastError` in state, do not open handle. Other handles continue. |
+| Handle returns error mid-session (interface goes down) | Goroutine logs, exits. State updates. UI sees the change on next `/api/network/state` poll. |
+| All handles down | State = `awaiting_interfaces`. UI banner shows. |
+| Reconfigure called with empty list | Stop all handles. State = `awaiting_interfaces`. (User has to opt back in.) |
+
+### Frontend (vanilla JS + Go templates)
+
+#### Settings page: new "Network" section
+
+Inserted in `internal/templates/pages/settings.gohtml`, two subsections:
+
+**Capture interfaces** (multi-select):
+- Checkbox list, one row per interface returned by `GET /api/network/interfaces`.
+- Each row: badge (🔌/🛜/🚀/🔒/🧪), description, IP address, "(unavailable)" suffix if `!isAvailable`.
+- Sorted by `RankCandidates` order.
+- Buttons: "Refresh list" (calls `POST /api/network/refresh`), "Apply changes" (disabled until selection differs from current; spinner while POST in flight).
+- Status banner at top:
+  - Green: "✓ Capturing on N interfaces" with bullet list.
+  - Orange: "⚠ Capture not running. Pick at least one interface to start." (when `awaiting_interfaces`).
+  - Yellow read-only: "Capture interfaces can only be changed from the host PC." (when client is non-localhost; the apply button is hidden).
+
+**LAN access** (read-only):
+- Bullet list of `lanAddresses` rendered as clickable URLs `http://<addr>:5001/`.
+- Subtitle: "Reachable from devices on the same local network."
+- Helper text: "These are independent of the capture interfaces above."
+
+#### Frontend handler
+
+`web/scripts/handlers/NetworkSettingsHandler.js`:
+- Fetches `/api/network/interfaces` and `/api/network/state` on settings page load.
+- Polls `/api/network/state` every 5s while the settings page is visible (to reflect changes made from another client).
+- Submits diff via `POST /api/network/interfaces` on Apply.
+- Renders a toast on success/failure.
+
+#### TUI changes
+
+`internal/ui/dashboard.go`:
+- Field `adapterIP string` removed.
+- Fields added: `captureInterfaces []CaptureInterfaceState`, `lanAddresses []string`.
+- Display:
+  ```
+  Capture: Wi-Fi (192.168.1.42), Ethernet (192.168.1.10)
+  LAN:     http://192.168.1.42:5001  http://192.168.1.10:5001
+  ```
+- Updated when `Manager.State()` changes (via channel from manager to dashboard, same pattern as the existing stats updates).
+
+#### CLI
+
+The interactive prompt in `internal/capture/pcap.go:promptForInterface()` is removed. The `--ip` flag stays for one-shot legacy override (resolves IP to interface name in-process, doesn't write `network.json`). Headless deployments edit `network.json` directly.
+
+## Files affected
+
+Created:
+- `internal/capture/manager.go` — `Manager` struct + lifecycle.
+- `internal/capture/categorize.go` — `Categorize`, `RankCandidates`, regex constants.
+- `internal/capture/network_config.go` — `network.json` read/write, `ip.txt` migration.
+- `internal/capture/manager_test.go`, `categorize_test.go`, `network_config_test.go`.
+- `internal/server/network_api.go` — HTTP handlers.
+- `internal/server/network_api_test.go`.
+- `web/scripts/handlers/NetworkSettingsHandler.js`.
+- `web/scripts/handlers/_NetworkSettingsHandler.test.js`.
+
+Modified:
+- `internal/capture/pcap.go` — split: keep `Capturer` (single-handle worker), drop the IP-keyed factory and prompt logic.
+- `internal/server/http.go` — register the new API routes.
+- `internal/ui/dashboard.go` — replace `adapterIP` with multi-interface state.
+- `internal/templates/pages/settings.gohtml` — new "Network" section.
+- `cmd/radar/main.go` — wire `Manager` instead of `Capturer`, remove the prompt code path.
+
+Deleted:
+- `internal/capture/pcap.go:promptForInterface` and helpers `printInterfaces`, `selectInterface`, `saveIPToFile`.
+- The `ip.txt` write path. Read path stays only for migration.
+
+## Testing strategy
+
+**Unit Go**:
+- `Categorize` table-driven against ~30 real-world adapter names from web fact-check (Windows + Linux mix).
+- `RankCandidates` ordering on mixed input.
+- `network_config_test`: read/write round-trip, migration from `ip.txt`, malformed JSON tolerance.
+- `Manager` lifecycle: start with stub interfaces, reconfigure (add/remove/swap), close cleanly. Verify no goroutine leaks via `goleak` if available.
+- `Manager` failure: stub `pcap.OpenLive` error → state reflects, others keep running.
+
+**HTTP API**:
+- Shape of GET endpoints.
+- POST 403 from non-loopback `RemoteAddr`.
+- POST persistence on disk.
+- POST triggers `Manager.Reconfigure`.
+
+**Frontend Vitest**:
+- `NetworkSettingsHandler` rendering function: input list → DOM markup with badges and current state.
+- Apply diff calculation (selected vs current).
+- Toast on success/error.
+
+**E2E manual smoke** (post-merge checklist for the user):
+- Cold start with no `ip.txt`, no `network.json` → auto-select kicks in, radar captures.
+- Cold start with legacy `ip.txt` → migration → `network.json` written, `ip.txt` deleted.
+- Toggle WiFi off mid-session → goroutine exits, state shows degraded, ethernet keeps capturing.
+- ExitLag toggle: enable, verify radar still receives events. Disable, verify same. Document outcome (see Known limitation).
+- Phone on LAN: open `/settings`, verify capture-interface checkboxes are read-only, LAN access section shows correct URLs.
+- Phone tries POST: 403.
+- Settings change from host: phone's view updates within 5s (polling).
+
+## Known limitation: ExitLag NDIS LWF positioning
+
+ExitLag installs a **NDIS Lightweight Filter** ("ExitLag LightWeight Filter" by Skowsand Tecnologia LTDA) rather than a virtual adapter. Pcap on Windows uses NPF, itself a NDIS protocol driver. Three possible cases for what pcap captures with ExitLag enabled:
+
+- **Case A**: ExitLag-LWF below NPF in the stack → pcap sees the original game-server-bound traffic on the host's physical interface. Multi-interface capture covers this.
+- **Case B**: ExitLag-LWF above NPF → pcap sees only the rewritten/relay-bound traffic. Multi-interface still captures it (BPF filter on UDP port 5056 matches as long as ExitLag preserves the port).
+- **Case C**: ExitLag re-routes Albion traffic from one physical interface (WiFi) to another (Ethernet, or vice versa). The original single-interface capture missed it; **multi-interface capture resolves this**.
+- **Case D** (worst case): ExitLag swallows packets entirely from NPF's view (filter strips them before they reach the protocol driver). No software solution at the pcap layer; would require WFP-level capture (different threat model).
+
+Cases A/B/C are addressed by this PR. Case D, if it materializes, will need a follow-up issue.
+
+## Follow-up: ExitLag free trial validation
+
+After merge, the project owner will activate ExitLag's 3-day free trial and live-test the radar in the four scenarios above (toggle ExitLag on/off, observe radar continuity, verify which case A/B/C/D applies to their setup). Outcome will be appended to issue #91 and may trigger a follow-up issue if Case D is observed.
+
+## Rollback plan
+
+Single feature branch, multiple commits. If a regression surfaces post-merge:
+- The `Manager` goroutine architecture is additive on top of the existing `Capturer`. Reverting the manager + the new API + the Settings UI changes restores the single-handle behavior keyed by IP.
+- The `network.json` file remains on disk (harmless if `ip.txt` is restored alongside via revert; both can coexist temporarily).
+- TUI changes can be reverted independently if only the display is wrong.

--- a/internal/capture/categorize.go
+++ b/internal/capture/categorize.go
@@ -1,0 +1,65 @@
+package capture
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type Category string
+
+const (
+	CategoryWiFi     Category = "wifi"
+	CategoryEthernet Category = "ethernet"
+	CategoryExitLag  Category = "exitlag"
+	CategoryVPN      Category = "vpn"
+	CategoryVirtual  Category = "virtual"
+	CategoryOther    Category = "other"
+)
+
+var categoryRules = []struct {
+	cat Category
+	re  *regexp.Regexp
+}{
+	{CategoryVirtual, regexp.MustCompile(`virtualbox|vmware|hyper-v|virtual switch|vethernet|teredo|loopback pseudo|software loopback|wi-fi direct|mobile hotspot|\bdocker\d|\bbr-|\bvirbr\d|\bvmnet\d|\bveth|\blo\b`)},
+	{CategoryExitLag, regexp.MustCompile(`exit\s*lag`)},
+	{CategoryVPN, regexp.MustCompile(`vpn|wireguard|wintun|tap-windows|openvpn|\btun\d|\btap\d|\bwg\d|\bppp\d`)},
+	{CategoryWiFi, regexp.MustCompile(`wi-?fi|wireless|802\.11|\bwlan\d|\bwlp\d|\bwifi\d`)},
+	{CategoryEthernet, regexp.MustCompile(`ethernet|gigabit|family controller|\beth\d|\benp\d|\beno\d|\bens\d`)},
+}
+
+func Categorize(name, description string) Category {
+	if name == "" && description == "" {
+		return CategoryOther
+	}
+	hay := strings.ToLower(name + " " + description)
+	for _, r := range categoryRules {
+		if r.re.MatchString(hay) {
+			return r.cat
+		}
+	}
+	return CategoryOther
+}
+
+var categoryRank = map[Category]int{
+	CategoryEthernet: 0,
+	CategoryWiFi:     1,
+	CategoryExitLag:  2,
+	CategoryVPN:      3,
+	CategoryVirtual:  4,
+	CategoryOther:    5,
+}
+
+func RankCandidates(in []NetworkInterface) []NetworkInterface {
+	out := make([]NetworkInterface, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		ci := Categorize(out[i].Name, out[i].Description)
+		cj := Categorize(out[j].Name, out[j].Description)
+		if ci != cj {
+			return categoryRank[ci] < categoryRank[cj]
+		}
+		return out[i].Description != "" && out[j].Description == ""
+	})
+	return out
+}

--- a/internal/capture/categorize.go
+++ b/internal/capture/categorize.go
@@ -17,6 +17,7 @@ const (
 	CategoryOther    Category = "other"
 )
 
+// Order matters: Virtual first overrides Wi-Fi/Ethernet substrings; ExitLag before VPN.
 var categoryRules = []struct {
 	cat Category
 	re  *regexp.Regexp

--- a/internal/capture/categorize_test.go
+++ b/internal/capture/categorize_test.go
@@ -90,3 +90,20 @@ func TestRankCandidates(t *testing.T) {
 		}
 	}
 }
+
+func TestRankCandidatesStableWithinCategory(t *testing.T) {
+	in := []NetworkInterface{
+		{Name: "first", Description: "Realtek PCIe GbE Family Controller"},
+		{Name: "second", Description: "Killer E2600 Gigabit Ethernet Controller"},
+	}
+	got := RankCandidates(in)
+	wantNames := []string{"first", "second"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("got %d entries, want %d", len(got), len(wantNames))
+	}
+	for i, want := range wantNames {
+		if got[i].Name != want {
+			t.Errorf("position %d: name %q, want %q (stable input order broken)", i, got[i].Name, want)
+		}
+	}
+}

--- a/internal/capture/categorize_test.go
+++ b/internal/capture/categorize_test.go
@@ -1,0 +1,92 @@
+package capture
+
+import (
+	"testing"
+)
+
+func TestCategorize(t *testing.T) {
+	cases := []struct {
+		name        string
+		ifaceName   string
+		description string
+		want        Category
+	}{
+		// Windows descriptions
+		{"win wifi intel", `\Device\NPF_{1}`, "Intel(R) Wi-Fi 6 AX201", CategoryWiFi},
+		{"win wifi realtek wireless", `\Device\NPF_{2}`, "Realtek 8821CE Wireless LAN 802.11ac PCI-E NIC", CategoryWiFi},
+		{"win ethernet realtek family", `\Device\NPF_{3}`, "Realtek PCIe GbE Family Controller", CategoryEthernet},
+		{"win ethernet intel connection", `\Device\NPF_{4}`, "Intel(R) Ethernet Connection (7) I219-V", CategoryEthernet},
+		{"win ethernet killer gigabit", `\Device\NPF_{5}`, "Killer E2600 Gigabit Ethernet Controller", CategoryEthernet},
+		{"win exitlag", `\Device\NPF_{6}`, "ExitLag LightWeight Filter", CategoryExitLag},
+		{"win exit lag spaced", `\Device\NPF_{7}`, "Exit Lag Adapter", CategoryExitLag},
+		{"win vpn tap", `\Device\NPF_{8}`, "TAP-Windows Adapter V9", CategoryVPN},
+		{"win vpn wintun", `\Device\NPF_{9}`, "WireGuard Tunnel", CategoryVPN},
+		{"win vpn openvpn", `\Device\NPF_{10}`, "OpenVPN Wintun", CategoryVPN},
+		{"win virtual hyper-v", `\Device\NPF_{11}`, "Hyper-V Virtual Ethernet Adapter", CategoryVirtual},
+		{"win virtual vethernet", `\Device\NPF_{12}`, "vEthernet (Default Switch)", CategoryVirtual},
+		{"win virtual virtualbox", `\Device\NPF_{13}`, "VirtualBox Host-Only Ethernet Adapter", CategoryVirtual},
+		{"win virtual vmware", `\Device\NPF_{14}`, "VMware Virtual Ethernet Adapter for VMnet8", CategoryVirtual},
+		{"win virtual teredo", `\Device\NPF_{15}`, "Teredo Tunneling Pseudo-Interface", CategoryVirtual},
+		{"win virtual loopback pseudo", `\Device\NPF_{16}`, "Software Loopback Interface 1", CategoryVirtual},
+		{"win virtual wifi direct", `\Device\NPF_{17}`, "Microsoft Wi-Fi Direct Virtual Adapter", CategoryVirtual},
+		{"win virtual mobile hotspot", `\Device\NPF_{18}`, "Microsoft Wi-Fi Direct Virtual Adapter #2 Mobile Hotspot", CategoryVirtual},
+		{"win other bluetooth", `\Device\NPF_{19}`, "Bluetooth Network Connection", CategoryOther},
+
+		// Linux interface names (description often empty)
+		{"linux wifi wlan0", "wlan0", "", CategoryWiFi},
+		{"linux wifi wlp3s0", "wlp3s0", "", CategoryWiFi},
+		{"linux ethernet eth0", "eth0", "", CategoryEthernet},
+		{"linux ethernet enp0s3", "enp0s3", "", CategoryEthernet},
+		{"linux ethernet eno1", "eno1", "", CategoryEthernet},
+		{"linux vpn tun0", "tun0", "", CategoryVPN},
+		{"linux vpn tap0", "tap0", "", CategoryVPN},
+		{"linux vpn wg0", "wg0", "", CategoryVPN},
+		{"linux vpn ppp0", "ppp0", "", CategoryVPN},
+		{"linux virtual docker0", "docker0", "", CategoryVirtual},
+		{"linux virtual virbr0", "virbr0", "", CategoryVirtual},
+		{"linux virtual vmnet1", "vmnet1", "", CategoryVirtual},
+		{"linux virtual veth", "veth0a1b2c3", "", CategoryVirtual},
+		{"linux virtual lo", "lo", "", CategoryVirtual},
+		{"linux virtual br-docker", "br-1234abcd", "", CategoryVirtual},
+
+		// Edge cases
+		{"empty", "", "", CategoryOther},
+		{"unknown adapter", "Some Random Adapter", "", CategoryOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Categorize(tc.ifaceName, tc.description)
+			if got != tc.want {
+				t.Errorf("Categorize(%q, %q) = %q, want %q", tc.ifaceName, tc.description, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRankCandidates(t *testing.T) {
+	in := []NetworkInterface{
+		{Name: "lo", Description: ""},
+		{Name: `\Device\NPF_{V}`, Description: "VirtualBox Host-Only"},
+		{Name: `\Device\NPF_{W}`, Description: "Wi-Fi"},
+		{Name: `\Device\NPF_{E}`, Description: "Realtek PCIe GbE Family Controller"},
+		{Name: `\Device\NPF_{X}`, Description: "ExitLag LightWeight Filter"},
+		{Name: "tun0", Description: ""},
+	}
+	got := RankCandidates(in)
+	wantOrder := []string{
+		"Realtek PCIe GbE Family Controller", // ethernet
+		"Wi-Fi",                              // wifi
+		"ExitLag LightWeight Filter",         // exitlag
+		"",                                   // vpn (tun0 has empty description)
+		"VirtualBox Host-Only",               // virtual
+		"",                                   // virtual (lo has empty description)
+	}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d entries, want %d", len(got), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if got[i].Description != want {
+			t.Errorf("position %d: description %q, want %q", i, got[i].Description, want)
+		}
+	}
+}

--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -2,6 +2,7 @@ package capture
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -66,11 +67,11 @@ func (m *Manager) Reconfigure(target []NetworkInterface) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		return fmt.Errorf("manager closed")
+		return errors.New("manager closed")
 	}
 	if m.onPacket == nil {
 		m.mu.Unlock()
-		return fmt.Errorf("OnPacket must be called before Reconfigure")
+		return errors.New("OnPacket must be called before Reconfigure")
 	}
 
 	desired := make(map[string]NetworkInterface, len(target))
@@ -182,11 +183,9 @@ func (m *Manager) Close(closeCtx context.Context) {
 }
 
 func startWorker(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		if err := c.Start(); err != nil && err != context.Canceled {
 			onError(c.iface.Name, err)
 		}
-	}()
+	})
 }

--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -1,0 +1,190 @@
+package capture
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Status string
+
+const (
+	StatusRunning  Status = "running"
+	StatusAwaiting Status = "awaiting_interfaces"
+)
+
+type CaptureSummary struct {
+	Name        string
+	Description string
+	Address     string
+	Category    Category
+	StartedAt   time.Time
+}
+
+type State struct {
+	Status     Status
+	Active     []CaptureSummary
+	LastErrors map[string]string
+}
+
+var managerStartWorker = startWorker
+
+type Manager struct {
+	parentCtx context.Context
+
+	mu         sync.Mutex
+	active     map[string]*managedCapturer
+	wg         sync.WaitGroup
+	onPacket   PacketHandler
+	lastErrors map[string]string
+	closed     bool
+}
+
+type managedCapturer struct {
+	cap       *Capturer
+	startedAt time.Time
+	cancel    context.CancelFunc
+}
+
+func NewManager(parentCtx context.Context) *Manager {
+	return &Manager{
+		parentCtx:  parentCtx,
+		active:     make(map[string]*managedCapturer),
+		lastErrors: make(map[string]string),
+	}
+}
+
+func (m *Manager) OnPacket(h PacketHandler) {
+	m.mu.Lock()
+	m.onPacket = h
+	m.mu.Unlock()
+}
+
+func (m *Manager) Reconfigure(target []NetworkInterface) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return fmt.Errorf("manager closed")
+	}
+	if m.onPacket == nil {
+		m.mu.Unlock()
+		return fmt.Errorf("OnPacket must be called before Reconfigure")
+	}
+
+	desired := make(map[string]NetworkInterface, len(target))
+	for _, i := range target {
+		desired[i.Name] = i
+	}
+
+	var openErrs []string
+	for name, iface := range desired {
+		if _, exists := m.active[name]; exists {
+			continue
+		}
+		c, err := captureFactory(m.parentCtx, iface)
+		if err != nil {
+			m.lastErrors[name] = err.Error()
+			openErrs = append(openErrs, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		c.OnPacket(m.onPacket)
+		mc := &managedCapturer{cap: c, startedAt: time.Now(), cancel: c.cancel}
+		m.active[name] = mc
+		delete(m.lastErrors, name)
+		managerStartWorker(c, &m.wg, func(n string, e error) {
+			m.mu.Lock()
+			m.lastErrors[n] = e.Error()
+			delete(m.active, n)
+			m.mu.Unlock()
+		})
+	}
+
+	for name, mc := range m.active {
+		if _, keep := desired[name]; keep {
+			continue
+		}
+		mc.cancel()
+		mc.cap.Close()
+		delete(m.active, name)
+		delete(m.lastErrors, name)
+	}
+
+	m.mu.Unlock()
+
+	if len(openErrs) > 0 {
+		return fmt.Errorf("partial open failures: %v", openErrs)
+	}
+	return nil
+}
+
+func (m *Manager) State() State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := State{
+		LastErrors: make(map[string]string, len(m.lastErrors)),
+	}
+	for k, v := range m.lastErrors {
+		out.LastErrors[k] = v
+	}
+	for _, mc := range m.active {
+		i := mc.cap.iface
+		out.Active = append(out.Active, CaptureSummary{
+			Name:        i.Name,
+			Description: i.Description,
+			Address:     i.Address,
+			Category:    Categorize(i.Name, i.Description),
+			StartedAt:   mc.startedAt,
+		})
+	}
+	if len(out.Active) == 0 {
+		out.Status = StatusAwaiting
+	} else {
+		out.Status = StatusRunning
+	}
+	return out
+}
+
+// Close cancels all read loops, waits for workers, then closes handles.
+// libpcap is unsafe to close while a Read poll is in flight, so handles
+// are closed only after wg.Wait or closeCtx expires.
+func (m *Manager) Close(closeCtx context.Context) {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	for _, mc := range m.active {
+		mc.cancel()
+	}
+	captures := make([]*Capturer, 0, len(m.active))
+	for _, mc := range m.active {
+		captures = append(captures, mc.cap)
+	}
+	m.active = nil
+	m.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-closeCtx.Done():
+	}
+	for _, c := range captures {
+		c.Close()
+	}
+}
+
+func startWorker(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := c.Start(); err != nil && err != context.Canceled {
+			onError(c.iface.Name, err)
+		}
+	}()
+}

--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -3,6 +3,7 @@ package capture
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -137,6 +138,7 @@ func (m *Manager) State() State {
 			StartedAt:   mc.startedAt,
 		})
 	}
+	sort.Slice(out.Active, func(i, j int) bool { return out.Active[i].Name < out.Active[j].Name })
 	if len(out.Active) == 0 {
 		out.Status = StatusAwaiting
 	} else {

--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -120,6 +120,18 @@ func (m *Manager) Reconfigure(target []NetworkInterface) error {
 	return nil
 }
 
+// BytesReceived sums per-handle bytes across active capturers.
+// pcap.Stats is not aggregated here; per-handle kernel stats are out of scope.
+func (m *Manager) BytesReceived() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var sum uint64
+	for _, mc := range m.active {
+		sum += mc.cap.BytesReceived()
+	}
+	return sum
+}
+
 func (m *Manager) State() State {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/capture/manager_test.go
+++ b/internal/capture/manager_test.go
@@ -104,6 +104,19 @@ func TestManagerCloseTwiceSafe(t *testing.T) {
 	m.Close(context.Background())
 }
 
+func TestManagerBytesReceivedAggregates(t *testing.T) {
+	defer withStubFactory(t, nil)()
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	if err := m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}, {Name: "b", Device: "b"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.BytesReceived(); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+	m.Close(context.Background())
+}
+
 func TestManagerNoGoroutineLeak(t *testing.T) {
 	defer withStubFactory(t, nil)()
 

--- a/internal/capture/manager_test.go
+++ b/internal/capture/manager_test.go
@@ -1,0 +1,137 @@
+package capture
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newStubCapturer(iface NetworkInterface) *Capturer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Capturer{
+		iface:  iface,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func withStubFactory(t *testing.T, opens map[string]error) func() {
+	t.Helper()
+	prev := captureFactory
+	captureFactory = func(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
+		if err, ok := opens[iface.Name]; ok && err != nil {
+			return nil, err
+		}
+		c := newStubCapturer(iface)
+		c.ctx, c.cancel = context.WithCancel(ctx)
+		return c, nil
+	}
+	return func() { captureFactory = prev }
+}
+
+func TestManagerReconfigureAddsRemoves(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+
+	if err := m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}, {Name: "b", Device: "b"}}); err != nil {
+		t.Fatalf("Reconfigure add: %v", err)
+	}
+	state := m.State()
+	if len(state.Active) != 2 {
+		t.Fatalf("got %d active, want 2", len(state.Active))
+	}
+
+	if err := m.Reconfigure([]NetworkInterface{{Name: "b", Device: "b"}, {Name: "c", Device: "c"}}); err != nil {
+		t.Fatalf("Reconfigure swap: %v", err)
+	}
+	state = m.State()
+	names := make(map[string]bool)
+	for _, i := range state.Active {
+		names[i.Name] = true
+	}
+	if !names["b"] || !names["c"] || names["a"] {
+		t.Errorf("after swap want {b,c}, got %+v", state.Active)
+	}
+
+	if err := m.Reconfigure(nil); err != nil {
+		t.Fatalf("Reconfigure empty: %v", err)
+	}
+	state = m.State()
+	if len(state.Active) != 0 {
+		t.Errorf("after empty want 0 active, got %d", len(state.Active))
+	}
+	if state.Status != StatusAwaiting {
+		t.Errorf("status %q, want %q", state.Status, StatusAwaiting)
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManagerOpenFailureIsolatesOthers(t *testing.T) {
+	defer withStubFactory(t, map[string]error{"bad": errors.New("boom")})()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	err := m.Reconfigure([]NetworkInterface{
+		{Name: "good", Device: "good"},
+		{Name: "bad", Device: "bad"},
+	})
+	if err == nil {
+		t.Fatal("expected partial-failure error")
+	}
+	state := m.State()
+	if len(state.Active) != 1 || state.Active[0].Name != "good" {
+		t.Errorf("after partial failure want {good}, got %+v", state.Active)
+	}
+	if len(state.LastErrors) == 0 || state.LastErrors["bad"] == "" {
+		t.Errorf("expected lastErrors[bad], got %+v", state.LastErrors)
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManagerCloseTwiceSafe(t *testing.T) {
+	defer withStubFactory(t, nil)()
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	_ = m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}})
+	m.Close(context.Background())
+	m.Close(context.Background())
+}
+
+func TestManagerNoGoroutineLeak(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	var workerStarted, workerExited atomic.Int32
+	prev := managerStartWorker
+	managerStartWorker = func(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
+		workerStarted.Add(1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer workerExited.Add(1)
+			<-c.ctx.Done()
+		}()
+	}
+	defer func() { managerStartWorker = prev }()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	_ = m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}, {Name: "b", Device: "b"}})
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	m.Close(closeCtx)
+
+	if got, want := workerStarted.Load(), int32(2); got != want {
+		t.Errorf("workerStarted=%d, want %d", got, want)
+	}
+	if got, want := workerExited.Load(), int32(2); got != want {
+		t.Errorf("workerExited=%d, want %d (goroutine leak)", got, want)
+	}
+}

--- a/internal/capture/manager_test.go
+++ b/internal/capture/manager_test.go
@@ -109,14 +109,12 @@ func TestManagerNoGoroutineLeak(t *testing.T) {
 
 	var workerStarted, workerExited atomic.Int32
 	prev := managerStartWorker
-	managerStartWorker = func(c *Capturer, wg *sync.WaitGroup, onError func(string, error)) {
+	managerStartWorker = func(c *Capturer, wg *sync.WaitGroup, _ func(string, error)) {
 		workerStarted.Add(1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer workerExited.Add(1)
 			<-c.ctx.Done()
-		}()
+		})
 	}
 	defer func() { managerStartWorker = prev }()
 

--- a/internal/capture/network_addrs.go
+++ b/internal/capture/network_addrs.go
@@ -1,0 +1,62 @@
+package capture
+
+import "net"
+
+// rfc1918Nets is the parsed set of private IPv4 ranges defined in RFC 1918.
+// Parsed once at init to avoid re-parsing per call.
+var rfc1918Nets = func() []*net.IPNet {
+	cidrs := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err == nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}()
+
+// IsRFC1918 reports whether addr is a non-empty IPv4 string inside one of the
+// RFC 1918 private ranges (10/8, 172.16/12, 192.168/16). Loopback and link-local
+// addresses are excluded.
+func IsRFC1918(addr string) bool {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	for _, n := range rfc1918Nets {
+		if n.Contains(ip4) {
+			return true
+		}
+	}
+	return false
+}
+
+// LANAddresses returns IPv4 RFC 1918 host addresses bound to local interfaces.
+// Used to print LAN URLs at startup and to populate /api/network/state.
+func LANAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0)
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipnet.IP.To4()
+		if ip4 == nil {
+			continue
+		}
+		s := ip4.String()
+		if IsRFC1918(s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/capture/network_addrs_test.go
+++ b/internal/capture/network_addrs_test.go
@@ -1,0 +1,25 @@
+package capture
+
+import "testing"
+
+func TestIsRFC1918(t *testing.T) {
+	if !IsRFC1918("192.168.1.1") {
+		t.Error("192.168.1.1 should be RFC1918")
+	}
+	if IsRFC1918("8.8.8.8") {
+		t.Error("8.8.8.8 should not be RFC1918")
+	}
+	if IsRFC1918("") {
+		t.Error("empty should not be RFC1918")
+	}
+}
+
+func TestLANAddressesReturnsRFC1918OnlyOrEmpty(t *testing.T) {
+	got := LANAddresses()
+	for _, a := range got {
+		if !IsRFC1918(a) {
+			t.Errorf("LAN addr %q is not RFC1918", a)
+		}
+	}
+	// Empty slice is allowed (CI runners often have no RFC1918 IP).
+}

--- a/internal/capture/network_config.go
+++ b/internal/capture/network_config.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 )
 
-const configFilename = "network.json"
-const legacyIPFilename = "ip.txt"
+const (
+	configFilename   = "network.json"
+	legacyIPFilename = "ip.txt"
+)
 
 type PersistedInterface struct {
 	Name        string `json:"name"`
@@ -70,7 +72,10 @@ func MigrateIPTxt(appDir string, resolve IPResolver) (bool, error) {
 		return false, nil
 	}
 	existing, err := ReadConfig(appDir)
-	if err == nil && len(existing.CaptureInterfaces) > 0 {
+	if err != nil {
+		return false, fmt.Errorf("read existing config before migration: %w", err)
+	}
+	if len(existing.CaptureInterfaces) > 0 {
 		_ = os.Remove(ipPath)
 		return false, nil
 	}

--- a/internal/capture/network_config.go
+++ b/internal/capture/network_config.go
@@ -1,0 +1,91 @@
+package capture
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const configFilename = "network.json"
+const legacyIPFilename = "ip.txt"
+
+type PersistedInterface struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type Config struct {
+	CaptureInterfaces []PersistedInterface `json:"captureInterfaces"`
+}
+
+func ReadConfig(appDir string) (Config, error) {
+	path := filepath.Join(appDir, configFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+func WriteConfig(appDir string, cfg Config) error {
+	path := filepath.Join(appDir, configFilename)
+	tmp := path + ".tmp"
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename tmp: %w", err)
+	}
+	return nil
+}
+
+type IPResolver func(ip string) (PersistedInterface, error)
+
+func MigrateIPTxt(appDir string, resolve IPResolver) (bool, error) {
+	ipPath := filepath.Join(appDir, legacyIPFilename)
+	data, err := os.ReadFile(ipPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", ipPath, err)
+	}
+	ip := strings.TrimSpace(string(data))
+	if ip == "" {
+		_ = os.Remove(ipPath)
+		return false, nil
+	}
+	existing, err := ReadConfig(appDir)
+	if err == nil && len(existing.CaptureInterfaces) > 0 {
+		_ = os.Remove(ipPath)
+		return false, nil
+	}
+	if resolve == nil {
+		return false, fmt.Errorf("no IP resolver provided for migration")
+	}
+	entry, err := resolve(ip)
+	if err != nil {
+		_ = os.Remove(ipPath)
+		return false, fmt.Errorf("resolve legacy ip %q: %w", ip, err)
+	}
+	cfg := Config{CaptureInterfaces: []PersistedInterface{entry}}
+	if err := WriteConfig(appDir, cfg); err != nil {
+		return false, err
+	}
+	_ = os.Remove(ipPath)
+	return true, nil
+}

--- a/internal/capture/network_config_test.go
+++ b/internal/capture/network_config_test.go
@@ -1,0 +1,118 @@
+package capture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		CaptureInterfaces: []PersistedInterface{
+			{Name: `\Device\NPF_{ABC}`, Description: "Wi-Fi"},
+			{Name: `\Device\NPF_{DEF}`, Description: "Realtek"},
+		},
+	}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if len(got.CaptureInterfaces) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got.CaptureInterfaces))
+	}
+	if got.CaptureInterfaces[0].Description != "Wi-Fi" {
+		t.Errorf("entry 0 description = %q, want Wi-Fi", got.CaptureInterfaces[0].Description)
+	}
+}
+
+func TestReadConfigMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig on empty dir: %v", err)
+	}
+	if len(cfg.CaptureInterfaces) != 0 {
+		t.Errorf("missing config returned %d entries, want 0", len(cfg.CaptureInterfaces))
+	}
+}
+
+func TestReadConfigMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "network.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := ReadConfig(dir)
+	if err == nil {
+		t.Fatalf("expected error on malformed JSON, got cfg=%+v", cfg)
+	}
+}
+
+func TestMigrateFromIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("192.168.1.42\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolve := func(ip string) (PersistedInterface, error) {
+		if ip != "192.168.1.42" {
+			t.Errorf("resolve called with %q, want 192.168.1.42", ip)
+		}
+		return PersistedInterface{Name: `\Device\NPF_{X}`, Description: "Wi-Fi"}, nil
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migrated=true")
+	}
+	cfg, _ := ReadConfig(dir)
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Description != "Wi-Fi" {
+		t.Errorf("migrated config wrong: %+v", cfg)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); !os.IsNotExist(err) {
+		t.Errorf("ip.txt should be deleted, err=%v", err)
+	}
+}
+
+func TestMigrateNoIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	migrated, err := MigrateIPTxt(dir, nil)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt with no ip.txt: %v", err)
+	}
+	if migrated {
+		t.Error("expected migrated=false when no ip.txt")
+	}
+}
+
+func TestWriteConfigOverwritesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	cfg1 := Config{CaptureInterfaces: []PersistedInterface{{Name: "A", Description: "First"}}}
+	if err := WriteConfig(dir, cfg1); err != nil {
+		t.Fatal(err)
+	}
+	cfg2 := Config{CaptureInterfaces: []PersistedInterface{{Name: "B", Description: "Second"}}}
+	if err := WriteConfig(dir, cfg2); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := ReadConfig(dir)
+	if got.CaptureInterfaces[0].Description != "Second" {
+		t.Errorf("overwrite failed, got %+v", got)
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover tmp file: %s", e.Name())
+		}
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "network.json"))
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Errorf("network.json not valid JSON: %v", err)
+	}
+}

--- a/internal/capture/network_config_test.go
+++ b/internal/capture/network_config_test.go
@@ -2,8 +2,10 @@ package capture
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -87,6 +89,135 @@ func TestMigrateNoIPTxt(t *testing.T) {
 	}
 	if migrated {
 		t.Error("expected migrated=false when no ip.txt")
+	}
+}
+
+func TestMigrateSkipsWhenConfigPopulated(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{CaptureInterfaces: []PersistedInterface{{Name: `\Device\NPF_{Y}`, Description: "Existing"}}}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("192.168.1.42\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolve := func(ip string) (PersistedInterface, error) {
+		t.Fatalf("resolver should not be called when config is already populated; got ip=%q", ip)
+		return PersistedInterface{}, nil
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt: %v", err)
+	}
+	if migrated {
+		t.Error("expected migrated=false when config is populated")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); !os.IsNotExist(err) {
+		t.Errorf("ip.txt should be deleted, err=%v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if len(got.CaptureInterfaces) != 1 || got.CaptureInterfaces[0].Description != "Existing" {
+		t.Errorf("network.json should be unchanged, got %+v", got)
+	}
+}
+
+func TestMigrateEmptyIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("  \n"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolve := func(ip string) (PersistedInterface, error) {
+		t.Fatalf("resolver should not be called for whitespace-only ip.txt; got ip=%q", ip)
+		return PersistedInterface{}, nil
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err != nil {
+		t.Fatalf("MigrateIPTxt: %v", err)
+	}
+	if migrated {
+		t.Error("expected migrated=false for empty ip.txt")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); !os.IsNotExist(err) {
+		t.Errorf("ip.txt should be deleted, err=%v", err)
+	}
+}
+
+func TestMigrateNilResolverWithNonEmptyIPTxt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("192.168.1.42"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	migrated, err := MigrateIPTxt(dir, nil)
+	if err == nil {
+		t.Fatal("expected error when resolver is nil and ip.txt has content")
+	}
+	if migrated {
+		t.Error("expected migrated=false")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "no IP resolver") {
+		t.Errorf("error message %q should mention missing resolver", msg)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); err != nil {
+		t.Errorf("ip.txt should be preserved for retry, err=%v", err)
+	}
+}
+
+func TestMigrateResolverError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("10.0.0.1"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolverErr := errors.New("interface not found")
+	resolve := func(ip string) (PersistedInterface, error) {
+		return PersistedInterface{}, resolverErr
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err == nil {
+		t.Fatal("expected error when resolver fails")
+	}
+	if migrated {
+		t.Error("expected migrated=false")
+	}
+	if !errors.Is(err, resolverErr) {
+		t.Errorf("error chain should wrap resolver error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); !os.IsNotExist(err) {
+		t.Errorf("ip.txt should be deleted on resolver error, err=%v", err)
+	}
+}
+
+func TestMigrateMalformedConfigErrors(t *testing.T) {
+	dir := t.TempDir()
+	malformed := []byte("{not json")
+	if err := os.WriteFile(filepath.Join(dir, "network.json"), malformed, 0o644); err != nil {
+		t.Fatalf("WriteFile network.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ip.txt"), []byte("192.168.1.42"), 0o644); err != nil {
+		t.Fatalf("WriteFile ip.txt: %v", err)
+	}
+	resolve := func(ip string) (PersistedInterface, error) {
+		t.Fatalf("resolver should not be called when config is malformed; got ip=%q", ip)
+		return PersistedInterface{}, nil
+	}
+	migrated, err := MigrateIPTxt(dir, resolve)
+	if err == nil {
+		t.Fatal("expected error when network.json is malformed")
+	}
+	if migrated {
+		t.Error("expected migrated=false")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ip.txt")); err != nil {
+		t.Errorf("ip.txt should be preserved for recovery, err=%v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "network.json"))
+	if err != nil {
+		t.Fatalf("ReadFile network.json: %v", err)
+	}
+	if string(got) != string(malformed) {
+		t.Errorf("network.json should not be overwritten, got %q want %q", got, malformed)
 	}
 }
 

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -55,6 +55,7 @@ func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, er
 		handle.Close()
 		return nil, fmt.Errorf("set BPF filter on %q: %w", iface.Device, err)
 	}
+	//nolint:gosec // G118: cancel is stored on Capturer and invoked by Close().
 	cctx, cancel := context.WithCancel(ctx)
 	return &Capturer{
 		handle: handle,

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -3,6 +3,7 @@ package capture
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,15 +29,17 @@ type NetworkInterface struct {
 type PacketHandler func(payload []byte)
 
 type Capturer struct {
-	handle   *pcap.Handle
-	iface    NetworkInterface
-	onPacket PacketHandler
-	ctx      context.Context
-	cancel   context.CancelFunc
+	handle    *pcap.Handle
+	iface     NetworkInterface
+	onPacket  PacketHandler
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closeOnce sync.Once
 
 	bytesReceived uint64
 }
 
+// captureFactory is overridable in tests; restore via t.Cleanup.
 var captureFactory = openLiveCapture
 
 func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
@@ -75,13 +78,17 @@ func (c *Capturer) Start() error {
 	}
 }
 
+// Close cancels the read loop and closes the handle. Caller must serialize
+// against Start; Manager owns the locking.
 func (c *Capturer) Close() {
-	if c.cancel != nil {
-		c.cancel()
-	}
-	if c.handle != nil {
-		c.handle.Close()
-	}
+	c.closeOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		if c.handle != nil {
+			c.handle.Close()
+		}
+	})
 }
 
 func (c *Capturer) Iface() NetworkInterface { return c.iface }

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -27,9 +27,10 @@ const (
 
 // NetworkInterface represents a network interface with its details
 type NetworkInterface struct {
-	Name    string
-	Address string
-	Device  string
+	Name        string
+	Description string
+	Address     string
+	Device      string
 }
 
 // PacketHandler is called for each captured UDP payload

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -42,6 +42,9 @@ type Capturer struct {
 // captureFactory is overridable in tests; restore via t.Cleanup.
 var captureFactory = openLiveCapture
 
+// findAllDevs is overridable in tests; restore via t.Cleanup.
+var findAllDevs = pcap.FindAllDevs
+
 func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
 	handle, err := pcap.OpenLive(iface.Device, SnapLen, Promiscuous, ReadTimeout)
 	if err != nil {
@@ -120,7 +123,7 @@ func (c *Capturer) processPacket(p gopacket.Packet) {
 }
 
 func EnumerateInterfaces() ([]NetworkInterface, error) {
-	devs, err := pcap.FindAllDevs()
+	devs, err := findAllDevs()
 	if err != nil {
 		return nil, fmt.Errorf("list devices: %w", err)
 	}

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -68,6 +68,7 @@ func (c *Capturer) OnPacket(h PacketHandler) { c.onPacket = h }
 
 func (c *Capturer) Start() error {
 	if c.handle == nil {
+		// stub-mode for tests: block until cancellation, no real pcap source.
 		<-c.ctx.Done()
 		return c.ctx.Err()
 	}

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -1,14 +1,8 @@
 package capture
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"net"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -21,11 +15,9 @@ const (
 	AlbionPort  = 5056
 	SnapLen     = 65536
 	Promiscuous = false
-	// BlockForever deadlocks handle.Close() when idle; poll on timeout
 	ReadTimeout = 100 * time.Millisecond
 )
 
-// NetworkInterface represents a network interface with its details
 type NetworkInterface struct {
 	Name        string
 	Description string
@@ -33,10 +25,8 @@ type NetworkInterface struct {
 	Device      string
 }
 
-// PacketHandler is called for each captured UDP payload
 type PacketHandler func(payload []byte)
 
-// Capturer handles packet capture from network interface
 type Capturer struct {
 	handle   *pcap.Handle
 	iface    NetworkInterface
@@ -44,54 +34,47 @@ type Capturer struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 
-	// Traffic stats
 	bytesReceived uint64
 }
 
-// New creates a new Capturer for the given IP address
-func New(ctx context.Context, appDir string, ipOverride string) (*Capturer, error) {
-	ip, device, err := resolveAdapter(appDir, ipOverride)
-	if err != nil {
-		return nil, err
-	}
+var captureFactory = openLiveCapture
 
-	handle, err := openDevice(device)
+func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, error) {
+	handle, err := pcap.OpenLive(iface.Device, SnapLen, Promiscuous, ReadTimeout)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open device %q: %w", iface.Device, err)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
+	filter := fmt.Sprintf("udp and (dst port %d or src port %d)", AlbionPort, AlbionPort)
+	if err := handle.SetBPFFilter(filter); err != nil {
+		handle.Close()
+		return nil, fmt.Errorf("set BPF filter on %q: %w", iface.Device, err)
+	}
+	cctx, cancel := context.WithCancel(ctx)
 	return &Capturer{
 		handle: handle,
-		iface:  NetworkInterface{Address: ip, Device: device},
-		ctx:    ctx,
+		iface:  iface,
+		ctx:    cctx,
 		cancel: cancel,
 	}, nil
 }
 
-// OnPacket sets the handler for captured packets
-func (c *Capturer) OnPacket(handler PacketHandler) {
-	c.onPacket = handler
-}
+func (c *Capturer) OnPacket(h PacketHandler) { c.onPacket = h }
 
-// Start begins capturing packets (blocking)
 func (c *Capturer) Start() error {
-	packetSource := gopacket.NewPacketSource(c.handle, c.handle.LinkType())
-
+	source := gopacket.NewPacketSource(c.handle, c.handle.LinkType())
 	for {
 		select {
 		case <-c.ctx.Done():
 			return c.ctx.Err()
-		case packet, ok := <-packetSource.Packets():
+		case pkt, ok := <-source.Packets():
 			if !ok {
 				return nil
 			}
-			c.processPacket(packet)
+			c.processPacket(pkt)
 		}
 	}
 }
 
-// Close stops the capture
 func (c *Capturer) Close() {
 	if c.cancel != nil {
 		c.cancel()
@@ -101,29 +84,9 @@ func (c *Capturer) Close() {
 	}
 }
 
-// AdapterIP returns the IP address of the network adapter being used
-func (c *Capturer) AdapterIP() string {
-	return c.iface.Address
-}
+func (c *Capturer) Iface() NetworkInterface { return c.iface }
 
-func (c *Capturer) processPacket(packet gopacket.Packet) {
-	udpLayer := packet.Layer(layers.LayerTypeUDP)
-	if udpLayer == nil {
-		return
-	}
-
-	udp, ok := udpLayer.(*layers.UDP)
-	if !ok || len(udp.Payload) == 0 || c.onPacket == nil {
-		return
-	}
-
-	atomic.AddUint64(&c.bytesReceived, uint64(len(udp.Payload)))
-	c.onPacket(udp.Payload)
-}
-
-func (c *Capturer) BytesReceived() uint64 {
-	return atomic.LoadUint64(&c.bytesReceived)
-}
+func (c *Capturer) BytesReceived() uint64 { return atomic.LoadUint64(&c.bytesReceived) }
 
 func (c *Capturer) Stats() (*pcap.Stats, error) {
 	if c.handle == nil {
@@ -132,181 +95,52 @@ func (c *Capturer) Stats() (*pcap.Stats, error) {
 	return c.handle.Stats()
 }
 
-// resolveAdapter gets the IP and device name, with retry logic
-func resolveAdapter(appDir, ipOverride string) (ip, device string, err error) {
-	ip, err = getAdapterIP(appDir, ipOverride)
-	if err != nil {
-		return "", "", err
+func (c *Capturer) processPacket(p gopacket.Packet) {
+	udpLayer := p.Layer(layers.LayerTypeUDP)
+	if udpLayer == nil {
+		return
 	}
-
-	device, err = findDeviceByIP(ip)
-	if err == nil {
-		fmt.Printf("Using adapter IP: %s\n", ip)
-		return ip, device, nil
+	udp, ok := udpLayer.(*layers.UDP)
+	if !ok || len(udp.Payload) == 0 || c.onPacket == nil {
+		return
 	}
-
-	// Retry only if no override was provided
-	if ipOverride != "" {
-		return "", "", fmt.Errorf("adapter with IP %s not found", ip)
-	}
-
-	fmt.Printf("Adapter with IP %s not found. Please select a new adapter.\n", ip)
-	ip, err = getAdapterIP(appDir, "")
-	if err != nil {
-		return "", "", err
-	}
-
-	device, err = findDeviceByIP(ip)
-	if err != nil {
-		return "", "", err
-	}
-
-	fmt.Printf("Using adapter IP: %s\n", ip)
-	return ip, device, nil
+	atomic.AddUint64(&c.bytesReceived, uint64(len(udp.Payload)))
+	c.onPacket(udp.Payload)
 }
 
-func openDevice(device string) (*pcap.Handle, error) {
-	handle, err := pcap.OpenLive(device, SnapLen, Promiscuous, ReadTimeout)
+func EnumerateInterfaces() ([]NetworkInterface, error) {
+	devs, err := pcap.FindAllDevs()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open device: %w", err)
+		return nil, fmt.Errorf("list devices: %w", err)
 	}
-
-	filter := fmt.Sprintf("udp and (dst port %d or src port %d)", AlbionPort, AlbionPort)
-	if err := handle.SetBPFFilter(filter); err != nil {
-		handle.Close()
-		return nil, fmt.Errorf("failed to set BPF filter: %w", err)
-	}
-
-	return handle, nil
-}
-
-// getAdapterIP reads IP from: 1) override, 2) ip.txt, 3) prompt
-func getAdapterIP(appDir, ipOverride string) (string, error) {
-	if ip := tryIPOverride(ipOverride); ip != "" {
-		return ip, nil
-	}
-
-	if ip := tryIPFile(appDir); ip != "" {
-		return ip, nil
-	}
-
-	return promptForInterface(appDir)
-}
-
-func tryIPOverride(ipOverride string) string {
-	if ipOverride == "" {
-		return ""
-	}
-	if net.ParseIP(ipOverride) == nil {
-		return ""
-	}
-	fmt.Printf("Using IP from command line: %s\n", ipOverride)
-	return ipOverride
-}
-
-func tryIPFile(appDir string) string {
-	data, err := os.ReadFile(filepath.Join(appDir, "ip.txt"))
-	if err != nil {
-		return ""
-	}
-	ip := strings.TrimSpace(string(data))
-	if net.ParseIP(ip) == nil {
-		return ""
-	}
-	return ip
-}
-
-func promptForInterface(appDir string) (string, error) {
-	interfaces, err := listInterfaces()
-	if err != nil {
-		return "", err
-	}
-	if len(interfaces) == 0 {
-		return "", fmt.Errorf("no network interfaces found")
-	}
-
-	printInterfaces(interfaces)
-	return selectInterface(interfaces, appDir)
-}
-
-func listInterfaces() ([]NetworkInterface, error) {
-	devices, err := pcap.FindAllDevs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list devices: %w", err)
-	}
-
-	var interfaces []NetworkInterface
-	for _, device := range devices {
-		if iface := firstIPv4Interface(device); iface != nil {
-			interfaces = append(interfaces, *iface)
-		}
-	}
-	return interfaces, nil
-}
-
-func firstIPv4Interface(device pcap.Interface) *NetworkInterface {
-	for _, addr := range device.Addresses {
-		if ip4 := addr.IP.To4(); ip4 != nil {
-			return &NetworkInterface{
-				Name:    device.Description,
-				Address: ip4.String(),
-				Device:  device.Name,
+	var out []NetworkInterface
+	for _, d := range devs {
+		for _, addr := range d.Addresses {
+			ip4 := addr.IP.To4()
+			if ip4 == nil {
+				continue
 			}
+			out = append(out, NetworkInterface{
+				Name:        d.Name,
+				Description: d.Description,
+				Address:     ip4.String(),
+				Device:      d.Name,
+			})
+			break
 		}
 	}
-	return nil
+	return out, nil
 }
 
-func findDeviceByIP(ip string) (string, error) {
-	devices, err := pcap.FindAllDevs()
+func ResolveByIP(ip string) (PersistedInterface, error) {
+	ifaces, err := EnumerateInterfaces()
 	if err != nil {
-		return "", fmt.Errorf("failed to list devices: %w", err)
+		return PersistedInterface{}, err
 	}
-
-	for _, device := range devices {
-		for _, addr := range device.Addresses {
-			if addr.IP.String() == ip {
-				return device.Name, nil
-			}
+	for _, i := range ifaces {
+		if i.Address == ip {
+			return PersistedInterface{Name: i.Name, Description: i.Description}, nil
 		}
 	}
-	return "", fmt.Errorf("no device found with IP: %s", ip)
-}
-
-func printInterfaces(interfaces []NetworkInterface) {
-	fmt.Println("\nPlease select the adapter used to connect to the Internet:")
-	for i, iface := range interfaces {
-		fmt.Printf("  %d. %s\t ip address: %s\n", i+1, iface.Name, iface.Address)
-	}
-	fmt.Println()
-}
-
-func selectInterface(interfaces []NetworkInterface, appDir string) (string, error) {
-	reader := bufio.NewReader(os.Stdin)
-
-	for {
-		fmt.Print("Enter the adapter number: ")
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			return "", fmt.Errorf("failed to read input: %w", err)
-		}
-
-		idx, err := strconv.Atoi(strings.TrimSpace(input))
-		if err != nil || idx < 1 || idx > len(interfaces) {
-			fmt.Println("Invalid input, please try again.")
-			continue
-		}
-
-		selected := interfaces[idx-1]
-		fmt.Printf("\nYou have selected \"%s - %s\"\n\n", selected.Name, selected.Address)
-		saveIPToFile(appDir, selected.Address)
-		return selected.Address, nil
-	}
-}
-
-func saveIPToFile(appDir, ip string) {
-	path := filepath.Join(appDir, "ip.txt")
-	if err := os.WriteFile(path, []byte(ip), 0o644); err != nil {
-		fmt.Println("Warning: Error while saving the IP address.")
-	}
+	return PersistedInterface{}, fmt.Errorf("no interface with IP %s", ip)
 }

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -64,6 +64,10 @@ func openLiveCapture(ctx context.Context, iface NetworkInterface) (*Capturer, er
 func (c *Capturer) OnPacket(h PacketHandler) { c.onPacket = h }
 
 func (c *Capturer) Start() error {
+	if c.handle == nil {
+		<-c.ctx.Done()
+		return c.ctx.Err()
+	}
 	source := gopacket.NewPacketSource(c.handle, c.handle.LinkType())
 	for {
 		select {

--- a/internal/capture/pcap_test.go
+++ b/internal/capture/pcap_test.go
@@ -1,0 +1,101 @@
+package capture
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/pcap"
+)
+
+func withStubFindAllDevs(t *testing.T, devs []pcap.Interface, err error) {
+	t.Helper()
+	prev := findAllDevs
+	findAllDevs = func() ([]pcap.Interface, error) { return devs, err }
+	t.Cleanup(func() { findAllDevs = prev })
+}
+
+func TestEnumerateInterfacesPicksFirstIPv4(t *testing.T) {
+	withStubFindAllDevs(t, []pcap.Interface{
+		{
+			Name:        `\Device\NPF_{1}`,
+			Description: "Intel Wi-Fi",
+			Addresses: []pcap.InterfaceAddress{
+				{IP: net.ParseIP("fe80::1")},
+				{IP: net.ParseIP("192.168.1.10")},
+				{IP: net.ParseIP("192.168.1.99")},
+			},
+		},
+		{
+			Name:        `\Device\NPF_{2}`,
+			Description: "Loopback",
+			Addresses:   []pcap.InterfaceAddress{{IP: net.ParseIP("::1")}},
+		},
+		{
+			Name:        `\Device\NPF_{3}`,
+			Description: "Ethernet",
+			Addresses:   []pcap.InterfaceAddress{{IP: net.ParseIP("10.0.0.5")}},
+		},
+	}, nil)
+
+	out, err := EnumerateInterfaces()
+	if err != nil {
+		t.Fatalf("EnumerateInterfaces: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("got %d interfaces, want 2 (IPv6-only skipped)", len(out))
+	}
+	if out[0].Address != "192.168.1.10" {
+		t.Errorf("first iface addr = %q, want %q (first IPv4 wins)", out[0].Address, "192.168.1.10")
+	}
+	if out[0].Device != out[0].Name {
+		t.Errorf("Device=%q Name=%q, want equal", out[0].Device, out[0].Name)
+	}
+	if out[1].Address != "10.0.0.5" {
+		t.Errorf("second iface addr = %q, want %q", out[1].Address, "10.0.0.5")
+	}
+}
+
+func TestEnumerateInterfacesError(t *testing.T) {
+	withStubFindAllDevs(t, nil, errors.New("permission denied"))
+	if _, err := EnumerateInterfaces(); err == nil {
+		t.Fatal("expected error from EnumerateInterfaces")
+	}
+}
+
+func TestResolveByIPMatch(t *testing.T) {
+	withStubFindAllDevs(t, []pcap.Interface{
+		{
+			Name:        `\Device\NPF_{1}`,
+			Description: "Wi-Fi",
+			Addresses:   []pcap.InterfaceAddress{{IP: net.ParseIP("192.168.1.10")}},
+		},
+		{
+			Name:        `\Device\NPF_{2}`,
+			Description: "Ethernet",
+			Addresses:   []pcap.InterfaceAddress{{IP: net.ParseIP("10.0.0.5")}},
+		},
+	}, nil)
+
+	got, err := ResolveByIP("10.0.0.5")
+	if err != nil {
+		t.Fatalf("ResolveByIP: %v", err)
+	}
+	if got.Name != `\Device\NPF_{2}` || got.Description != "Ethernet" {
+		t.Errorf("ResolveByIP = %+v, want Name=NPF_{2} Description=Ethernet", got)
+	}
+}
+
+func TestResolveByIPNotFound(t *testing.T) {
+	withStubFindAllDevs(t, []pcap.Interface{
+		{
+			Name:        `\Device\NPF_{1}`,
+			Description: "Wi-Fi",
+			Addresses:   []pcap.InterfaceAddress{{IP: net.ParseIP("192.168.1.10")}},
+		},
+	}, nil)
+
+	if _, err := ResolveByIP("172.16.0.1"); err == nil {
+		t.Fatal("expected not-found error")
+	}
+}

--- a/internal/photon/deserializer.go
+++ b/internal/photon/deserializer.go
@@ -313,7 +313,7 @@ func deserializeTypedArray(buf *bytes.Buffer, elemType byte) interface{} {
 		packedBytes := (size + 7) / 8
 		packed := make([]byte, packedBytes)
 		_, _ = buf.Read(packed)
-		for i := 0; i < size; i++ {
+		for i := range result {
 			result[i] = (packed[i/8] & (1 << uint(i%8))) != 0
 		}
 		return result

--- a/internal/photon/deserializer_bench_test.go
+++ b/internal/photon/deserializer_bench_test.go
@@ -22,7 +22,7 @@ func buildBenchMoveEventPayload() []byte {
 
 func BenchmarkDeserializeMoveEvent(b *testing.B) {
 	payload := buildBenchMoveEventPayload()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ev, _ := DeserializeEvent(payload)
 		PostProcessEvent(ev)
 	}

--- a/internal/photon/deserializer_test.go
+++ b/internal/photon/deserializer_test.go
@@ -283,9 +283,9 @@ func TestDeserializeRequest_OpMove_PostPatch(t *testing.T) {
 	require.Equal(t, byte(22), req.OperationCode)
 	require.Equal(t, int64(1000), req.Parameters[0])
 	require.Equal(t, []float32{10.5, 20.5}, req.Parameters[1])
-	require.Equal(t, float32(1.5), req.Parameters[2])
+	require.InEpsilon(t, float32(1.5), req.Parameters[2], 1e-6)
 	require.Equal(t, []float32{9.5, 19.5}, req.Parameters[3])
-	require.Equal(t, float32(5.5), req.Parameters[4])
+	require.InEpsilon(t, float32(5.5), req.Parameters[4], 1e-6)
 	require.Equal(t, byte(22), req.Parameters[253])
 }
 

--- a/internal/photon/live_pcap_test.go
+++ b/internal/photon/live_pcap_test.go
@@ -184,7 +184,7 @@ func TestLivePcap_Fragments(t *testing.T) {
 	for _, n := range stats.responses {
 		decoded += n
 	}
-	require.Greater(t, decoded, 0,
+	require.Positive(t, decoded,
 		"expected at least one decoded message across fragments, saw events=%v", stats.events)
 }
 

--- a/internal/photon/packet.go
+++ b/internal/photon/packet.go
@@ -84,7 +84,7 @@ func (p *PhotonParser) ReceivePacket(payload []byte) bool {
 		return false
 	}
 
-	for i := 0; i < commandCount; i++ {
+	for range commandCount {
 		var ok bool
 		offset, ok = p.handleCommand(payload, offset)
 		if !ok {

--- a/internal/photon/packet_test.go
+++ b/internal/photon/packet_test.go
@@ -47,7 +47,7 @@ func buildFragmentedEventPackets(n int) [][]byte {
 	chunkSize := (total + n - 1) / n
 
 	packets := make([][]byte, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		start := i * chunkSize
 		end := start + chunkSize
 		if end > total {
@@ -123,7 +123,7 @@ func TestPhotonParser_Fragment_Eviction(t *testing.T) {
 		return newSingleCommandPhotonPacket(cmdSendFragment,
 			append(fragHeader, 0x00, 0x00, 0x00, 0x00, 0x00))
 	}
-	for i := uint32(0); i < uint32(maxPendingSegments+5); i++ {
+	for i := range uint32(maxPendingSegments + 5) {
 		p.ReceivePacket(buildIncompleteFragment(i))
 	}
 	require.LessOrEqual(t, len(p.pendingSegments), maxPendingSegments)

--- a/internal/photon/readers_test.go
+++ b/internal/photon/readers_test.go
@@ -68,11 +68,11 @@ func TestReadLEPrimitives(t *testing.T) {
 	})
 	t.Run("float32 one", func(t *testing.T) {
 		buf := bytes.NewBuffer([]byte{0x00, 0x00, 0x80, 0x3f})
-		require.Equal(t, float32(1.0), readFloat32(buf))
+		require.InEpsilon(t, float32(1.0), readFloat32(buf), 1e-6)
 	})
 	t.Run("float64 one", func(t *testing.T) {
 		buf := bytes.NewBuffer([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f})
-		require.Equal(t, float64(1.0), readFloat64(buf))
+		require.InEpsilon(t, 1.0, readFloat64(buf), 1e-9)
 	})
 }
 
@@ -83,10 +83,10 @@ func TestReadString(t *testing.T) {
 
 func TestReadString_Empty(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{0x00})
-	require.Equal(t, "", readString(buf))
+	require.Empty(t, readString(buf))
 }
 
 func TestReadString_Truncated(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{0x0a, 'h', 'i', '!'})
-	require.Equal(t, "", readString(buf))
+	require.Empty(t, readString(buf))
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -92,7 +92,7 @@ func NewHTTPServer(
 		version:   version,
 	}
 	if mgr != nil {
-		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, ComputeLANAddresses)
+		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
 	s.setupRoutes()
 	return s, nil
@@ -131,7 +131,7 @@ func NewHTTPServerDev(
 		devMode:   true,
 	}
 	if mgr != nil {
-		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, ComputeLANAddresses)
+		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
 	s.setupRoutes()
 	return s, nil

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/segmentio/encoding/json"
 
+	"github.com/nospy/albion-openradar/internal/capture"
 	"github.com/nospy/albion-openradar/internal/logger"
 	"github.com/nospy/albion-openradar/internal/templates"
 )
@@ -31,9 +32,10 @@ type HTTPServer struct {
 	sounds  fs.FS
 	styles  fs.FS
 	// Template engine
-	tmpl    *templates.Engine
-	version string
-	devMode bool
+	tmpl       *templates.Engine
+	version    string
+	devMode    bool
+	networkAPI *NetworkAPI
 }
 
 // NewHTTPServer creates a new HTTP server with embedded assets (production mode)
@@ -43,6 +45,9 @@ func NewHTTPServer(
 	wsHandler *WebSocketHandler,
 	log *logger.Logger,
 	version string,
+	mgr NetworkManager,
+	allInterfaces []capture.NetworkInterface,
+	appDir string,
 ) (*HTTPServer, error) {
 	// Extract subdirectories from embed.FS (they include the folder path)
 	imagesFS, err := fs.Sub(images, "web/images")
@@ -86,12 +91,23 @@ func NewHTTPServer(
 		tmpl:      tmpl,
 		version:   version,
 	}
+	if mgr != nil {
+		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, ComputeLANAddresses)
+	}
 	s.setupRoutes()
 	return s, nil
 }
 
 // NewHTTPServerDev creates a new HTTP server reading from filesystem (dev mode)
-func NewHTTPServerDev(port int, appDir string, wsHandler *WebSocketHandler, log *logger.Logger, version string) (*HTTPServer, error) {
+func NewHTTPServerDev(
+	port int,
+	appDir string,
+	wsHandler *WebSocketHandler,
+	log *logger.Logger,
+	version string,
+	mgr NetworkManager,
+	allInterfaces []capture.NetworkInterface,
+) (*HTTPServer, error) {
 	// Initialize template engine in dev mode (hot reload)
 	tmplDir := appDir + "/internal/templates"
 	tmpl, err := templates.NewEngineDev(tmplDir)
@@ -113,6 +129,9 @@ func NewHTTPServerDev(port int, appDir string, wsHandler *WebSocketHandler, log 
 		tmpl:      tmpl,
 		version:   version,
 		devMode:   true,
+	}
+	if mgr != nil {
+		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, ComputeLANAddresses)
 	}
 	s.setupRoutes()
 	return s, nil
@@ -175,6 +194,9 @@ func (s *HTTPServer) setupRoutes() {
 
 	// API endpoints
 	s.mux.HandleFunc("/api/settings/server-logs", s.handleServerLogs)
+	if s.networkAPI != nil {
+		s.networkAPI.Register(s.mux)
+	}
 }
 
 // renderPage renders a page template

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -375,14 +375,14 @@ func (s *HTTPServer) handleServerLogs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	switch r.Method {
-	case "GET":
+	case http.MethodGet:
 		enabled := false
 		if s.logger != nil {
 			enabled = s.logger.IsEnabled()
 		}
 		_ = json.NewEncoder(w).Encode(map[string]bool{"enabled": enabled})
 
-	case "POST":
+	case http.MethodPost:
 		var req struct {
 			Enabled bool `json:"enabled"`
 		}

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+)
+
+type NetworkManager interface {
+	State() capture.State
+	Reconfigure([]capture.NetworkInterface) error
+}
+
+type LANAddrFn func() []string
+
+type NetworkAPI struct {
+	mgr      NetworkManager
+	all      []capture.NetworkInterface
+	appDir   string
+	lanAddrs LANAddrFn
+}
+
+func NewNetworkAPI(mgr NetworkManager, all []capture.NetworkInterface, appDir string, lan LANAddrFn) *NetworkAPI {
+	return &NetworkAPI{mgr: mgr, all: all, appDir: appDir, lanAddrs: lan}
+}
+
+func (a *NetworkAPI) Register(mux *http.ServeMux) {
+	mux.Handle("/api/network/interfaces", a)
+	mux.Handle("/api/network/state", a)
+	mux.Handle("/api/network/refresh", a)
+}
+
+func (a *NetworkAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/network/interfaces":
+		switch r.Method {
+		case http.MethodGet:
+			a.handleList(w, r)
+		case http.MethodPost:
+			a.handleSelect(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case "/api/network/state":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		a.handleState(w, r)
+	case "/api/network/refresh":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		a.handleRefresh(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+type ifaceRow struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Address     string `json:"address"`
+	Category    string `json:"category"`
+	IsPersisted bool   `json:"isPersisted"`
+	IsAvailable bool   `json:"isAvailable"`
+}
+
+func (a *NetworkAPI) handleList(w http.ResponseWriter, _ *http.Request) {
+	persisted := make(map[string]bool)
+	cfg, _ := capture.ReadConfig(a.appDir)
+	for _, p := range cfg.CaptureInterfaces {
+		persisted[p.Name] = true
+	}
+	available := make(map[string]bool)
+	for _, i := range a.all {
+		available[i.Name] = true
+	}
+	rows := make([]ifaceRow, 0, len(a.all))
+	for _, i := range capture.RankCandidates(a.all) {
+		rows = append(rows, ifaceRow{
+			Name:        i.Name,
+			Description: i.Description,
+			Address:     i.Address,
+			Category:    string(capture.Categorize(i.Name, i.Description)),
+			IsPersisted: persisted[i.Name],
+			IsAvailable: available[i.Name],
+		})
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
+type stateBody struct {
+	CaptureInterfaces []capture.CaptureSummary `json:"captureInterfaces"`
+	IsCapturing       bool                     `json:"isCapturing"`
+	LanAddresses      []string                 `json:"lanAddresses"`
+	LastErrors        map[string]string        `json:"lastErrors"`
+	Status            string                   `json:"status"`
+}
+
+func (a *NetworkAPI) handleState(w http.ResponseWriter, _ *http.Request) {
+	s := a.mgr.State()
+	body := stateBody{
+		CaptureInterfaces: s.Active,
+		IsCapturing:       len(s.Active) > 0,
+		LanAddresses:      a.lanAddrs(),
+		LastErrors:        s.LastErrors,
+		Status:            string(s.Status),
+	}
+	writeJSON(w, http.StatusOK, body)
+}
+
+type selectBody struct {
+	Names []string `json:"names"`
+}
+
+func (a *NetworkAPI) handleSelect(w http.ResponseWriter, r *http.Request) {
+	if !isLoopback(r.RemoteAddr) {
+		http.Error(w, "capture interfaces can only be changed from the host PC", http.StatusForbidden)
+		return
+	}
+	var body selectBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	desired := make([]capture.NetworkInterface, 0, len(body.Names))
+	for _, name := range body.Names {
+		for _, i := range a.all {
+			if i.Name == name {
+				desired = append(desired, i)
+				break
+			}
+		}
+	}
+	if err := a.mgr.Reconfigure(desired); err != nil {
+		http.Error(w, "reconfigure: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	persisted := make([]capture.PersistedInterface, 0, len(desired))
+	for _, i := range desired {
+		persisted = append(persisted, capture.PersistedInterface{Name: i.Name, Description: i.Description})
+	}
+	if err := capture.WriteConfig(a.appDir, capture.Config{CaptureInterfaces: persisted}); err != nil {
+		http.Error(w, "persist: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (a *NetworkAPI) handleRefresh(w http.ResponseWriter, _ *http.Request) {
+	fresh, err := capture.EnumerateInterfaces()
+	if err != nil {
+		http.Error(w, "enumerate: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	a.all = fresh
+	a.handleList(w, nil)
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func isLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/nospy/albion-openradar/internal/capture"
 )
@@ -18,6 +20,7 @@ type LANAddrFn func() []string
 
 type NetworkAPI struct {
 	mgr      NetworkManager
+	mu       sync.RWMutex
 	all      []capture.NetworkInterface
 	appDir   string
 	lanAddrs LANAddrFn
@@ -71,17 +74,22 @@ type ifaceRow struct {
 }
 
 func (a *NetworkAPI) handleList(w http.ResponseWriter, _ *http.Request) {
+	a.mu.RLock()
+	snapshot := make([]capture.NetworkInterface, len(a.all))
+	copy(snapshot, a.all)
+	a.mu.RUnlock()
+
 	persisted := make(map[string]bool)
 	cfg, _ := capture.ReadConfig(a.appDir)
 	for _, p := range cfg.CaptureInterfaces {
 		persisted[p.Name] = true
 	}
 	available := make(map[string]bool)
-	for _, i := range a.all {
+	for _, i := range snapshot {
 		available[i.Name] = true
 	}
-	rows := make([]ifaceRow, 0, len(a.all))
-	for _, i := range capture.RankCandidates(a.all) {
+	rows := make([]ifaceRow, 0, len(snapshot))
+	for _, i := range capture.RankCandidates(snapshot) {
 		rows = append(rows, ifaceRow{
 			Name:        i.Name,
 			Description: i.Description,
@@ -128,14 +136,24 @@ func (a *NetworkAPI) handleSelect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	a.mu.RLock()
+	available := make(map[string]capture.NetworkInterface, len(a.all))
+	for _, i := range a.all {
+		available[i.Name] = i
+	}
+	a.mu.RUnlock()
 	desired := make([]capture.NetworkInterface, 0, len(body.Names))
+	var unknown []string
 	for _, name := range body.Names {
-		for _, i := range a.all {
-			if i.Name == name {
-				desired = append(desired, i)
-				break
-			}
+		if i, ok := available[name]; ok {
+			desired = append(desired, i)
+		} else {
+			unknown = append(unknown, name)
 		}
+	}
+	if len(unknown) > 0 {
+		http.Error(w, fmt.Sprintf("unknown interface names: %v", unknown), http.StatusBadRequest)
+		return
 	}
 	if err := a.mgr.Reconfigure(desired); err != nil {
 		http.Error(w, "reconfigure: "+err.Error(), http.StatusInternalServerError)
@@ -158,7 +176,9 @@ func (a *NetworkAPI) handleRefresh(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "enumerate: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	a.mu.Lock()
 	a.all = fresh
+	a.mu.Unlock()
 	a.handleList(w, nil)
 }
 

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -31,37 +31,10 @@ func NewNetworkAPI(mgr NetworkManager, all []capture.NetworkInterface, appDir st
 }
 
 func (a *NetworkAPI) Register(mux *http.ServeMux) {
-	mux.Handle("/api/network/interfaces", a)
-	mux.Handle("/api/network/state", a)
-	mux.Handle("/api/network/refresh", a)
-}
-
-func (a *NetworkAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.URL.Path {
-	case "/api/network/interfaces":
-		switch r.Method {
-		case http.MethodGet:
-			a.handleList(w, r)
-		case http.MethodPost:
-			a.handleSelect(w, r)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		}
-	case "/api/network/state":
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		a.handleState(w, r)
-	case "/api/network/refresh":
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		a.handleRefresh(w, r)
-	default:
-		http.NotFound(w, r)
-	}
+	mux.HandleFunc("GET /api/network/interfaces", a.handleList)
+	mux.HandleFunc("POST /api/network/interfaces", a.handleSelect)
+	mux.HandleFunc("GET /api/network/state", a.handleState)
+	mux.HandleFunc("POST /api/network/refresh", a.handleRefresh)
 }
 
 type ifaceRow struct {

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -155,6 +155,35 @@ func (a *NetworkAPI) handleRefresh(w http.ResponseWriter, _ *http.Request) {
 	a.handleList(w, nil)
 }
 
+// ComputeLANAddresses returns IPv4 RFC1918 host addresses bound to local
+// interfaces, used to print LAN URLs at startup and to populate /api/network/state.
+func ComputeLANAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	rfc1918 := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	out := make([]string, 0)
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipnet.IP.To4()
+		if ip4 == nil {
+			continue
+		}
+		for _, cidr := range rfc1918 {
+			_, n, _ := net.ParseCIDR(cidr)
+			if n.Contains(ip4) {
+				out = append(out, ip4.String())
+				break
+			}
+		}
+	}
+	return out
+}
+
 func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -155,35 +155,6 @@ func (a *NetworkAPI) handleRefresh(w http.ResponseWriter, _ *http.Request) {
 	a.handleList(w, nil)
 }
 
-// ComputeLANAddresses returns IPv4 RFC1918 host addresses bound to local
-// interfaces, used to print LAN URLs at startup and to populate /api/network/state.
-func ComputeLANAddresses() []string {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return nil
-	}
-	rfc1918 := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
-	out := make([]string, 0)
-	for _, a := range addrs {
-		ipnet, ok := a.(*net.IPNet)
-		if !ok {
-			continue
-		}
-		ip4 := ipnet.IP.To4()
-		if ip4 == nil {
-			continue
-		}
-		for _, cidr := range rfc1918 {
-			_, n, _ := net.ParseCIDR(cidr)
-			if n.Contains(ip4) {
-				out = append(out, ip4.String())
-				break
-			}
-		}
-	}
-	return out
-}
-
 func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/internal/server/network_api_test.go
+++ b/internal/server/network_api_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+)
+
+type fakeManager struct {
+	state         capture.State
+	reconfArgs    []capture.NetworkInterface
+	reconfErr     error
+	allInterfaces []capture.NetworkInterface
+}
+
+func (f *fakeManager) State() capture.State { return f.state }
+func (f *fakeManager) Reconfigure(t []capture.NetworkInterface) error {
+	f.reconfArgs = append([]capture.NetworkInterface(nil), t...)
+	return f.reconfErr
+}
+
+func TestNetworkAPI_ListReturnsCategorized(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{
+			{Name: "n1", Description: "Wi-Fi", Address: "192.168.1.1"},
+			{Name: "n2", Description: "Realtek PCIe GbE Family Controller", Address: "192.168.1.2"},
+		},
+		state: capture.State{
+			Active: []capture.CaptureSummary{{Name: "n1"}},
+		},
+	}
+	api := NewNetworkAPI(fm, fm.allInterfaces, "/tmp/notused", func() []string { return []string{"192.168.1.5"} })
+	req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	for _, row := range got {
+		if row["category"] == "" {
+			t.Errorf("missing category in %+v", row)
+		}
+	}
+}
+
+func TestNetworkAPI_PostFromLoopback(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{
+			{Name: "x", Description: "Wi-Fi", Address: "10.0.0.1"},
+		},
+	}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("loopback POST got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fm.reconfArgs) != 1 || fm.reconfArgs[0].Name != "x" {
+		t.Errorf("Reconfigure called with %+v", fm.reconfArgs)
+	}
+	cfg, _ := capture.ReadConfig(dir)
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Name != "x" {
+		t.Errorf("config not persisted: %+v", cfg)
+	}
+}
+
+func TestNetworkAPI_PostFromLanRejected(t *testing.T) {
+	fm := &fakeManager{}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "192.168.1.42:5555"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status %d, want 403", rec.Code)
+	}
+	if len(fm.reconfArgs) != 0 {
+		t.Errorf("Reconfigure should not have been called from non-loopback")
+	}
+}
+
+func TestNetworkAPI_StateShape(t *testing.T) {
+	fm := &fakeManager{
+		state: capture.State{
+			Status: capture.StatusRunning,
+			Active: []capture.CaptureSummary{{Name: "x", Description: "Wi-Fi", Address: "10.0.0.1"}},
+		},
+	}
+	api := NewNetworkAPI(fm, nil, "/tmp", func() []string { return []string{"192.168.1.1"} })
+	req := httptest.NewRequest("GET", "/api/network/state", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["isCapturing"] != true {
+		t.Errorf("isCapturing=%v", body["isCapturing"])
+	}
+	if body["lanAddresses"] == nil {
+		t.Error("lanAddresses missing")
+	}
+}

--- a/internal/server/network_api_test.go
+++ b/internal/server/network_api_test.go
@@ -25,6 +25,12 @@ func (f *fakeManager) Reconfigure(t []capture.NetworkInterface) error {
 	return f.reconfErr
 }
 
+func newTestMux(api *NetworkAPI) *http.ServeMux {
+	mux := http.NewServeMux()
+	api.Register(mux)
+	return mux
+}
+
 func TestNetworkAPI_ListReturnsCategorized(t *testing.T) {
 	fm := &fakeManager{
 		allInterfaces: []capture.NetworkInterface{
@@ -36,9 +42,10 @@ func TestNetworkAPI_ListReturnsCategorized(t *testing.T) {
 		},
 	}
 	api := NewNetworkAPI(fm, fm.allInterfaces, "/tmp/notused", func() []string { return []string{"192.168.1.5"} })
+	mux := newTestMux(api)
 	req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != 200 {
 		t.Fatalf("status %d", rec.Code)
 	}
@@ -64,12 +71,13 @@ func TestNetworkAPI_PostFromLoopback(t *testing.T) {
 	}
 	dir := t.TempDir()
 	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
 	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != 200 {
 		t.Fatalf("loopback POST got %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -86,12 +94,13 @@ func TestNetworkAPI_PostFromLanRejected(t *testing.T) {
 	fm := &fakeManager{}
 	dir := t.TempDir()
 	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
+	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
 	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "192.168.1.42:5555"
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("status %d, want 403", rec.Code)
 	}
@@ -108,9 +117,10 @@ func TestNetworkAPI_StateShape(t *testing.T) {
 		},
 	}
 	api := NewNetworkAPI(fm, nil, "/tmp", func() []string { return []string{"192.168.1.1"} })
+	mux := newTestMux(api)
 	req := httptest.NewRequest("GET", "/api/network/state", nil)
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != 200 {
 		t.Fatalf("status %d", rec.Code)
 	}
@@ -132,12 +142,13 @@ func TestNetworkAPI_PostUnknownNames(t *testing.T) {
 	}
 	dir := t.TempDir()
 	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"a", "unknown"}})
 	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status %d, want 400", rec.Code)
 	}
@@ -153,11 +164,12 @@ func TestNetworkAPI_PostMalformedBody(t *testing.T) {
 	fm := &fakeManager{}
 	dir := t.TempDir()
 	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
+	mux := newTestMux(api)
 
 	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader([]byte("{not json")))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status %d, want 400", rec.Code)
 	}
@@ -169,10 +181,11 @@ func TestNetworkAPI_PostMalformedBody(t *testing.T) {
 func TestNetworkAPI_RefreshGETIs405(t *testing.T) {
 	fm := &fakeManager{}
 	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
+	mux := newTestMux(api)
 
 	req := httptest.NewRequest("GET", "/api/network/refresh", nil)
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status %d, want 405", rec.Code)
 	}
@@ -181,10 +194,11 @@ func TestNetworkAPI_RefreshGETIs405(t *testing.T) {
 func TestNetworkAPI_StatePOSTIs405(t *testing.T) {
 	fm := &fakeManager{}
 	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
+	mux := newTestMux(api)
 
 	req := httptest.NewRequest("POST", "/api/network/state", nil)
 	rec := httptest.NewRecorder()
-	api.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status %d, want 405", rec.Code)
 	}
@@ -197,30 +211,30 @@ func TestNetworkAPI_RefreshConcurrentSafe(t *testing.T) {
 		allInterfaces: []capture.NetworkInterface{{Name: "n1", Description: "Wi-Fi", Address: "10.0.0.1"}},
 	}
 	api := NewNetworkAPI(fm, fm.allInterfaces, t.TempDir(), func() []string { return nil })
+	mux := newTestMux(api)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
 			rec := httptest.NewRecorder()
-			api.ServeHTTP(rec, req)
+			mux.ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Errorf("list status %d", rec.Code)
 			}
 		}()
 	}
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
-		go func(idx int) {
+		go func() {
 			defer wg.Done()
 			fresh := []capture.NetworkInterface{{Name: "mut", Description: "X", Address: "10.0.0.99"}}
 			api.mu.Lock()
 			api.all = fresh
 			api.mu.Unlock()
-			_ = idx
-		}(i)
+		}()
 	}
 	wg.Wait()
 }

--- a/internal/server/network_api_test.go
+++ b/internal/server/network_api_test.go
@@ -43,10 +43,10 @@ func TestNetworkAPI_ListReturnsCategorized(t *testing.T) {
 	}
 	api := NewNetworkAPI(fm, fm.allInterfaces, "/tmp/notused", func() []string { return []string{"192.168.1.5"} })
 	mux := newTestMux(api)
-	req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/network/interfaces", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	if rec.Code != 200 {
+	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d", rec.Code)
 	}
 	var got []map[string]any
@@ -74,11 +74,11 @@ func TestNetworkAPI_PostFromLoopback(t *testing.T) {
 	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
-	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	if rec.Code != 200 {
+	if rec.Code != http.StatusOK {
 		t.Fatalf("loopback POST got %d, body=%s", rec.Code, rec.Body.String())
 	}
 	if len(fm.reconfArgs) != 1 || fm.reconfArgs[0].Name != "x" {
@@ -97,7 +97,7 @@ func TestNetworkAPI_PostFromLanRejected(t *testing.T) {
 	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"x"}})
-	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "192.168.1.42:5555"
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -118,10 +118,10 @@ func TestNetworkAPI_StateShape(t *testing.T) {
 	}
 	api := NewNetworkAPI(fm, nil, "/tmp", func() []string { return []string{"192.168.1.1"} })
 	mux := newTestMux(api)
-	req := httptest.NewRequest("GET", "/api/network/state", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/network/state", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	if rec.Code != 200 {
+	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d", rec.Code)
 	}
 	var body map[string]any
@@ -145,7 +145,7 @@ func TestNetworkAPI_PostUnknownNames(t *testing.T) {
 	mux := newTestMux(api)
 
 	body, _ := json.Marshal(map[string]any{"names": []string{"a", "unknown"}})
-	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/network/interfaces", bytes.NewReader(body))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -166,7 +166,7 @@ func TestNetworkAPI_PostMalformedBody(t *testing.T) {
 	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
 	mux := newTestMux(api)
 
-	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader([]byte("{not json")))
+	req := httptest.NewRequest(http.MethodPost, "/api/network/interfaces", bytes.NewReader([]byte("{not json")))
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -183,7 +183,7 @@ func TestNetworkAPI_RefreshGETIs405(t *testing.T) {
 	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
 	mux := newTestMux(api)
 
-	req := httptest.NewRequest("GET", "/api/network/refresh", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/network/refresh", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
@@ -196,7 +196,7 @@ func TestNetworkAPI_StatePOSTIs405(t *testing.T) {
 	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
 	mux := newTestMux(api)
 
-	req := httptest.NewRequest("POST", "/api/network/state", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/network/state", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
@@ -215,26 +215,22 @@ func TestNetworkAPI_RefreshConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 50 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
+		wg.Go(func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/network/interfaces", nil)
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Errorf("list status %d", rec.Code)
 			}
-		}()
+		})
 	}
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			fresh := []capture.NetworkInterface{{Name: "mut", Description: "X", Address: "10.0.0.99"}}
 			api.mu.Lock()
 			api.all = fresh
 			api.mu.Unlock()
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/server/network_api_test.go
+++ b/internal/server/network_api_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/nospy/albion-openradar/internal/capture"
@@ -122,4 +124,103 @@ func TestNetworkAPI_StateShape(t *testing.T) {
 	if body["lanAddresses"] == nil {
 		t.Error("lanAddresses missing")
 	}
+}
+
+func TestNetworkAPI_PostUnknownNames(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{{Name: "a", Description: "Wi-Fi", Address: "10.0.0.1"}},
+	}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"a", "unknown"}})
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "unknown") {
+		t.Errorf("body should mention unknown names: %s", rec.Body.String())
+	}
+	if len(fm.reconfArgs) != 0 {
+		t.Errorf("Reconfigure should not have been called, got %+v", fm.reconfArgs)
+	}
+}
+
+func TestNetworkAPI_PostMalformedBody(t *testing.T) {
+	fm := &fakeManager{}
+	dir := t.TempDir()
+	api := NewNetworkAPI(fm, nil, dir, func() []string { return nil })
+
+	req := httptest.NewRequest("POST", "/api/network/interfaces", bytes.NewReader([]byte("{not json")))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "invalid body") {
+		t.Errorf("body should mention invalid body: %s", rec.Body.String())
+	}
+}
+
+func TestNetworkAPI_RefreshGETIs405(t *testing.T) {
+	fm := &fakeManager{}
+	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
+
+	req := httptest.NewRequest("GET", "/api/network/refresh", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status %d, want 405", rec.Code)
+	}
+}
+
+func TestNetworkAPI_StatePOSTIs405(t *testing.T) {
+	fm := &fakeManager{}
+	api := NewNetworkAPI(fm, nil, t.TempDir(), func() []string { return nil })
+
+	req := httptest.NewRequest("POST", "/api/network/state", nil)
+	rec := httptest.NewRecorder()
+	api.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status %d, want 405", rec.Code)
+	}
+}
+
+// Proves the RWMutex fix: without it, concurrent reads of a.all while a writer
+// mutates the slice would race under -race.
+func TestNetworkAPI_RefreshConcurrentSafe(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{{Name: "n1", Description: "Wi-Fi", Address: "10.0.0.1"}},
+	}
+	api := NewNetworkAPI(fm, fm.allInterfaces, t.TempDir(), func() []string { return nil })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("GET", "/api/network/interfaces", nil)
+			rec := httptest.NewRecorder()
+			api.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Errorf("list status %d", rec.Code)
+			}
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			fresh := []capture.NetworkInterface{{Name: "mut", Description: "X", Address: "10.0.0.99"}}
+			api.mu.Lock()
+			api.all = fresh
+			api.mu.Unlock()
+			_ = idx
+		}(i)
+	}
+	wg.Wait()
 }

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/segmentio/encoding/json"
+
 	"github.com/nospy/albion-openradar/internal/logger"
 	"github.com/nospy/albion-openradar/internal/photon"
-	"github.com/segmentio/encoding/json"
 )
 
 const (

--- a/internal/server/websocket_test.go
+++ b/internal/server/websocket_test.go
@@ -3,9 +3,10 @@ package server
 import (
 	"testing"
 
-	"github.com/nospy/albion-openradar/internal/photon"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nospy/albion-openradar/internal/photon"
 )
 
 // Locks the JSON wire shape broadcast to the web front-end. The front reads

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -281,6 +281,17 @@
         </div>
     </div>
 
+    <!-- Network Settings -->
+    <div class="card bg-base-200">
+        <div class="card-body">
+            <h2 class="text-xl font-semibold text-base-content mb-4 flex items-center gap-2">
+                <i data-lucide="wifi" class="w-5 h-5 text-primary"></i>
+                Network
+            </h2>
+            <div id="network-section" class="text-base-content/80">Loading network configuration…</div>
+        </div>
+    </div>
+
     <!-- Danger Zone -->
     <div class="card bg-error/5 border border-error/20">
         <div class="card-body">
@@ -459,6 +470,19 @@
                 });
                 document.getElementById('modal-clearCache').close();
                 if (window.toast) window.toast.success('Cache cleared');
+            });
+
+            // Network section: dynamic interface selection
+            import('/scripts/handlers/NetworkSettingsHandler.js').then(({NetworkSettingsHandler}) => {
+                const networkContainer = document.getElementById('network-section');
+                if (networkContainer) {
+                    const networkHandler = new NetworkSettingsHandler(networkContainer);
+                    networkHandler.load();
+                    const networkPoll = setInterval(() => {
+                        if (!document.hidden) networkHandler.load();
+                    }, 5000);
+                    cleanup.push(() => clearInterval(networkPoll));
+                }
             });
         }
 

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -69,6 +69,20 @@ type StatusMsg struct {
 	CaptureRunning bool
 }
 
+// CaptureSummary mirrors internal/capture.CaptureSummary so internal/ui has no
+// dependency on internal/capture.
+type CaptureSummary struct {
+	Description string
+	Address     string
+	Category    string
+}
+
+type CaptureStateMsg struct {
+	Active       []CaptureSummary
+	LanAddresses []string
+	Status       string
+}
+
 type RestartMsg struct{}
 
 type TickMsg time.Time
@@ -95,7 +109,12 @@ type Dashboard struct {
 	lanServerURL string
 	lanWsURL     string
 	mode         string
-	adapterIP    string
+	port         int
+
+	// Capture interfaces and LAN addresses (sourced from Manager.State() poll)
+	captureInterfaces []CaptureSummary
+	lanAddresses      []string
+	captureStatus     string
 
 	// Status indicators
 	httpRunning    bool
@@ -155,7 +174,7 @@ type Dashboard struct {
 }
 
 // NewDashboard creates a new dashboard model
-func NewDashboard(version string, port int, devMode bool, adapterIP string) Dashboard {
+func NewDashboard(version string, port int, devMode bool, lanAddresses []string, captures []CaptureSummary) Dashboard {
 	mode := "Production"
 	if devMode {
 		mode = "Development"
@@ -166,25 +185,27 @@ func NewDashboard(version string, port int, devMode bool, adapterIP string) Dash
 	ti.CharLimit = 50
 
 	d := Dashboard{
-		version:          version,
-		serverURL:        fmt.Sprintf("http://localhost:%d", port),
-		wsURL:            fmt.Sprintf("ws://localhost:%d/ws", port),
-		mode:             mode,
-		adapterIP:        adapterIP,
-		startTime:        time.Now(),
-		logs:             make([]LogEntry, 0, maxLogs),
-		packetsHistory:   make([]uint64, 0, sparklineHistory),
-		memoryHistory:    make([]float64, 0, sparklineHistory),
-		memorySysHistory: make([]float64, 0, sparklineHistory),
-		wsBatchHistory:   make([]uint64, 0, sparklineHistory),
-		autoScroll:       true,
-		currentTab:       TabLogs,
-		logFilter:        LevelAll,
-		searchInput:      ti,
+		version:           version,
+		serverURL:         fmt.Sprintf("http://localhost:%d", port),
+		wsURL:             fmt.Sprintf("ws://localhost:%d/ws", port),
+		mode:              mode,
+		port:              port,
+		startTime:         time.Now(),
+		logs:              make([]LogEntry, 0, maxLogs),
+		packetsHistory:    make([]uint64, 0, sparklineHistory),
+		memoryHistory:     make([]float64, 0, sparklineHistory),
+		memorySysHistory:  make([]float64, 0, sparklineHistory),
+		wsBatchHistory:    make([]uint64, 0, sparklineHistory),
+		autoScroll:        true,
+		currentTab:        TabLogs,
+		logFilter:         LevelAll,
+		searchInput:       ti,
+		captureInterfaces: captures,
+		lanAddresses:      lanAddresses,
 	}
-	if adapterIP != "" && adapterIP != "127.0.0.1" {
-		d.lanServerURL = fmt.Sprintf("http://%s:%d", adapterIP, port)
-		d.lanWsURL = fmt.Sprintf("ws://%s:%d/ws", adapterIP, port)
+	if len(lanAddresses) > 0 && lanAddresses[0] != "127.0.0.1" {
+		d.lanServerURL = fmt.Sprintf("http://%s:%d", lanAddresses[0], port)
+		d.lanWsURL = fmt.Sprintf("ws://%s:%d/ws", lanAddresses[0], port)
 	}
 	return d
 }
@@ -356,6 +377,18 @@ func (d Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.wsRunning = msg.WSRunning
 		d.captureRunning = msg.CaptureRunning
 
+	case CaptureStateMsg:
+		d.captureInterfaces = msg.Active
+		d.lanAddresses = msg.LanAddresses
+		d.captureStatus = msg.Status
+		if len(msg.LanAddresses) > 0 && msg.LanAddresses[0] != "127.0.0.1" {
+			d.lanServerURL = fmt.Sprintf("http://%s:%d", msg.LanAddresses[0], d.port)
+			d.lanWsURL = fmt.Sprintf("ws://%s:%d/ws", msg.LanAddresses[0], d.port)
+		} else {
+			d.lanServerURL = ""
+			d.lanWsURL = ""
+		}
+
 	case TickMsg:
 		cmds = append(cmds, tickCmd())
 	}
@@ -492,9 +525,17 @@ func (d *Dashboard) renderHeader() string {
 	captureStatus := statusIndicator(d.captureRunning, "CAP")
 	status := fmt.Sprintf("%s %s %s", httpStatus, wsStatus, captureStatus)
 
-	// Mode and adapter
+	// Mode and capture interfaces
 	mode := ModeStyle.Render(fmt.Sprintf("Mode: %s", d.mode))
-	adapter := TimestampStyle.Render(fmt.Sprintf("Adapter: %s", d.adapterIP))
+	captureLine := "Capture: (awaiting)"
+	if len(d.captureInterfaces) > 0 {
+		parts := make([]string, 0, len(d.captureInterfaces))
+		for _, c := range d.captureInterfaces {
+			parts = append(parts, fmt.Sprintf("%s (%s)", c.Description, c.Address))
+		}
+		captureLine = "Capture: " + strings.Join(parts, ", ")
+	}
+	adapter := TimestampStyle.Render(captureLine)
 
 	httpLine := d.serverURL
 	wsLine := d.wsURL
@@ -764,7 +805,8 @@ func (d *Dashboard) renderConfigView() string {
 		cfgLine("Mode:", d.mode, ModeStyle),
 		cfgLine("HTTP URL:", d.serverURL, URLStyle),
 		cfgLine("WS URL:", d.wsURL, URLStyle),
-		cfgLine("Adapter:", d.adapterIP, StatValueStyle),
+		cfgLine("Capture:", captureSummary(d.captureInterfaces), StatValueStyle),
+		cfgLine("LAN:", strings.Join(d.lanAddresses, ", "), StatValueStyle),
 		"",
 		section("ℹ️", "About"),
 		cfgLine("", "OpenRadar - Albion Online", StatLabelStyle),
@@ -913,6 +955,17 @@ func formatBytes(b uint64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func captureSummary(summaries []CaptureSummary) string {
+	if len(summaries) == 0 {
+		return "(awaiting)"
+	}
+	parts := make([]string, 0, len(summaries))
+	for _, c := range summaries {
+		parts = append(parts, fmt.Sprintf("%s (%s)", c.Description, c.Address))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func formatDuration(d time.Duration) string {

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -518,7 +519,7 @@ func (d Dashboard) View() string {
 
 func (d *Dashboard) renderHeader() string {
 	// Title and status indicators
-	title := TitleStyle.Render(fmt.Sprintf("OpenRadar v%s", d.version))
+	title := TitleStyle.Render("OpenRadar v" + d.version)
 
 	httpStatus := statusIndicator(d.httpRunning, "HTTP")
 	wsStatus := statusIndicator(d.wsRunning, "WS")
@@ -526,7 +527,7 @@ func (d *Dashboard) renderHeader() string {
 	status := fmt.Sprintf("%s %s %s", httpStatus, wsStatus, captureStatus)
 
 	// Mode and capture interfaces
-	mode := ModeStyle.Render(fmt.Sprintf("Mode: %s", d.mode))
+	mode := ModeStyle.Render("Mode: " + d.mode)
 	captureLine := "Capture: " + formatCaptureLine(d.captureInterfaces)
 	adapter := TimestampStyle.Render(captureLine)
 
@@ -540,7 +541,7 @@ func (d *Dashboard) renderHeader() string {
 	wsURL := URLStyle.Render(wsLine)
 
 	// Started time
-	startedAt := TimestampStyle.Render(fmt.Sprintf("Started: %s", d.startTime.Format("15:04:05")))
+	startedAt := TimestampStyle.Render("Started: " + d.startTime.Format("15:04:05"))
 
 	// Tabs
 	tabs := d.renderTabs()
@@ -609,11 +610,11 @@ func (d *Dashboard) renderFooter() string {
 		StatLabelStyle.Render("Batch:"),
 		StatValueStyle.Render(fmt.Sprintf("%s/%s", formatNumber(d.wsBatches), formatNumber(d.wsMessages))),
 		StatLabelStyle.Render("WS:"),
-		StatValueStyle.Render(fmt.Sprintf("%d", d.wsClients)),
+		StatValueStyle.Render(strconv.Itoa(d.wsClients)),
 		StatLabelStyle.Render("Err:"),
 		StatValueStyle.Render(formatNumber(d.errors)),
 		StatLabelStyle.Render("Logs:"),
-		StatValueStyle.Render(fmt.Sprintf("%d", len(d.logs))),
+		StatValueStyle.Render(strconv.Itoa(len(d.logs))),
 	)
 
 	// Filter and scroll status
@@ -623,7 +624,7 @@ func (d *Dashboard) renderFooter() string {
 		scrollStr = " | " + ModeStyle.Render("PAUSED")
 	}
 	if d.searchQuery != "" {
-		scrollStr += " | " + URLStyle.Render(fmt.Sprintf("Search: %s", d.searchQuery))
+		scrollStr += " | " + URLStyle.Render("Search: "+d.searchQuery)
 	}
 	statusLine := filterStr + scrollStr
 
@@ -703,12 +704,12 @@ func (d *Dashboard) renderStatsView() string {
 		stat("Err rate:", fmt.Sprintf("%.2f%%", errorRate), d.getErrorColor(errorRate)),
 		"",
 		section("🔌", "WebSocket"),
-		stat("Clients:", fmt.Sprintf("%d", d.wsClients), ColorPrimary),
+		stat("Clients:", strconv.Itoa(d.wsClients), ColorPrimary),
 		stat("Batches:", formatNumber(d.wsBatches), ColorSuccess),
 		stat("Batch/s:", fmt.Sprintf("%.0f", batchesPerSec), ColorPrimary),
 		stat("Messages:", formatNumber(d.wsMessages), ColorSuccess),
 		stat("Avg/batch:", fmt.Sprintf("%.1f", avgMsgsPerBatch), ColorWarning),
-		stat("Queue:", fmt.Sprintf("%d", d.wsQueueSize), d.getQueueColor()),
+		stat("Queue:", strconv.Itoa(d.wsQueueSize), d.getQueueColor()),
 		"",
 		section("📡", "Traffic"),
 		stat("RX total:", formatBytes(d.bytesReceived), ColorPrimary),
@@ -734,7 +735,7 @@ func (d *Dashboard) renderStatsView() string {
 		section("📝", "Logging"),
 		stat("Entries:", formatNumber(d.logEntries), ColorSuccess),
 		stat("Batches:", formatNumber(d.logBatches), ColorPrimary),
-		stat("Buffer:", fmt.Sprintf("%d", d.logBufferSize), ColorWarning),
+		stat("Buffer:", strconv.Itoa(d.logBufferSize), ColorWarning),
 	}
 
 	colWidth := (d.width - 4) / 2
@@ -844,7 +845,7 @@ func renderSparkline[T uint64 | float64](data []T, color lipgloss.Color) string 
 	if len(data) > sparklineDisplayLen {
 		displayData = make([]T, sparklineDisplayLen)
 		ratio := float64(len(data)) / float64(sparklineDisplayLen)
-		for i := 0; i < sparklineDisplayLen; i++ {
+		for i := range sparklineDisplayLen {
 			// Average the values in each bucket
 			start := int(float64(i) * ratio)
 			end := int(float64(i+1) * ratio)
@@ -922,7 +923,7 @@ func avgVal[T uint64 | float64](data []T) float64 {
 }
 
 func formatNumber(n uint64) string {
-	str := fmt.Sprintf("%d", n)
+	str := strconv.FormatUint(n, 10)
 	if len(str) <= 3 {
 		return str
 	}

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -527,14 +527,7 @@ func (d *Dashboard) renderHeader() string {
 
 	// Mode and capture interfaces
 	mode := ModeStyle.Render(fmt.Sprintf("Mode: %s", d.mode))
-	captureLine := "Capture: (awaiting)"
-	if len(d.captureInterfaces) > 0 {
-		parts := make([]string, 0, len(d.captureInterfaces))
-		for _, c := range d.captureInterfaces {
-			parts = append(parts, fmt.Sprintf("%s (%s)", c.Description, c.Address))
-		}
-		captureLine = "Capture: " + strings.Join(parts, ", ")
-	}
+	captureLine := "Capture: " + formatCaptureLine(d.captureInterfaces)
 	adapter := TimestampStyle.Render(captureLine)
 
 	httpLine := d.serverURL
@@ -805,7 +798,7 @@ func (d *Dashboard) renderConfigView() string {
 		cfgLine("Mode:", d.mode, ModeStyle),
 		cfgLine("HTTP URL:", d.serverURL, URLStyle),
 		cfgLine("WS URL:", d.wsURL, URLStyle),
-		cfgLine("Capture:", captureSummary(d.captureInterfaces), StatValueStyle),
+		cfgLine("Capture:", formatCaptureLine(d.captureInterfaces), StatValueStyle),
 		cfgLine("LAN:", strings.Join(d.lanAddresses, ", "), StatValueStyle),
 		"",
 		section("ℹ️", "About"),
@@ -957,7 +950,7 @@ func formatBytes(b uint64) string {
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
-func captureSummary(summaries []CaptureSummary) string {
+func formatCaptureLine(summaries []CaptureSummary) string {
 	if len(summaries) == 0 {
 		return "(awaiting)"
 	}

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -30,8 +30,51 @@ func TestCaptureStateMsgUpdatesFields(t *testing.T) {
 	}
 }
 
-func TestCaptureSummaryEmpty(t *testing.T) {
-	if got := captureSummary(nil); got != "(awaiting)" {
-		t.Errorf("captureSummary(nil) = %q, want '(awaiting)'", got)
+func TestCaptureStateMsgClearsLANUrlsWhenEmpty(t *testing.T) {
+	d := NewDashboard("v0", 5001, true, []string{"192.168.1.42"}, nil)
+	if d.lanServerURL == "" {
+		t.Fatal("expected non-empty lanServerURL after init with LAN address")
+	}
+	msg := CaptureStateMsg{
+		Active:       []CaptureSummary{},
+		LanAddresses: nil,
+		Status:       "awaiting_interfaces",
+	}
+	updated, _ := d.Update(msg)
+	out, ok := updated.(Dashboard)
+	if !ok {
+		t.Fatal("Update did not return Dashboard")
+	}
+	if out.lanServerURL != "" {
+		t.Errorf("lanServerURL should be cleared, got %q", out.lanServerURL)
+	}
+	if out.lanWsURL != "" {
+		t.Errorf("lanWsURL should be cleared, got %q", out.lanWsURL)
+	}
+	if out.captureStatus != "awaiting_interfaces" {
+		t.Errorf("status=%q, want awaiting_interfaces", out.captureStatus)
+	}
+}
+
+func TestFormatCaptureLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []CaptureSummary
+		want string
+	}{
+		{"nil", nil, "(awaiting)"},
+		{"empty slice", []CaptureSummary{}, "(awaiting)"},
+		{"one", []CaptureSummary{{Description: "Wi-Fi", Address: "10.0.0.1"}}, "Wi-Fi (10.0.0.1)"},
+		{"two", []CaptureSummary{
+			{Description: "Wi-Fi", Address: "10.0.0.1"},
+			{Description: "Ethernet", Address: "10.0.0.2"},
+		}, "Wi-Fi (10.0.0.1), Ethernet (10.0.0.2)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatCaptureLine(tc.in); got != tc.want {
+				t.Errorf("formatCaptureLine(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestCaptureStateMsgUpdatesFields(t *testing.T) {
+	d := NewDashboard("v0", 5001, true, nil, nil)
+	msg := CaptureStateMsg{
+		Active: []CaptureSummary{
+			{Description: "Wi-Fi", Address: "192.168.1.42", Category: "wifi"},
+			{Description: "Realtek", Address: "192.168.1.10", Category: "ethernet"},
+		},
+		LanAddresses: []string{"192.168.1.42", "192.168.1.10"},
+		Status:       "running",
+	}
+	updated, _ := d.Update(msg)
+	out, ok := updated.(Dashboard)
+	if !ok {
+		t.Fatal("Update did not return Dashboard")
+	}
+	if len(out.captureInterfaces) != 2 {
+		t.Errorf("captureInterfaces len=%d, want 2", len(out.captureInterfaces))
+	}
+	if out.captureStatus != "running" {
+		t.Errorf("status=%q, want running", out.captureStatus)
+	}
+	if out.lanServerURL == "" {
+		t.Error("lanServerURL not derived from first LAN address")
+	}
+}
+
+func TestCaptureSummaryEmpty(t *testing.T) {
+	if got := captureSummary(nil); got != "(awaiting)" {
+		t.Errorf("captureSummary(nil) = %q, want '(awaiting)'", got)
+	}
+}

--- a/tools/photon-dump/main.go
+++ b/tools/photon-dump/main.go
@@ -1,12 +1,14 @@
 // photon-dump extracts per-scenario fixtures from an anonymized Photon pcap.
 //
 // Produces two corpora:
-//   internal/photon/testdata/<handler>/<scenario>.pcap  (small anonymized pcap fragments)
-//   web/scripts/__fixtures__/ws/<handler>/<scenario>.json  (WS-level JSON for Vitest)
+//
+//	internal/photon/testdata/<handler>/<scenario>.pcap  (small anonymized pcap fragments)
+//	web/scripts/__fixtures__/ws/<handler>/<scenario>.json  (WS-level JSON for Vitest)
 //
 // Usage:
-//   photon-dump -in capture.anon.pcap -out-go internal/photon/testdata -out-js web/scripts/__fixtures__/ws
-//   photon-dump -in capture.anon.pcap -inventory docs/technical/PROTOCOL18_OBSERVED_CODES.md
+//
+//	photon-dump -in capture.anon.pcap -out-go internal/photon/testdata -out-js web/scripts/__fixtures__/ws
+//	photon-dump -in capture.anon.pcap -inventory docs/technical/PROTOCOL18_OBSERVED_CODES.md
 package main
 
 import (

--- a/tools/photon-dump/matcher_test.go
+++ b/tools/photon-dump/matcher_test.go
@@ -3,8 +3,9 @@ package main
 import (
 	"testing"
 
-	"github.com/nospy/albion-openradar/internal/photon"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nospy/albion-openradar/internal/photon"
 )
 
 func TestMatchEvent_CodeOnly(t *testing.T) {

--- a/web/scripts/handlers/NetworkSettingsHandler.js
+++ b/web/scripts/handlers/NetworkSettingsHandler.js
@@ -1,0 +1,124 @@
+const BADGES = {
+    wifi: '🛜', ethernet: '🔌', exitlag: '🚀', vpn: '🔒', virtual: '🧪', other: '•',
+};
+const BADGE_LABEL = {
+    wifi: 'WiFi', ethernet: 'Ethernet', exitlag: 'ExitLag', vpn: 'VPN', virtual: 'Virtual', other: 'Other',
+};
+
+export class NetworkSettingsHandler {
+    constructor(container) {
+        this.container = container;
+        this.interfaces = [];
+        this.state = null;
+    }
+
+    async load() {
+        const [ifacesRes, stateRes] = await Promise.all([
+            fetch('/api/network/interfaces'),
+            fetch('/api/network/state'),
+        ]);
+        if (!ifacesRes.ok || !stateRes.ok) {
+            this.container.innerHTML = `<div class="alert alert-error">Failed to load network configuration.</div>`;
+            return;
+        }
+        this.interfaces = await ifacesRes.json();
+        this.state = await stateRes.json();
+        this.render();
+    }
+
+    render() {
+        const activeNames = new Set((this.state?.captureInterfaces ?? []).map(c => c.name));
+        const banner = this.renderBanner();
+        const rows = this.interfaces.map(i => this.renderRow(i, activeNames.has(i.name))).join('');
+        const lan = (this.state?.lanAddresses ?? []).map(a =>
+            `<li><a data-lan-url href="http://${a}:5001/" target="_blank" class="link link-primary">http://${a}:5001/</a></li>`
+        ).join('');
+        this.container.innerHTML = `
+            ${banner}
+            <h3 class="text-base font-semibold mt-2">Capture interfaces</h3>
+            <p class="text-sm opacity-70 mb-2">Captured packets are merged across all checked interfaces. Tick at least one to start capture.</p>
+            <div class="flex flex-col gap-1">${rows}</div>
+            <div class="flex gap-2 mt-3">
+                <button class="btn btn-sm" data-action="refresh">Refresh list</button>
+                <button class="btn btn-sm btn-primary" data-action="apply" disabled>Apply changes</button>
+            </div>
+            <h3 class="text-base font-semibold mt-6">LAN access</h3>
+            <p class="text-sm opacity-70">Reachable from devices on the same local network. Independent of the capture interfaces above.</p>
+            <ul class="list-disc pl-5">${lan || '<li class="opacity-60">No LAN address detected.</li>'}</ul>
+        `;
+        this.bindEvents();
+    }
+
+    renderBanner() {
+        if (this.state?.status === 'awaiting_interfaces') {
+            return `<div class="alert alert-warning mb-2">⚠ Capture not running. Pick at least one interface below to start.</div>`;
+        }
+        const n = (this.state?.captureInterfaces ?? []).length;
+        return `<div class="alert alert-success mb-2">✓ Capturing on ${n} interface${n > 1 ? 's' : ''}.</div>`;
+    }
+
+    renderRow(iface, checked) {
+        const badge = BADGES[iface.category] ?? BADGES.other;
+        const label = BADGE_LABEL[iface.category] ?? BADGE_LABEL.other;
+        const unavail = iface.isAvailable ? '' : ' <span class="opacity-60">(unavailable)</span>';
+        return `
+            <label class="flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-base-300/40" data-iface="${iface.name}">
+                <input type="checkbox" class="checkbox checkbox-sm" ${checked ? 'checked' : ''} ${iface.isAvailable ? '' : 'disabled'}>
+                <span class="badge badge-outline">${badge} ${label}</span>
+                <span class="flex-1">${escapeHTML(iface.description || iface.name)}${unavail}</span>
+                <span class="opacity-60 text-sm">${iface.address || ''}</span>
+            </label>
+        `;
+    }
+
+    bindEvents() {
+        for (const cb of this.container.querySelectorAll('[data-iface] input')) {
+            cb.addEventListener('change', () => this.updateApplyState());
+        }
+        const applyBtn = this.container.querySelector('[data-action="apply"]');
+        applyBtn?.addEventListener('click', () => this.apply());
+        const refreshBtn = this.container.querySelector('[data-action="refresh"]');
+        refreshBtn?.addEventListener('click', () => this.refresh());
+    }
+
+    updateApplyState() {
+        const selected = this.selectedNames();
+        const current = (this.state?.captureInterfaces ?? []).map(c => c.name).sort();
+        const same = JSON.stringify([...selected].sort()) === JSON.stringify(current);
+        const btn = this.container.querySelector('[data-action="apply"]');
+        if (btn) btn.disabled = same;
+    }
+
+    selectedNames() {
+        return [...this.container.querySelectorAll('[data-iface] input:checked')]
+            .map(cb => cb.closest('[data-iface]').dataset.iface);
+    }
+
+    async apply() {
+        const names = this.selectedNames();
+        const res = await fetch('/api/network/interfaces', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({names}),
+        });
+        if (!res.ok) {
+            const txt = await res.text();
+            window.toast?.error?.(`Apply failed: ${txt}`);
+            return;
+        }
+        window.toast?.success?.('Capture interfaces updated.');
+        await this.load();
+    }
+
+    async refresh() {
+        const r = await fetch('/api/network/refresh', {method: 'POST'});
+        if (r.ok) {
+            this.interfaces = await r.json();
+            this.render();
+        }
+    }
+}
+
+function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+}

--- a/web/scripts/handlers/NetworkSettingsHandler.js
+++ b/web/scripts/handlers/NetworkSettingsHandler.js
@@ -30,9 +30,10 @@ export class NetworkSettingsHandler {
         const activeNames = new Set((this.state?.captureInterfaces ?? []).map(c => c.name));
         const banner = this.renderBanner();
         const rows = this.interfaces.map(i => this.renderRow(i, activeNames.has(i.name))).join('');
-        const lan = (this.state?.lanAddresses ?? []).map(a =>
-            `<li><a data-lan-url href="http://${a}:5001/" target="_blank" class="link link-primary">http://${a}:5001/</a></li>`
-        ).join('');
+        const lan = (this.state?.lanAddresses ?? []).map(a => {
+            const safe = escapeHTML(a);
+            return `<li><a data-lan-url href="http://${safe}:5001/" target="_blank" rel="noopener noreferrer" class="link link-primary">http://${safe}:5001/</a></li>`;
+        }).join('');
         this.container.innerHTML = `
             ${banner}
             <h3 class="text-base font-semibold mt-2">Capture interfaces</h3>
@@ -62,11 +63,11 @@ export class NetworkSettingsHandler {
         const label = BADGE_LABEL[iface.category] ?? BADGE_LABEL.other;
         const unavail = iface.isAvailable ? '' : ' <span class="opacity-60">(unavailable)</span>';
         return `
-            <label class="flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-base-300/40" data-iface="${iface.name}">
+            <label class="flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-base-300/40" data-iface="${escapeHTML(iface.name)}">
                 <input type="checkbox" class="checkbox checkbox-sm" ${checked ? 'checked' : ''} ${iface.isAvailable ? '' : 'disabled'}>
                 <span class="badge badge-outline">${badge} ${label}</span>
                 <span class="flex-1">${escapeHTML(iface.description || iface.name)}${unavail}</span>
-                <span class="opacity-60 text-sm">${iface.address || ''}</span>
+                <span class="opacity-60 text-sm">${escapeHTML(iface.address || '')}</span>
             </label>
         `;
     }
@@ -82,9 +83,9 @@ export class NetworkSettingsHandler {
     }
 
     updateApplyState() {
-        const selected = this.selectedNames();
+        const selected = [...this.selectedNames()].sort();
         const current = (this.state?.captureInterfaces ?? []).map(c => c.name).sort();
-        const same = JSON.stringify([...selected].sort()) === JSON.stringify(current);
+        const same = selected.length === current.length && selected.every((n, i) => n === current[i]);
         const btn = this.container.querySelector('[data-action="apply"]');
         if (btn) btn.disabled = same;
     }
@@ -95,26 +96,40 @@ export class NetworkSettingsHandler {
     }
 
     async apply() {
-        const names = this.selectedNames();
-        const res = await fetch('/api/network/interfaces', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({names}),
-        });
-        if (!res.ok) {
-            const txt = await res.text();
-            window.toast?.error?.(`Apply failed: ${txt}`);
-            return;
+        const btn = this.container.querySelector('[data-action="apply"]');
+        if (btn?.disabled) return;
+        if (btn) btn.disabled = true;
+        try {
+            const names = this.selectedNames();
+            const res = await fetch('/api/network/interfaces', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({names}),
+            });
+            if (!res.ok) {
+                const txt = await res.text();
+                window.toast?.error?.(`Apply failed: ${txt}`);
+                if (btn) btn.disabled = false;
+                return;
+            }
+            window.toast?.success?.('Capture interfaces updated.');
+            await this.load();
+        } catch (err) {
+            window.toast?.error?.(`Network error: ${err.message ?? err}`);
+            if (btn) btn.disabled = false;
         }
-        window.toast?.success?.('Capture interfaces updated.');
-        await this.load();
     }
 
     async refresh() {
-        const r = await fetch('/api/network/refresh', {method: 'POST'});
-        if (r.ok) {
-            this.interfaces = await r.json();
-            this.render();
+        try {
+            const r = await fetch('/api/network/refresh', {method: 'POST'});
+            if (!r.ok) {
+                window.toast?.error?.('Refresh failed.');
+                return;
+            }
+            await this.load();
+        } catch (err) {
+            window.toast?.error?.(`Refresh error: ${err.message ?? err}`);
         }
     }
 }

--- a/web/scripts/handlers/_NetworkSettingsHandler.test.js
+++ b/web/scripts/handlers/_NetworkSettingsHandler.test.js
@@ -127,4 +127,100 @@ describe('NetworkSettingsHandler', () => {
 
         expect(container.textContent).toMatch(/Capturing on 2 interface/i);
     });
+
+    test('apply enables when current is non-empty and user clears selection', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ([
+                    {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: true, isAvailable: true},
+                ]),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [{name: 'a'}], lanAddresses: [], status: 'running'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        let btn = container.querySelector('[data-action="apply"]');
+        expect(btn.disabled).toBe(true);
+
+        container.querySelector('[data-iface="a"] input').click();
+        btn = container.querySelector('[data-action="apply"]');
+        expect(btn.disabled).toBe(false);
+    });
+
+    test('apply shows error toast on backend 400', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => [
+                {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: false, isAvailable: true},
+            ]})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: [], status: 'awaiting_interfaces'})})
+            .mockResolvedValueOnce({ok: false, status: 400, text: async () => 'unknown interface names: [zzz]'});
+
+        const errorToast = vi.fn();
+        window.toast = {error: errorToast, success: vi.fn()};
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+        container.querySelector('[data-iface="a"] input').click();
+        await h.apply();
+
+        expect(errorToast).toHaveBeenCalledWith(expect.stringContaining('unknown interface names'));
+    });
+
+    test('apply handles network failure (fetch throws)', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => [
+                {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: false, isAvailable: true},
+            ]})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: [], status: 'awaiting_interfaces'})})
+            .mockRejectedValueOnce(new Error('connection refused'));
+
+        const errorToast = vi.fn();
+        window.toast = {error: errorToast, success: vi.fn()};
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+        container.querySelector('[data-iface="a"] input').click();
+        await h.apply();
+
+        expect(errorToast).toHaveBeenCalledWith(expect.stringContaining('connection refused'));
+    });
+
+    test('refresh refetches both endpoints', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => []})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: [], status: 'awaiting_interfaces'})})
+            .mockResolvedValueOnce({ok: true, json: async () => null})
+            .mockResolvedValueOnce({ok: true, json: async () => [
+                {name: 'new', description: 'Brand new iface', address: '10.0.0.99', category: 'ethernet', isPersisted: false, isAvailable: true},
+            ]})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: ['10.0.0.99'], status: 'awaiting_interfaces'})});
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+        await h.refresh();
+
+        const rows = container.querySelectorAll('[data-iface]');
+        expect(rows.length).toBe(1);
+        expect(container.querySelector('[data-iface="new"]')).toBeTruthy();
+    });
+
+    test('escapes html in interface description', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => [
+                {name: 'evil', description: '<script>alert(1)</script>', address: '<img>', category: 'wifi', isPersisted: false, isAvailable: true},
+            ]})
+            .mockResolvedValueOnce({ok: true, json: async () => ({captureInterfaces: [], lanAddresses: [], status: 'awaiting_interfaces'})});
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        expect(container.innerHTML).not.toContain('<script>alert(1)</script>');
+        expect(container.innerHTML).not.toContain('<img>');
+        expect(container.textContent).toContain('alert(1)');
+    });
 });

--- a/web/scripts/handlers/_NetworkSettingsHandler.test.js
+++ b/web/scripts/handlers/_NetworkSettingsHandler.test.js
@@ -1,0 +1,130 @@
+// synthetic: inline mock fetch responses
+import {describe, test, expect, beforeEach, vi, afterEach} from 'vitest';
+
+const {NetworkSettingsHandler} = await import('./NetworkSettingsHandler.js');
+
+describe('NetworkSettingsHandler', () => {
+    let container;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="network-section"></div>';
+        container = document.getElementById('network-section');
+        globalThis.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    test('renders one row per interface with badge and current selection', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ([
+                    {name: 'a', description: 'Wi-Fi', address: '192.168.1.1', category: 'wifi', isPersisted: true, isAvailable: true},
+                    {name: 'b', description: 'TAP-Windows', address: '10.8.0.1', category: 'vpn', isPersisted: false, isAvailable: true},
+                ]),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [{name: 'a'}], lanAddresses: ['192.168.1.5'], status: 'running'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        const rows = container.querySelectorAll('[data-iface]');
+        expect(rows.length).toBe(2);
+
+        const wifiRow = container.querySelector('[data-iface="a"]');
+        expect(wifiRow.textContent).toContain('Wi-Fi');
+        expect(wifiRow.querySelector('input[type="checkbox"]').checked).toBe(true);
+
+        const vpnRow = container.querySelector('[data-iface="b"]');
+        expect(vpnRow.querySelector('input[type="checkbox"]').checked).toBe(false);
+    });
+
+    test('apply submits selected names to backend and refetches state', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ([
+                    {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: true, isAvailable: true},
+                    {name: 'b', description: 'Eth', address: '2', category: 'ethernet', isPersisted: false, isAvailable: true},
+                ]),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [{name: 'a'}], lanAddresses: [], status: 'running'}),
+            })
+            .mockResolvedValueOnce({ok: true, json: async () => ({status: 'ok'})})
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ([
+                    {name: 'a', description: 'Wi-Fi', address: '1', category: 'wifi', isPersisted: true, isAvailable: true},
+                    {name: 'b', description: 'Eth', address: '2', category: 'ethernet', isPersisted: true, isAvailable: true},
+                ]),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [{name: 'a'}, {name: 'b'}], lanAddresses: [], status: 'running'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        container.querySelector('[data-iface="b"] input').click();
+        await h.apply();
+
+        const post = globalThis.fetch.mock.calls.find(c => c[0] === '/api/network/interfaces' && c[1]?.method === 'POST');
+        expect(post).toBeDefined();
+        const body = JSON.parse(post[1].body);
+        expect(body.names.sort()).toEqual(['a', 'b']);
+    });
+
+    test('renders LAN addresses as clickable URLs', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => []})
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [], lanAddresses: ['192.168.1.5', '10.0.0.3'], status: 'awaiting_interfaces'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        const links = container.querySelectorAll('[data-lan-url]');
+        expect(links.length).toBe(2);
+        expect(links[0].href).toContain('192.168.1.5');
+        expect(links[1].href).toContain('10.0.0.3');
+    });
+
+    test('shows awaiting banner when capture is not running', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => []})
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [], lanAddresses: [], status: 'awaiting_interfaces'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        expect(container.textContent).toContain('Capture not running');
+    });
+
+    test('shows success banner when capturing on N interfaces', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ok: true, json: async () => []})
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({captureInterfaces: [{name: 'a'}, {name: 'b'}], lanAddresses: [], status: 'running'}),
+            });
+
+        const h = new NetworkSettingsHandler(container);
+        await h.load();
+
+        expect(container.textContent).toMatch(/Capturing on 2 interface/i);
+    });
+});


### PR DESCRIPTION
## Summary

Replaces IP-keyed `ip.txt` + single-handle pcap with a multi-interface `capture.Manager` keyed by `{name, description}`, capturing on every candidate interface so ExitLag re-routing between physical NICs no longer breaks detection. Dynamic add/remove from Settings via 4 endpoints (POST is loopback-only). One-shot `ip.txt` migration; cross-platform interface categorization (wifi/ethernet/exitlag/vpn/virtual/other).

Refs #91 (does not close: the ExitLag default case where the client routes via Winsock-hooked UDP localhost is out of scope here and tracked in a follow-up).

## Test plan

- [ ] Cold start, no `network.json`: auto-pick fires, radar captures
- [ ] Legacy `ip.txt` present: migrated to `network.json`, `ip.txt` removed
- [ ] Toggle one interface off mid-session: its worker exits, others keep capturing
- [ ] Phone on LAN: checkboxes read-only, POST `/api/network/interfaces` → 403

## Out of scope (follow-up)

ExitLag's default mode hooks Winsock in `Albion-Online.exe` and tunnels via UDP localhost on dynamic ports. No UDP 5056 traffic exits on any physical NIC, so multi-interface capture cannot help. The follow-up will add an opt-in loopback mode with dynamic Albion-port detection.

<img width="1193" height="950" alt="image" src="https://github.com/user-attachments/assets/4b200bea-2bbf-4a29-a219-0fe674ff76c9" />
