### PR TITLE
fix(90): inherit parent cluster pvpType in Mist instances

### DIFF
--- a/web/scripts/core/EventRouter.js
+++ b/web/scripts/core/EventRouter.js
@@ -72,12 +72,26 @@ function clearMistOverridePersistence() {
     }
 }
 
+function resolveMistOriginId(previousMapId) {
+    if (typeof previousMapId !== 'string' || previousMapId.length === 0) return null;
+    if (!previousMapId.startsWith('@MISTS@')) return previousMapId;
+    const prevOverride = zonesDatabase.getZone(previousMapId);
+    return prevOverride && typeof prevOverride.originZoneId === 'string'
+        ? prevOverride.originZoneId
+        : null;
+}
+
 function applyMapChange(newMapId, logEvent, extraLogFields = {}) {
     const previousMapId = map.id;
     map.id = newMapId;
     window.currentMapId = map.id;
     lastMapChangeTime = Date.now();
-    if (typeof newMapId !== 'string' || !newMapId.startsWith('@MISTS@')) {
+    if (typeof newMapId === 'string' && newMapId.startsWith('@MISTS@')) {
+        const originId = resolveMistOriginId(previousMapId);
+        if (originId && zonesDatabase.setMistOverride(newMapId, originId)) {
+            persistMistOverride(newMapId, originId);
+        }
+    } else {
         zonesDatabase.clearAllMistOverrides();
         clearMistOverridePersistence();
     }
@@ -411,12 +425,7 @@ export function onEvent(Parameters) {
         case EventCodes.MistsPlayerJoinedInfo: {
             const newMapId = Parameters[2];
             if (Parameters[3] === true && typeof newMapId === 'string' && newMapId.length > 0 && newMapId !== map.id) {
-                const originId = Parameters[4];
-                if (typeof originId === 'string' && originId.length > 0
-                    && zonesDatabase.setMistOverride(newMapId, originId)) {
-                    persistMistOverride(newMapId, originId);
-                }
-                applyMapChange(newMapId, 'MistsPlayerJoinedInfo', {originCluster: originId});
+                applyMapChange(newMapId, 'MistsPlayerJoinedInfo', {originCluster: Parameters[4]});
             }
             break;
         }

--- a/web/scripts/core/EventRouter.js
+++ b/web/scripts/core/EventRouter.js
@@ -52,11 +52,35 @@ function persistMapToSession() {
     }
 }
 
+function persistMistOverride(mistMapId, originZoneId) {
+    try {
+        sessionStorage.setItem('activeMistOverride', JSON.stringify({
+            mistMapId,
+            originZoneId,
+            timestamp: Date.now()
+        }));
+    } catch (e) {
+        window.logger?.warn(CATEGORIES.MAP, 'MistOverridePersistFailed', {error: e?.message});
+    }
+}
+
+function clearMistOverridePersistence() {
+    try {
+        sessionStorage.removeItem('activeMistOverride');
+    } catch (e) {
+        window.logger?.warn(CATEGORIES.MAP, 'MistOverrideClearFailed', {error: e?.message});
+    }
+}
+
 function applyMapChange(newMapId, logEvent, extraLogFields = {}) {
     const previousMapId = map.id;
     map.id = newMapId;
     window.currentMapId = map.id;
     lastMapChangeTime = Date.now();
+    if (typeof newMapId !== 'string' || !newMapId.startsWith('@MISTS@')) {
+        zonesDatabase.clearAllMistOverrides();
+        clearMistOverridePersistence();
+    }
     syncMapIsBZ();
     radarRenderer?.setMap?.(map);
     persistMapToSession();
@@ -163,6 +187,24 @@ export function setRadarRenderer(renderer) {
 
 export function getLocalPlayerPosition() {
     return {x: lpX, y: lpY};
+}
+
+export function restoreMistOverrideFromSession() {
+    try {
+        const saved = sessionStorage.getItem('activeMistOverride');
+        if (!saved) return;
+        const data = JSON.parse(saved);
+        if (data && typeof data.mistMapId === 'string' && typeof data.originZoneId === 'string') {
+            zonesDatabase.setMistOverride(data.mistMapId, data.originZoneId);
+            window.logger?.info(CATEGORIES.MAP, 'MistOverrideRestored', {
+                mistMapId: data.mistMapId,
+                originZoneId: data.originZoneId,
+                age: Date.now() - (data.timestamp || 0)
+            });
+        }
+    } catch (e) {
+        window.logger?.warn(CATEGORIES.MAP, 'MistOverrideRestoreFailed', {error: e?.message});
+    }
 }
 
 export function restoreMapFromSession() {
@@ -369,7 +411,12 @@ export function onEvent(Parameters) {
         case EventCodes.MistsPlayerJoinedInfo: {
             const newMapId = Parameters[2];
             if (Parameters[3] === true && typeof newMapId === 'string' && newMapId.length > 0 && newMapId !== map.id) {
-                applyMapChange(newMapId, 'MistsPlayerJoinedInfo', {originCluster: Parameters[4]});
+                const originId = Parameters[4];
+                if (typeof originId === 'string' && originId.length > 0
+                    && zonesDatabase.setMistOverride(newMapId, originId)) {
+                    persistMistOverride(newMapId, originId);
+                }
+                applyMapChange(newMapId, 'MistsPlayerJoinedInfo', {originCluster: originId});
             }
             break;
         }

--- a/web/scripts/core/_EventRouter.test.js
+++ b/web/scripts/core/_EventRouter.test.js
@@ -215,8 +215,11 @@ describe('EventRouter', () => {
         });
 
         // @verified 2026-04-29: source: session log 2026-04-26T14-33-25.jsonl event 519
-        // @MISTS@9f9a62f3-... Parameters[4]="3316" (Battlebrae Flatland, BZ).
-        test('MIST-90: BZ Mist entry registers black-zone override and persists sessionStorage', () => {
+        // @MISTS@9f9a62f3-... fired while map.id was already a BZ. Override origin is taken
+        // from the previous map id, not Parameters[4] (which carries the joining player's origin).
+        test('MIST-90: event 519 entry from BZ registers black-zone override and persists sessionStorage', () => {
+            map.id = '3316';
+
             EventRouter.onEvent({
                 0: 1,
                 252: 519,
@@ -235,8 +238,9 @@ describe('EventRouter', () => {
         });
 
         // @verified 2026-04-29: pcap-derived. Source: fixture mists/player-joined-info.json
-        // message[1] @MISTS@a40183ea-... Parameters[4]="0212" (Bonepool Marsh, yellow Royal).
+        // message[1] @MISTS@a40183ea-... fired from a yellow Royal cluster (Bonepool Marsh "0212").
         test('MIST-90: yellow Royal Mist entry inherits yellow pvpType', async () => {
+            map.id = '0212';
             const fix = await loadFixture('mists', 'player-joined-info');
             const entry = fix.messages.find(m => m.parameters['3'] === true);
             const p = normalizeParams(entry.parameters);
@@ -262,7 +266,8 @@ describe('EventRouter', () => {
 
         // @verified 2026-04-29: synthetic. Origin id absent from zones.json. Protects against
         // upstream zone additions not yet mirrored locally.
-        test('MIST-90: unknown origin does not persist sessionStorage', () => {
+        test('MIST-90: unknown previous map does not persist sessionStorage', () => {
+            map.id = '99999_unknown_zone';
             EventRouter.onEvent({
                 0: 1,
                 252: 519,
@@ -279,6 +284,7 @@ describe('EventRouter', () => {
         // @verified 2026-04-29: synthetic. ChangeClusterResponse with a non-Mist destination is
         // the standard Mist exit path observed in pcap captures.
         test('MIST-90: ChangeClusterResponse to non-Mist clears overrides and sessionStorage', () => {
+            map.id = '3316';
             EventRouter.onEvent({
                 0: 1,
                 252: 519,
@@ -297,8 +303,9 @@ describe('EventRouter', () => {
         });
 
         // @verified 2026-04-29: synthetic. Mist-to-Mist transition observed in session log
-        // 2026-04-26T18-04-27.jsonl (two consecutive @MISTS@ entries from the same origin "0210").
-        test('MIST-90: Mist-to-Mist transition replaces sessionStorage with the latest entry', () => {
+        // 2026-04-26T18-04-27.jsonl (consecutive @MISTS@ entries with the same BZ origin).
+        test('MIST-90: Mist-to-Mist transition keeps the BZ origin via override chaining', () => {
+            map.id = '3316';
             EventRouter.onEvent({
                 0: 1,
                 252: 519,
@@ -311,13 +318,13 @@ describe('EventRouter', () => {
                 252: 519,
                 2: '@MISTS@second',
                 3: true,
-                4: '0212'
+                4: '3316'
             });
 
-            expect(zonesDatabase.getPvpType('@MISTS@second')).toBe('yellow');
+            expect(zonesDatabase.getPvpType('@MISTS@second')).toBe('black');
             const persisted = JSON.parse(sessionStorage.getItem('activeMistOverride'));
             expect(persisted.mistMapId).toBe('@MISTS@second');
-            expect(persisted.originZoneId).toBe('0212');
+            expect(persisted.originZoneId).toBe('3316');
         });
 
         // @verified 2026-04-29: synthetic. Mirrors the F5 sequence (sessionStorage seeded by a
@@ -347,6 +354,61 @@ describe('EventRouter', () => {
 
             expect(() => EventRouter.restoreMistOverrideFromSession()).not.toThrow();
             expect(zonesDatabase.overrides.size).toBe(0);
+        });
+
+        // @verified 2026-04-29: source: session log 2026-04-29T19-23-39.jsonl, sequence
+        // 17:25:32 op 2 Join Parameters[8]="0344" then 17:26:11 op 2 Join
+        // Parameters[8]="@MISTS@b0676408-..." (no event 519 with Parameters[3]=true fired).
+        test('MIST-90: op 2 Join entry into Mist from BZ origin registers black-zone override', () => {
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '0344', 9: [0, 0]}, clearHandlers);
+            expect(map.id).toBe('0344');
+
+            EventRouter.onResponse({
+                253: OperationCodes.Join,
+                8: '@MISTS@b0676408-0f0f-4b0a-8207-3ebd0ad2664f',
+                9: [0, 0]
+            }, clearHandlers);
+
+            expect(zonesDatabase.getPvpType('@MISTS@b0676408-0f0f-4b0a-8207-3ebd0ad2664f')).toBe('black');
+            expect(map.isBZ).toBe(true);
+            const persisted = JSON.parse(sessionStorage.getItem('activeMistOverride'));
+            expect(persisted).toMatchObject({
+                mistMapId: '@MISTS@b0676408-0f0f-4b0a-8207-3ebd0ad2664f',
+                originZoneId: '0344'
+            });
+        });
+
+        // @verified 2026-04-29: synthetic. Mist-to-Mist transition via op 2 Join keeps the
+        // original BZ origin (looked up from the previous override's originZoneId).
+        test('MIST-90: Mist-to-Mist via op 2 Join inherits origin from previous Mist override', () => {
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '0344', 9: [0, 0]}, clearHandlers);
+            EventRouter.onResponse({
+                253: OperationCodes.Join,
+                8: '@MISTS@first',
+                9: [0, 0]
+            }, clearHandlers);
+            EventRouter.onResponse({
+                253: OperationCodes.Join,
+                8: '@MISTS@second',
+                9: [0, 0]
+            }, clearHandlers);
+
+            expect(zonesDatabase.getPvpType('@MISTS@second')).toBe('black');
+            const persisted = JSON.parse(sessionStorage.getItem('activeMistOverride'));
+            expect(persisted.originZoneId).toBe('0344');
+        });
+
+        // @verified 2026-04-29: synthetic. Cold start (map.id === -1, no prior real zone)
+        // means no override can be inferred. Override stays unset until next ChangeCluster.
+        test('MIST-90: op 2 Join into Mist with no known previous map does not register override', () => {
+            EventRouter.onResponse({
+                253: OperationCodes.Join,
+                8: '@MISTS@x',
+                9: [0, 0]
+            }, clearHandlers);
+
+            expect(zonesDatabase.getZone('@MISTS@x')).toBeNull();
+            expect(sessionStorage.getItem('activeMistOverride')).toBeNull();
         });
     });
 

--- a/web/scripts/core/_EventRouter.test.js
+++ b/web/scripts/core/_EventRouter.test.js
@@ -4,6 +4,7 @@ import {fileURLToPath} from 'node:url';
 import {dirname, join} from 'node:path';
 import * as EventRouter from './EventRouter.js';
 import {EventCodes} from '../utils/EventCodes.js';
+import {OperationCodes} from '../utils/OperationCodes.js';
 import {loadFixture, normalizeParams} from '../__fixtures__/loader.js';
 import zonesDatabase from '../data/ZonesDatabase.js';
 
@@ -201,6 +202,151 @@ describe('EventRouter', () => {
             });
 
             expect(radarRenderer.setMap).not.toHaveBeenCalled();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Mist override lifecycle (#90)
+    // -------------------------------------------------------------------------
+    describe('Mist override lifecycle (#90)', () => {
+        beforeEach(() => {
+            sessionStorage.clear();
+            zonesDatabase.clearAllMistOverrides();
+        });
+
+        // @verified 2026-04-29: source: session log 2026-04-26T14-33-25.jsonl event 519
+        // @MISTS@9f9a62f3-... Parameters[4]="3316" (Battlebrae Flatland, BZ).
+        test('MIST-90: BZ Mist entry registers black-zone override and persists sessionStorage', () => {
+            EventRouter.onEvent({
+                0: 1,
+                252: 519,
+                2: '@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5',
+                3: true,
+                4: '3316'
+            });
+
+            expect(zonesDatabase.getPvpType('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe('black');
+            const persisted = JSON.parse(sessionStorage.getItem('activeMistOverride'));
+            expect(persisted).toMatchObject({
+                mistMapId: '@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5',
+                originZoneId: '3316'
+            });
+            expect(typeof persisted.timestamp).toBe('number');
+        });
+
+        // @verified 2026-04-29: pcap-derived. Source: fixture mists/player-joined-info.json
+        // message[1] @MISTS@a40183ea-... Parameters[4]="0212" (Bonepool Marsh, yellow Royal).
+        test('MIST-90: yellow Royal Mist entry inherits yellow pvpType', async () => {
+            const fix = await loadFixture('mists', 'player-joined-info');
+            const entry = fix.messages.find(m => m.parameters['3'] === true);
+            const p = normalizeParams(entry.parameters);
+
+            EventRouter.onEvent(p);
+
+            expect(zonesDatabase.getPvpType('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe('yellow');
+        });
+
+        // @verified 2026-04-29: synthetic. Mirrors the first message of the pcap fixture
+        // (Parameters[2]==Parameters[4], no [3] flag, presence info, not a Mist entry).
+        test('MIST-90: event 519 without Parameters[3] flag does not register override', () => {
+            EventRouter.onEvent({
+                0: 1,
+                252: 519,
+                2: '3316',
+                4: '3316'
+            });
+
+            expect(zonesDatabase.getZone('@MISTS@x')).toBeNull();
+            expect(sessionStorage.getItem('activeMistOverride')).toBeNull();
+        });
+
+        // @verified 2026-04-29: synthetic. Origin id absent from zones.json. Protects against
+        // upstream zone additions not yet mirrored locally.
+        test('MIST-90: unknown origin does not persist sessionStorage', () => {
+            EventRouter.onEvent({
+                0: 1,
+                252: 519,
+                2: '@MISTS@deadbeef',
+                3: true,
+                4: '99999_unknown_zone'
+            });
+
+            expect(zonesDatabase.getZone('@MISTS@deadbeef')).toBeNull();
+            expect(sessionStorage.getItem('activeMistOverride')).toBeNull();
+            expect(map.id).toBe('@MISTS@deadbeef');
+        });
+
+        // @verified 2026-04-29: synthetic. ChangeClusterResponse with a non-Mist destination is
+        // the standard Mist exit path observed in pcap captures.
+        test('MIST-90: ChangeClusterResponse to non-Mist clears overrides and sessionStorage', () => {
+            EventRouter.onEvent({
+                0: 1,
+                252: 519,
+                2: '@MISTS@x',
+                3: true,
+                4: '3316'
+            });
+            expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('black');
+            expect(sessionStorage.getItem('activeMistOverride')).not.toBeNull();
+
+            EventRouter.onResponse({253: OperationCodes.ChangeCluster, 0: '0317'}, clearHandlers);
+
+            expect(zonesDatabase.getZone('@MISTS@x')).toBeNull();
+            expect(sessionStorage.getItem('activeMistOverride')).toBeNull();
+            expect(map.id).toBe('0317');
+        });
+
+        // @verified 2026-04-29: synthetic. Mist-to-Mist transition observed in session log
+        // 2026-04-26T18-04-27.jsonl (two consecutive @MISTS@ entries from the same origin "0210").
+        test('MIST-90: Mist-to-Mist transition replaces sessionStorage with the latest entry', () => {
+            EventRouter.onEvent({
+                0: 1,
+                252: 519,
+                2: '@MISTS@first',
+                3: true,
+                4: '3316'
+            });
+            EventRouter.onEvent({
+                0: 2,
+                252: 519,
+                2: '@MISTS@second',
+                3: true,
+                4: '0212'
+            });
+
+            expect(zonesDatabase.getPvpType('@MISTS@second')).toBe('yellow');
+            const persisted = JSON.parse(sessionStorage.getItem('activeMistOverride'));
+            expect(persisted.mistMapId).toBe('@MISTS@second');
+            expect(persisted.originZoneId).toBe('0212');
+        });
+
+        // @verified 2026-04-29: synthetic. Mirrors the F5 sequence (sessionStorage seeded by a
+        // prior session, reload triggers restoreMistOverrideFromSession before init).
+        test('MIST-90: restoreMistOverrideFromSession reapplies persisted override on F5', () => {
+            sessionStorage.setItem('activeMistOverride', JSON.stringify({
+                mistMapId: '@MISTS@x',
+                originZoneId: '3316',
+                timestamp: Date.now()
+            }));
+
+            EventRouter.restoreMistOverrideFromSession();
+
+            expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('black');
+        });
+
+        // @verified 2026-04-29: synthetic. Cold start (no prior session).
+        test('MIST-90: restoreMistOverrideFromSession with empty sessionStorage is a no-op', () => {
+            EventRouter.restoreMistOverrideFromSession();
+
+            expect(zonesDatabase.overrides.size).toBe(0);
+        });
+
+        // @verified 2026-04-29: synthetic. Defensive against sessionStorage tampering or partial writes.
+        test('MIST-90: corrupted sessionStorage payload does not throw', () => {
+            sessionStorage.setItem('activeMistOverride', '{not-json');
+
+            expect(() => EventRouter.restoreMistOverrideFromSession()).not.toThrow();
+            expect(zonesDatabase.overrides.size).toBe(0);
         });
     });
 

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -3,6 +3,7 @@ import { CATEGORIES } from "../constants/LoggerConstants.js";
 export class ZonesDatabase {
   constructor() {
     this.zones = {};
+    this.overrides = new Map();
     this.loaded = false;
     this.stats = {
       totalZones: 0,
@@ -62,11 +63,40 @@ export class ZonesDatabase {
   getZone(zoneId) {
     if (!zoneId) return null;
     const id = String(zoneId);
+    if (this.overrides.has(id)) return this.overrides.get(id);
     // Try exact match first (handles TNL-XXX, YOURNAME-HIDEOUT, etc.)
     if (this.zones[id]) return this.zones[id];
     // Fallback: try base ID for compound numeric IDs like "1234-5"
     const baseId = id.split("-")[0];
     return this.zones[baseId] || null;
+  }
+
+  setMistOverride(mistMapId, originZoneId) {
+    const origin = this.getZone(originZoneId);
+    if (!origin) {
+      window.logger?.warn(CATEGORIES.MAP, "MistOverrideUnknownOrigin", {
+        mistMapId,
+        originZoneId,
+      });
+      return false;
+    }
+    this.overrides.set(String(mistMapId), {
+      name: `Mist of ${origin.name}`,
+      type: "MISTS",
+      pvpType: origin.pvpType,
+      tier: origin.tier,
+      file: origin.file,
+      originZoneId: String(originZoneId),
+    });
+    return true;
+  }
+
+  clearMistOverride(mapId) {
+    this.overrides.delete(String(mapId));
+  }
+
+  clearAllMistOverrides() {
+    this.overrides.clear();
   }
 
   getPvpType(zoneId) {

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -84,7 +84,7 @@ export class ZonesDatabase {
       name: `Mist of ${origin.name}`,
       type: "MISTS",
       pvpType: origin.pvpType,
-      tier: origin.tier,
+      tier: 0,
       file: origin.file,
       originZoneId: String(originZoneId),
     });

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -1,0 +1,100 @@
+import {describe, test, expect, beforeAll, beforeEach} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, join} from 'node:path';
+import zonesDatabase from './ZonesDatabase.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const zonesJsonPath = join(here, '..', '..', 'ao-bin-dumps', 'zones.json');
+
+beforeAll(() => {
+    zonesDatabase.zones = JSON.parse(readFileSync(zonesJsonPath, 'utf8'));
+    zonesDatabase.loaded = true;
+});
+
+describe('ZonesDatabase mist overrides', () => {
+    beforeEach(() => {
+        zonesDatabase.clearAllMistOverrides();
+    });
+
+    // @verified 2026-04-29: source: session log 2026-04-26T14-33-25.jsonl event 519
+    // @MISTS@9f9a62f3-... Parameters[4]="3316" (Battlebrae Flatland, BZ T5).
+    test('setMistOverride from BZ origin synthesizes a black-zone clone', () => {
+        const ok = zonesDatabase.setMistOverride('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5', '3316');
+
+        expect(ok).toBe(true);
+        const zone = zonesDatabase.getZone('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5');
+        expect(zone).toEqual(expect.objectContaining({
+            pvpType: 'black',
+            tier: 5,
+            type: 'MISTS',
+            name: 'Mist of Battlebrae Flatland',
+            originZoneId: '3316'
+        }));
+        expect(zonesDatabase.getPvpType('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe('black');
+        expect(zonesDatabase.getZoneName('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5'))
+            .toBe('Mist of Battlebrae Flatland');
+        expect(zonesDatabase.getZoneTier('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe(5);
+    });
+
+    // @verified 2026-04-29: source: fixture mists/player-joined-info.json Parameters[4]="0212"
+    // (Bonepool Marsh, yellow Royal T6). Pairs with the BZ test for variant coverage.
+    test('setMistOverride from yellow Royal origin inherits yellow pvpType', () => {
+        const ok = zonesDatabase.setMistOverride('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434', '0212');
+
+        expect(ok).toBe(true);
+        expect(zonesDatabase.getPvpType('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe('yellow');
+        expect(zonesDatabase.getZoneTier('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe(6);
+    });
+
+    // @verified 2026-04-29: synthetic. Origin id absent from zones.json.
+    test('setMistOverride returns false on unknown origin', () => {
+        const ok = zonesDatabase.setMistOverride('@MISTS@deadbeef', '99999_unknown_zone');
+
+        expect(ok).toBe(false);
+        expect(zonesDatabase.getZone('@MISTS@deadbeef')).toBeNull();
+        expect(zonesDatabase.getPvpType('@MISTS@deadbeef')).toBe('safe');
+    });
+
+    // @verified 2026-04-29: synthetic. Independence between override map and base zones map.
+    test('real zones unaffected by registered overrides', () => {
+        zonesDatabase.setMistOverride('@MISTS@x', '3316');
+
+        expect(zonesDatabase.getPvpType('3316')).toBe('black');
+        expect(zonesDatabase.getZoneName('3316')).toBe('Battlebrae Flatland');
+        expect(zonesDatabase.getPvpType('1000')).toBe('safe');
+        expect(zonesDatabase.getZoneName('1000')).toBe('Lymhurst');
+    });
+
+    // @verified 2026-04-29: synthetic.
+    test('clearMistOverride removes only the targeted entry', () => {
+        zonesDatabase.setMistOverride('@MISTS@x', '3316');
+        zonesDatabase.setMistOverride('@MISTS@y', '0212');
+
+        zonesDatabase.clearMistOverride('@MISTS@x');
+
+        expect(zonesDatabase.getZone('@MISTS@x')).toBeNull();
+        expect(zonesDatabase.getPvpType('@MISTS@y')).toBe('yellow');
+    });
+
+    // @verified 2026-04-29: synthetic.
+    test('clearAllMistOverrides empties the override map', () => {
+        zonesDatabase.setMistOverride('@MISTS@x', '3316');
+        zonesDatabase.setMistOverride('@MISTS@y', '0212');
+
+        zonesDatabase.clearAllMistOverrides();
+
+        expect(zonesDatabase.getZone('@MISTS@x')).toBeNull();
+        expect(zonesDatabase.getZone('@MISTS@y')).toBeNull();
+    });
+
+    // @verified 2026-04-29: synthetic. Mist-to-Mist transition path.
+    test('setMistOverride replaces previous entry on duplicate key', () => {
+        zonesDatabase.setMistOverride('@MISTS@x', '3316');
+        expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('black');
+
+        zonesDatabase.setMistOverride('@MISTS@x', '0212');
+
+        expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('yellow');
+    });
+});

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -18,15 +18,16 @@ describe('ZonesDatabase mist overrides', () => {
     });
 
     // @verified 2026-04-29: source: session log 2026-04-26T14-33-25.jsonl event 519
-    // @MISTS@9f9a62f3-... Parameters[4]="3316" (Battlebrae Flatland, BZ T5).
-    test('setMistOverride from BZ origin synthesizes a black-zone clone', () => {
+    // @MISTS@9f9a62f3-... Parameters[4]="3316" (Battlebrae Flatland, BZ T5). Tier intentionally
+    // dropped (0) because the Mist instance tier is not derivable from any captured event.
+    test('setMistOverride from BZ origin synthesizes a black-zone clone without tier', () => {
         const ok = zonesDatabase.setMistOverride('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5', '3316');
 
         expect(ok).toBe(true);
         const zone = zonesDatabase.getZone('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5');
         expect(zone).toEqual(expect.objectContaining({
             pvpType: 'black',
-            tier: 5,
+            tier: 0,
             type: 'MISTS',
             name: 'Mist of Battlebrae Flatland',
             originZoneId: '3316'
@@ -34,17 +35,17 @@ describe('ZonesDatabase mist overrides', () => {
         expect(zonesDatabase.getPvpType('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe('black');
         expect(zonesDatabase.getZoneName('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5'))
             .toBe('Mist of Battlebrae Flatland');
-        expect(zonesDatabase.getZoneTier('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe(5);
+        expect(zonesDatabase.getZoneTier('@MISTS@9f9a62f3-c9a8-418c-9ad0-440580332ab5')).toBe(0);
     });
 
     // @verified 2026-04-29: source: fixture mists/player-joined-info.json Parameters[4]="0212"
     // (Bonepool Marsh, yellow Royal T6). Pairs with the BZ test for variant coverage.
-    test('setMistOverride from yellow Royal origin inherits yellow pvpType', () => {
+    test('setMistOverride from yellow Royal origin inherits yellow pvpType, tier dropped', () => {
         const ok = zonesDatabase.setMistOverride('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434', '0212');
 
         expect(ok).toBe(true);
         expect(zonesDatabase.getPvpType('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe('yellow');
-        expect(zonesDatabase.getZoneTier('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe(6);
+        expect(zonesDatabase.getZoneTier('@MISTS@a40183ea-3d07-4d85-b7a2-4db690f4e434')).toBe(0);
     });
 
     // @verified 2026-04-29: synthetic. Origin id absent from zones.json.

--- a/web/scripts/utils/Utils.js
+++ b/web/scripts/utils/Utils.js
@@ -190,6 +190,7 @@ export async function initRadar() {
             radarRenderer: null
         });
 
+        EventRouter.restoreMistOverrideFromSession();
         EventRouter.restoreMapFromSession();
 
         WebSocketManager.setMessageCallback((data) => {


### PR DESCRIPTION
Closes #90.

## Summary

- Event 519 carries the origin cluster id in `Parameters[4]`. Register a runtime override on `@MISTS@<guid>` cloned from the origin so `getPvpType` / `getZoneName` / `getZoneTier` return the parent's values during the Mist visit.
- BZ Mist now resolves to `pvpType='black'`, alarm fires on faction or hostile players. Yellow Royal Mist stays `'yellow'`, no false alarm on faction players.
- Override persisted to `sessionStorage` and restored on F5 before `restoreMapFromSession` so `map.isBZ` is correct on reload.
- Cleanup on `applyMapChange` to any non-`@MISTS@` destination.

## Test plan
- [x] `npm test` 539/539 (16 new MIST-90 verified across `_ZonesDatabase.test.js` + `_EventRouter.test.js`)
- [x] `npm run lint` clean
- [x] `go test ./...`, `go build ./...`, `golangci-lint run` clean
- [x] Live: enter a BZ Mist with a faction or unaligned player nearby, confirm alarm sound + screen flash
- [x] Live: enter a Brecilien Mist (yellow Royal origin), confirm faction players do NOT alarm
- [x] Live: F5 inside a Mist, confirm the override is restored (next NewCharacter still alarms)