### PR TITLE
feat(98): icon visibility (size slider + color badges + collapsible network)

### DIFF
--- a/docs/plans/2026-04-29-icon-visibility-design.md
+++ b/docs/plans/2026-04-29-icon-visibility-design.md
@@ -1,0 +1,252 @@
+# Icon visibility improvements (#98)
+
+| Field | Value |
+|---|---|
+| Status | Active, ready for implementation plan |
+| Created | 2026-04-29 |
+| Issue | [#98 Icon size](https://github.com/Nouuu/Albion-Online-OpenRadar/issues/98) |
+| Discussion | [#97 Icon size](https://github.com/Nouuu/Albion-Online-OpenRadar/discussions/97) |
+| Branch (planned) | `feat/98-icon-visibility` |
+| Depends on | None |
+| Blocks | Nothing critical |
+| User action required | No |
+| GitHub interaction | Single PR with 3 commits, closes #98 |
+
+## Context
+
+Issue #98 (converted from discussion #97 by the maintainer) gathers two user requests around radar icon visibility:
+
+1. The original ask from `srn3dcom`: resource icons rendered too small to be readable on the radar.
+2. A follow-up comment proposing an alternative rendering: colored category squares with the tier number in the middle, in addition to or instead of the game icons.
+
+The current rendering pipeline in `web/scripts/utils/DrawingUtils.js`:
+- `getZoomLevel()` reads `settingRadarZoom` (range 0.3–3, default 1.0).
+- `getCanvasScale()` returns `canvasSize / 500`.
+- `getScaledSize(base) = base × zoom × canvasScale` is used for everything: images, marker circles, text, healthbar, cluster ring, distance indicator, count badge.
+- Each `*Drawing.js` passes a hardcoded `baseSize` to `DrawCustomImage` (Harvestables/Mobs=40, Chests=35, Dungeons=28, Mists=21, Cage/Fish=18).
+- Hostile NPCs (Enemy, EnchantedEnemy, MiniBoss, Boss, Drone, MistBoss/Events without name) render as colored circles via `MobsDrawing.js:128` with hardcoded radius `getScaledSize(7)`.
+
+There is no way today to enlarge entity markers without enlarging the entire map (`settingRadarZoom`) or the canvas itself (`settingCanvasSize`). Both alternatives have side effects the user does not want.
+
+## Goals
+
+- Add a global `Icon Size` slider that scales entity markers (images and hostile NPC circles) without affecting overlay text, healthbars, cluster rings, distance indicators, or count badges.
+- Add an alternative rendering mode for harvestables (static + living) that replaces game icons with color-coded tier badges, intended as a low-vision / high-contrast option.
+- Keep the existing rendering as the default. Both new settings opt-in.
+- While editing the settings page, make the Network settings card collapsible to match the Logging and Debug cards.
+
+## Non goals
+
+- Per-category icon size overrides (single global slider only). YAGNI until a concrete need surfaces.
+- Color badges for non-harvestable entities (mobs, chests, dungeons, mists, fishing, cage). Mobs are already color-coded by hostility level; chests by rarity. Re-badging them would lose the existing semantic encoding.
+- New icon assets, animation, or shape variants.
+
+## Approach
+
+Three independent commits in a single PR, each with a single intent:
+
+1. **`feat(radar): add Icon Size slider for marker visibility`** introduces the global icon-size multiplier and applies it to images and hostile NPC marker circles. Default `1.0` preserves current rendering except for a small tightening of the hostile NPC circle radius (7 → 6).
+2. **`feat(badges): add Resource Color Badges toggle for harvestables`** introduces the alternative badge rendering for static harvestables and living harvestables/skinnables, behind a setting that defaults to off.
+3. **`ui(settings): make Network card collapsible`** applies the existing `collapse collapse-arrow` pattern (used by Logging and Debug cards) to the Network card. Bonus while editing the same template.
+
+## Section 1: Icon Size slider (commit 1)
+
+### Architecture
+
+Introduces a clean separation between two scaling concerns in `DrawingUtils`:
+
+- `getScaledSize(base)` (existing, unchanged): used for overlay rendering (text, healthbar, cluster ring, distance indicator, count badge, label offsets). Continues to depend only on `zoom × canvasScale`.
+- `getMarkerSize(base)` (new): used for entity marker rendering (images and hostile NPC circles). Adds the `iconSize` multiplier on top of `zoom × canvasScale`.
+
+This separation keeps overlay readability independent from marker sizing. A user who wants larger markers will not get oversized text or healthbars as a side effect.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `web/scripts/utils/DrawingUtils.js` | Add `getIconSizeMultiplier()` reading `settingIconSize` (default 1.0). Add `getMarkerSize(base) = base × iconSize × zoom × canvasScale`. In `DrawCustomImage`, replace `getScaledSize(size)` with `getMarkerSize(size)` (internal). In the same method, replace the loading-fallback `drawFilledCircle(ctx, x, y, getScaledSize(10), "#4169E1")` with `getMarkerSize(10)` since that fallback is a marker. |
+| `web/scripts/drawings/MobsDrawing.js` | Line 128: `drawFilledCircle(ctx, point.x, point.y, getScaledSize(7), color)` → `drawFilledCircle(ctx, point.x, point.y, getMarkerSize(6), color)`. Two changes: switch to `getMarkerSize`, reduce base radius from 7 to 6. |
+| `internal/templates/pages/radar.gohtml` | New slider `settingIconSize` placed after the existing Size slider (around line 59). Markup mirrors the Zoom slider block (lines 42–50): label `Icon size:`, range input `min="0.5" max="2" step="0.1" value="1"`, `iconSizeDown` / `iconSizeUp` / `iconSizeReset` buttons, value display `100%`. JS init/listeners block mirrors the `settingRadarZoom` block (lines 188–211). Persisted via `settingsSync.setFloat('settingIconSize', value)`. |
+
+### Data flow
+
+```
+User drags Icon Size slider on radar page
+        ↓
+settingsSync.setFloat('settingIconSize', value)
+        ↓ (localStorage + in-memory cache)
+DrawingUtils.getIconSizeMultiplier() picks up the new value
+        ↓
+DrawingUtils.getMarkerSize(base) returns base × iconSize × zoom × canvasScale
+        ↓
+       ┌──────────────────────────┴─────────────────────────────┐
+DrawCustomImage (resources, mobs, chests, ...)         MobsDrawing hostile NPC circle
+       ↓                                                       ↓
+ctx.drawImage with scaled size                  ctx.arc with scaled radius
+       ↓
+Canvas redraw on next gameLoop tick
+```
+
+### Tests (TDD strict, Rule 8)
+
+| Cible | Test | Label |
+|---|---|---|
+| `DrawingUtils.getMarkerSize` | Returns `base × multiplier × zoom × scale`. With `settingIconSize` unset, returns `base × 1.0 × zoom × scale`. With `settingIconSize=2.0`, returns `base × 2.0 × zoom × scale`. happy-dom + inline `vi.fn()` settings stub. | `@verified 2026-04-29` |
+| `DrawingUtils.DrawCustomImage` | Asserts that `ctx.drawImage` is called with size equal to `getMarkerSize(size)`, not `getScaledSize(size)`. Existing `_HarvestablesDrawing.test.js` and `_MobsDrawing.test.js` assert on the `baseSize` arg passed to `DrawCustomImage` (the `40` argument is unchanged), so they continue to pass. New file `_DrawingUtils.test.js` covers the internal scaling (the file does not exist yet). | `@verified 2026-04-29` |
+| `MobsDrawing` hostile NPC | With a hostile NPC entity (Enemy type), assert `drawFilledCircle` called with radius `getMarkerSize(6)` and base color matching `getEnemyColor(type)`. Existing `_MobsDrawing.test.js` already mocks `drawFilledCircle` and asserts it was called. Extend the assertions to check the radius arg. | `@verified 2026-04-29` |
+| Default backward compat | `settingIconSize` undefined → multiplier = 1.0 → rendering identical to baseline except for the deliberate 7→6 hostile NPC radius change. | `@verified 2026-04-29` |
+
+### Error handling
+
+- `settingsSync.getFloat('settingIconSize')` returns `null`/`NaN` when unset → fallback `|| 1.0`.
+- `<input type="range">` enforces min/max/step at the DOM level. No defensive clamping needed in JS.
+- Slider operates on a numeric scalar. No string parsing, no JSON.
+
+### Risks
+
+- **Performance**: one extra localStorage read per scaled draw call. Already the pattern for `settingRadarZoom` and `settingCanvasSize`; `SettingsSync` caches in memory, negligible cost.
+- **Visual regression**: none with multiplier=1.0 except the deliberate hostile NPC radius reduction (7→6). That change is documented in the commit message.
+- **Hot-spot adjacency**: this PR touches `MobsDrawing.js` (280 lines, not a hot-spot) but the parent `MobsHandler.js` IS a hot-spot per CLAUDE.md. No handler edits in this PR. Single-line edit at `MobsDrawing.js:128`, no structural change.
+
+## Section 2: Resource Color Badges toggle (commit 2)
+
+### Architecture
+
+A boolean toggle `settingResourceColorBadges` (default `false`) switches harvestable rendering between game icons (`DrawCustomImage`) and a colored tier badge (`drawResourceBadge`). The switch lives in:
+
+- `HarvestablesDrawing.invalidate`: covers all static harvestables.
+- `MobsDrawing.invalidate`, inside the `EnemyType.LivingHarvestable` / `EnemyType.LivingSkinnable` branch: covers living harvestables. Living variants get a gold border on top of their category color.
+
+The toggle reacts in real time via the existing `SettingsSync` watcher pattern. No reload required.
+
+### The badge
+
+Visual specification:
+
+```
+┌─────────┐
+│  T6 +2  │   Square, fillStyle = category color, borderRadius = 12% × baseSize,
+│         │   stroke alpha=0.3 white 1px
+└─────────┘
+```
+
+- **Background**: solid fill with the category color. No gradient (legibility prevails over aesthetic).
+- **Tier text** `T<n>`: bold, font size `getMarkerSize(baseSize × 0.55)`, white, with shadow `rgba(0,0,0,0.7)` blur 3 for legibility on any color.
+- **Enchant suffix** `+<n>`: bold, font size `getMarkerSize(baseSize × 0.30)`, drawn as a small superscript to the right of `T<n>`. Omitted when `enchant === 0`.
+- **Living border**: `strokeStyle = #FFD700`, `lineWidth = max(2, getMarkerSize(2))`, drawn over the standard border.
+
+### Color mapping (5 categories)
+
+| Category | Color | Hex | Rationale |
+|---|---|---|---|
+| Fiber | green | `#4CAF50` | Matches commenter suggestion (`bright green`) and plant association |
+| Hide | tan | `#A1887F` | Leather/skin tone |
+| Wood | brown | `#8D6E63` | Bark/wood tone |
+| Ore | blue | `#42A5F5` | Matches commenter suggestion (`blue square`) and metal association |
+| Rock | purple | `#9C27B0` | Matches commenter suggestion (`stone - purple`) |
+| Living variant | base color + gold border | `#FFD700` border | Visually distinguishes living from static |
+
+Category resolution from entity name reuses the lowercased substring matching already present in `DrawingUtils.detectClusters` (lines 423–442). To avoid duplication, that logic is extracted into a shared helper `getResourceCategory(name)` and re-used by both call sites.
+
+### Files touched
+
+#### Commit 2: color badges toggle
+
+| File | Change |
+|---|---|
+| `web/scripts/utils/DrawingUtils.js` | New helper `getResourceCategory(name)` extracted from `detectClusters`. New helper `getResourceCategoryColor(category)` returning the hex. New primitive `drawResourceBadge(ctx, x, y, baseSize, category, tier, enchant, isLiving)` that draws the rounded square + text + optional gold border. `detectClusters` switches to the new shared helper to avoid duplication. |
+| `web/scripts/drawings/HarvestablesDrawing.js` | At the call site that currently invokes `DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 40)` (line 110), branch on `settingsSync.getBool('settingResourceColorBadges')`. When true, resolve `category = getResourceCategory(harv.name)`, call `drawResourceBadge(...)`. When false (or `category === null`), call `DrawCustomImage` as today. |
+| `web/scripts/drawings/MobsDrawing.js` | In the LivingHarvestable / LivingSkinnable branch (lines 39–54), apply the same conditional with `isLiving=true`. Reuse the existing image-rendering gate `mobOne.name && mobOne.tier > 0` so the badge does not render with `T0` for unidentified living mobs (those keep their fallback circle). |
+| `internal/templates/pages/settings.gohtml` | Add a new label inside the Display grid (line 62 area), matching the style of `settingResourceCount` and `settingResourceDistance`: checkbox `settingResourceColorBadges`, Lucide icon `palette`, tooltip `Replace resource icons with colored tier badges (better visibility)`. |
+
+#### Commit 3: collapsible Network card
+
+| File | Change |
+|---|---|
+| `internal/templates/pages/settings.gohtml` lines 284-293 | Replace the outer `<div class="card bg-base-200">…<div class="card-body">` wrapper with `<div class="collapse collapse-arrow bg-base-200 rounded-xl"> <input type="checkbox" id="collapse-network"/> <div class="collapse-title text-xl font-semibold flex items-center gap-2"> [existing h2 content] </div> <div class="collapse-content"> [existing network-section div] </div> </div>`. Same shape as the Logging card (lines 130-136) and Debug card (lines 225-232). |
+| `internal/templates/pages/settings.gohtml` JS block (lines 336-345 area) | Add the bind: `const collapseNetwork = document.getElementById('collapse-network'); if (collapseNetwork) { collapseNetwork.checked = settingsSync.getBool('collapse-settings-network', false); addListener(collapseNetwork, 'change', () => settingsSync.setBool('collapse-settings-network', collapseNetwork.checked)); }`. |
+
+### Data flow (commit 2)
+
+```
+User toggles "Resource color badges" in settings page
+        ↓
+settingsSync.setBool('settingResourceColorBadges', true)
+        ↓
+HarvestablesDrawing.invalidate / MobsDrawing living branch (next frame)
+        ↓
+       ┌────────────────┴────────────────┐
+       badges=true                badges=false
+              ↓                          ↓
+   getResourceCategory(name)   DrawCustomImage (existing path)
+              ↓
+   ┌──────────┴─────────┐
+   category found       category null
+        ↓                     ↓
+drawResourceBadge       DrawCustomImage (fallback)
+```
+
+### Tests (TDD strict, Rule 8 + Rule 10)
+
+| Cible | Test | Label |
+|---|---|---|
+| `DrawingUtils.getResourceCategory(name)` | `'fiber_5_2'`→`'Fiber'`, `'hide_4_0'`→`'Hide'`, `'log_6_3'`→`'Wood'`, `'ore_T7_2'`→`'Ore'`, `'rock_3_1'`→`'Rock'`, unknown name→`null`. Five categories + null case. | `@verified 2026-04-29` |
+| `DrawingUtils.getResourceCategoryColor` | Five categories return their mapped hex. Unknown category returns `null`. | `@verified 2026-04-29` |
+| `DrawingUtils.drawResourceBadge` | With canvas-mock: asserts `fillRect` called with the right color, `fillText` called once for `T<n>` and a second time for `+<n>` only when enchant > 0. With `isLiving=true`, asserts an extra `strokeRect` call with `#FFD700`. | `@verified 2026-04-29` |
+| `HarvestablesDrawing.invalidate` | `settingResourceColorBadges=false` → `DrawCustomImage` called (existing behavior). `settingResourceColorBadges=true` + known category → `drawResourceBadge` called with the right category, tier, enchant. Covers the 5 categories using existing pcap-derived fixtures. | `@verified 2026-04-29` |
+| `MobsDrawing.invalidate` Living branch | `settingResourceColorBadges=true` + LivingHarvestable + name known → `drawResourceBadge` called with `isLiving=true`. Same with LivingSkinnable. Living without name → existing fallback (no badge). | `@verified 2026-04-29` |
+| Default backward compat | `settingResourceColorBadges` unset → `getBool` returns `false` → all existing rendering tests pass unchanged. | `@verified 2026-04-29` |
+
+Refactor of `getResourceCategory` from `detectClusters`: the existing cluster detection tests must continue to pass (no behavior change, only extraction).
+
+### Error handling
+
+- `getResourceCategory(name)` returns `null` if no substring match → `HarvestablesDrawing` and `MobsDrawing` fall back to `DrawCustomImage`. Preserves the existing rendering for any unmapped resource type.
+- `getResourceCategoryColor(null)` returns `null` → never reached in practice (call sites guard against `category === null`), but if it happens, `drawResourceBadge` falls back to `#4169E1` (royal blue, matches the existing image-loading fallback color).
+- Toggle changed in-session: `SettingsSync` watcher fires, the next `gameLoop` frame redraws. No forced redraw needed.
+
+### Risks
+
+- **Refactor risk** (`getResourceCategory` extraction): the existing cluster detection logic must continue to work. Mitigated by characterization tests on `detectClusters` returning the same cluster shapes before and after.
+- **Living variant edge case**: a living mob with a `name` but a name that does not match any of the 5 categories. Falls back to `DrawCustomImage` with the original name, identical to today's behavior.
+- **Visual regression**: none with `settingResourceColorBadges=false` (default). With `=true`, harvestables and living variants change visually as specified. That is the intent of the feature.
+- **Hot-spot**: `HarvestablesHandler.js` and `MobsHandler.js` are listed as hot-spots in CLAUDE.md, but this PR touches the *Drawing* siblings, which are smaller. No handler edits.
+
+## Verification
+
+Once all three commits land:
+
+1. `npm test` green, no characterization regressions.
+2. `npm run lint` exit 0.
+3. `go build ./...` and `go test ./...` green (PR has no Go changes, but CI must remain green).
+4. `golangci-lint run ./...` exit 0 (per `feedback_run_golangci_lint_not_just_vet`).
+5. Live smoke (per `feedback_embed_rebuild_gotcha`: rebuild `radar.exe` first):
+   1. Default settings → rendering identical to before, except hostile NPC circles slightly tighter (7→6).
+   2. Drag Icon Size to `1.5×` → all images and hostile NPC circles 50% larger; text and healthbars unchanged.
+   3. Drag Icon Size to `0.7×` → markers smaller, no overflow, text still readable.
+   4. Toggle `Resource color badges` ON → harvestables (Fiber/Hide/Wood/Ore/Rock) render as colored squares with `T<tier>` and optional `+<enchant>`; living variants get a gold border.
+   5. Toggle OFF → harvestables back to game icons.
+   6. Network card on settings page now collapses/expands; state persists across page reloads.
+6. No console errors in DevTools.
+
+## Files summary
+
+```
+docs/plans/2026-04-29-icon-visibility-design.md     [this file]
+docs/plans/2026-04-29-icon-visibility-implementation-plan.md  [next step]
+web/scripts/utils/DrawingUtils.js                   [+ 3 helpers, modify DrawCustomImage]
+web/scripts/drawings/HarvestablesDrawing.js         [conditional branch]
+web/scripts/drawings/MobsDrawing.js                 [conditional branch + radius 7→6]
+web/scripts/utils/_DrawingUtils.test.js             [new file to create]
+web/scripts/drawings/_HarvestablesDrawing.test.js   [extend]
+web/scripts/drawings/_MobsDrawing.test.js           [extend]
+internal/templates/pages/radar.gohtml               [Icon Size slider markup + JS]
+internal/templates/pages/settings.gohtml            [color badges checkbox + collapse Network]
+```
+
+## Out of scope (deferred or rejected)
+
+- Per-category icon size sliders (one global is enough for the original ask).
+- Color badges for mobs, chests, dungeons, mists, fishing, cage (mobs encode hostility level by color, chests encode rarity; re-badging would lose information).
+- Compact `+<enchant>`-only badge variant (could be added later if requested).
+- Exposing the multiplier as a numeric input field in addition to the slider (slider is enough; mirrors the existing zoom and size controls).

--- a/internal/templates/pages/radar.gohtml
+++ b/internal/templates/pages/radar.gohtml
@@ -57,6 +57,15 @@
                     <span id="sizeValue" class="text-xs text-base-content/60 font-mono w-12">500px</span>
                     <button id="sizeReset" class="btn btn-ghost btn-xs text-xs">Reset</button>
                 </div>
+                <!-- Icon Size control -->
+                <div class="hidden sm:flex items-center gap-2">
+                    <span class="text-xs text-base-content/50">Icons:</span>
+                    <button id="iconSizeDown" class="btn btn-ghost btn-xs">−</button>
+                    <input type="range" id="settingIconSize" min="0.5" max="2" step="0.1" value="1" class="range range-primary range-xs w-24">
+                    <button id="iconSizeUp" class="btn btn-ghost btn-xs">+</button>
+                    <span id="iconSizeValue" class="text-xs text-base-content/60 font-mono w-10">100%</span>
+                    <button id="iconSizeReset" class="btn btn-ghost btn-xs text-xs">Reset</button>
+                </div>
             </div>
         </div>
     </div>
@@ -210,6 +219,32 @@ window.onGlobalsReady(function() {
     addListener(zoomIn, 'click', () => setZoom((settingsSync.getFloat('settingRadarZoom') || 1.0) + 0.1));
     addListener(zoomOut, 'click', () => setZoom((settingsSync.getFloat('settingRadarZoom') || 1.0) - 0.1));
     addListener(zoomReset, 'click', () => setZoom(1.0));
+
+    // Icon Size controls
+    const iconSizeSlider = document.getElementById('settingIconSize');
+    const iconSizeValue = document.getElementById('iconSizeValue');
+    const iconSizeUp = document.getElementById('iconSizeUp');
+    const iconSizeDown = document.getElementById('iconSizeDown');
+    const iconSizeReset = document.getElementById('iconSizeReset');
+
+    function updateIconSizeDisplay(value) {
+        if (iconSizeValue) iconSizeValue.textContent = `${Math.round(value * 100)}%`;
+        if (iconSizeSlider) iconSizeSlider.value = value;
+    }
+
+    function setIconSize(value) {
+        value = Math.max(0.5, Math.min(2, value));
+        settingsSync.setFloat('settingIconSize', value);
+        updateIconSizeDisplay(value);
+    }
+
+    const initialIconSize = settingsSync.getFloat('settingIconSize') || 1.0;
+    updateIconSizeDisplay(initialIconSize);
+
+    addListener(iconSizeSlider, 'input', () => setIconSize(parseFloat(iconSizeSlider.value)));
+    addListener(iconSizeUp, 'click', () => setIconSize((settingsSync.getFloat('settingIconSize') || 1.0) + 0.1));
+    addListener(iconSizeDown, 'click', () => setIconSize((settingsSync.getFloat('settingIconSize') || 1.0) - 0.1));
+    addListener(iconSizeReset, 'click', () => setIconSize(1.0));
 
     // Canvas Size controls
     const sizeSlider = document.getElementById('settingCanvasSize');

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -294,12 +294,13 @@
     </div>
 
     <!-- Network Settings -->
-    <div class="card bg-base-200">
-        <div class="card-body">
-            <h2 class="text-xl font-semibold text-base-content mb-4 flex items-center gap-2">
-                <i data-lucide="wifi" class="w-5 h-5 text-primary"></i>
-                Network
-            </h2>
+    <div class="collapse collapse-arrow bg-base-200 rounded-xl">
+        <input type="checkbox" id="collapse-network"/>
+        <div class="collapse-title text-xl font-semibold flex items-center gap-2">
+            <i data-lucide="wifi" class="w-5 h-5 text-primary"></i>
+            Network
+        </div>
+        <div class="collapse-content">
             <div id="network-section" class="text-base-content/80">Loading network configuration…</div>
         </div>
     </div>
@@ -355,6 +356,12 @@
             if (collapseLogging) {
                 collapseLogging.checked = settingsSync.getBool('collapse-settings-logging', false);
                 addListener(collapseLogging, 'change', () => settingsSync.setBool('collapse-settings-logging', collapseLogging.checked));
+            }
+
+            const collapseNetwork = document.getElementById('collapse-network');
+            if (collapseNetwork) {
+                collapseNetwork.checked = settingsSync.getBool('collapse-settings-network', false);
+                addListener(collapseNetwork, 'change', () => settingsSync.setBool('collapse-settings-network', collapseNetwork.checked));
             }
 
             // Log level dropdown

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -95,6 +95,18 @@
                         <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
                     </div>
                 </label>
+
+                <!-- Resource Color Badges -->
+                <label class="flex items-center gap-3 p-3 rounded-lg bg-base-300 cursor-pointer group hover:bg-base-300/70 transition-colors">
+                    <input type="checkbox" id="settingResourceColorBadges" class="checkbox checkbox-primary checkbox-sm">
+                    <span class="text-base-content/80 group-hover:text-base-content transition-colors flex items-center gap-2">
+                        <i data-lucide="palette" class="w-4 h-4 text-base-content/50"></i>
+                        Resource Color Badges
+                    </span>
+                    <div class="tooltip" data-tip="Replace resource icons with colored tier badges (better visibility). Living variants get a gold border.">
+                        <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
+                    </div>
+                </label>
             </div>
 
             <!-- Cluster Settings (sub-section) -->
@@ -377,6 +389,7 @@
             // Resource overlay settings
             bindCheckbox("settingResourceCount");
             bindCheckbox("settingResourceDistance");
+            bindCheckbox("settingResourceColorBadges");
             bindCheckbox("settingResourceClusters");
             bindNumber("settingClusterRadius", 30);
             bindNumber("settingClusterMinSize", 2);

--- a/web/scripts/drawings/FishingDrawing.js
+++ b/web/scripts/drawings/FishingDrawing.js
@@ -27,7 +27,7 @@ export class FishingDrawing extends DrawingUtils
 
             this.DrawCustomImage(ctx, point.x, point.y, "fish", "Resources", 18);
             if (showCount) {
-                this.drawText(point.x, point.y + this.getScaledSize(18), `${fish.sizeSpawned}/${fish.totalSize}`, ctx);
+                this.drawText(point.x, point.y + this.getMarkerSize(18), `${fish.sizeSpawned}/${fish.totalSize}`, ctx);
             }
             this.lastVisibleCount++;
         }

--- a/web/scripts/drawings/HarvestablesDrawing.js
+++ b/web/scripts/drawings/HarvestablesDrawing.js
@@ -106,8 +106,16 @@ export class HarvestablesDrawing extends DrawingUtils  {
 
             this.lastVisibleCount++;
 
-            // Draw resource icon (same size as living resources)
-            this.DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 40);
+            const useBadge = settingsSync.getBool('settingResourceColorBadges');
+            const category = useBadge ? this.getResourceCategory(harvestableOne.stringType) : null;
+            if (useBadge && category) {
+                this.drawResourceBadge(
+                    ctx, point.x, point.y, 40,
+                    category, harvestableOne.tier, harvestableOne.charges, false
+                );
+            } else {
+                this.DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 40);
+            }
 
             // Debug: TypeID display (offset scaled with zoom)
             if (settingsSync.getBool('livingResourcesID'))

--- a/web/scripts/drawings/HarvestablesDrawing.js
+++ b/web/scripts/drawings/HarvestablesDrawing.js
@@ -119,7 +119,7 @@ export class HarvestablesDrawing extends DrawingUtils  {
 
             // Debug: TypeID display (offset scaled with zoom)
             if (settingsSync.getBool('livingResourcesID'))
-                this.drawText(point.x, point.y + this.getScaledSize(20), harvestableOne.type.toString(), ctx);
+                this.drawText(point.x, point.y + this.getMarkerSize(20), harvestableOne.type.toString(), ctx);
 
             // Distance indicator (if enabled) - use game-units (hX/hY) so metrics match clusters
             if (settingsSync.getBool('settingResourceDistance')) {

--- a/web/scripts/drawings/HarvestablesDrawing.js
+++ b/web/scripts/drawings/HarvestablesDrawing.js
@@ -110,11 +110,11 @@ export class HarvestablesDrawing extends DrawingUtils  {
             const category = useBadge ? this.getResourceCategory(harvestableOne.stringType) : null;
             if (useBadge && category) {
                 this.drawResourceBadge(
-                    ctx, point.x, point.y, 40,
+                    ctx, point.x, point.y, 32,
                     category, harvestableOne.tier, harvestableOne.charges, false
                 );
             } else {
-                this.DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 40);
+                this.DrawCustomImage(ctx, point.x, point.y, draw, "Resources", 32);
             }
 
             // Debug: TypeID display (offset scaled with zoom)

--- a/web/scripts/drawings/MistsWispDrawing.js
+++ b/web/scripts/drawings/MistsWispDrawing.js
@@ -13,7 +13,7 @@ export class MistsWispDrawing extends DrawingUtils {
 
         const showId = settingsSync.getBool('settingWispSpawnDebugID');
         const fontSize = `${this.getScaledFontSize(10, 7)}px`;
-        const yOffset = this.getScaledSize(26);
+        const yOffset = this.getMarkerSize(26);
 
         for (const m of mists) {
             if (!settingsSync.getBool('settingMistE' + m.enchant)) continue;

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -108,8 +108,18 @@ export class MobsDrawing extends DrawingUtils
 
             this.lastVisibleCount++;
 
-            if (imageName !== undefined && imageFolder !== undefined)
-                this.DrawCustomImage(ctx, point.x, point.y, imageName, imageFolder, 40); // Size scaled in DrawCustomImage
+            if (imageName !== undefined && imageFolder !== undefined) {
+                const useBadge = isLivingResource && settingsSync.getBool('settingResourceColorBadges');
+                const category = useBadge ? this.getResourceCategory(mobOne.name) : null;
+                if (useBadge && category) {
+                    this.drawResourceBadge(
+                        ctx, point.x, point.y, 40,
+                        category, mobOne.tier, mobOne.enchantmentLevel, true
+                    );
+                } else {
+                    this.DrawCustomImage(ctx, point.x, point.y, imageName, imageFolder, 40);
+                }
+            }
             else {
                 // Color-coded circles by enemy type
                 const color = this.getEnemyColor(mobOne.type);

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -125,7 +125,7 @@ export class MobsDrawing extends DrawingUtils
                     mobOne._debugLogged = true;
                 }
 
-                this.drawFilledCircle(ctx, point.x, point.y, this.getScaledSize(7), color);
+                this.drawFilledCircle(ctx, point.x, point.y, this.getMarkerSize(6), color);
             }
 
             // 📍 Distance indicator for living resources (if enabled) - use game-units (hX/hY)

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -111,13 +111,14 @@ export class MobsDrawing extends DrawingUtils
             if (imageName !== undefined && imageFolder !== undefined) {
                 const useBadge = isLivingResource && settingsSync.getBool('settingResourceColorBadges');
                 const category = useBadge ? this.getResourceCategory(mobOne.name) : null;
+                const baseSize = isLivingResource ? 32 : 40;
                 if (useBadge && category) {
                     this.drawResourceBadge(
-                        ctx, point.x, point.y, 40,
+                        ctx, point.x, point.y, baseSize,
                         category, mobOne.tier, mobOne.enchantmentLevel, true
                     );
                 } else {
-                    this.DrawCustomImage(ctx, point.x, point.y, imageName, imageFolder, 40);
+                    this.DrawCustomImage(ctx, point.x, point.y, imageName, imageFolder, baseSize);
                 }
             }
             else {

--- a/web/scripts/drawings/MobsDrawing.js
+++ b/web/scripts/drawings/MobsDrawing.js
@@ -156,8 +156,8 @@ export class MobsDrawing extends DrawingUtils
             }
 
             // 📊 Display enemy information below the mob (offsets scaled with zoom)
-            const offset36 = this.getScaledSize(36);
-            const offset26 = this.getScaledSize(26);
+            const offset36 = this.getMarkerSize(36);
+            const offset26 = this.getMarkerSize(26);
             const offset12 = this.getScaledSize(12);
             let currentYOffset = drawHealthBar ? offset36 : offset26; // Start position based on health bar presence
 

--- a/web/scripts/drawings/_ChestsDrawing.test.js
+++ b/web/scripts/drawings/_ChestsDrawing.test.js
@@ -5,6 +5,7 @@ import {describe, test, expect, beforeEach, vi} from 'vitest';
 vi.mock('../utils/SettingsSync.js', () => ({
     default: {
         getBool: vi.fn(() => true),
+        getFloat: vi.fn(() => null),
     },
 }));
 

--- a/web/scripts/drawings/_FishingDrawing.test.js
+++ b/web/scripts/drawings/_FishingDrawing.test.js
@@ -6,6 +6,7 @@ vi.mock('../utils/SettingsSync.js', () => ({
         getBool: vi.fn(() => true),
         getJSON: vi.fn(() => null),
         getNumber: vi.fn((_k, d) => d ?? 0),
+        getFloat: vi.fn(() => null),
     },
 }));
 

--- a/web/scripts/drawings/_HarvestablesDrawing.test.js
+++ b/web/scripts/drawings/_HarvestablesDrawing.test.js
@@ -62,7 +62,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
         const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_5_2', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_5_2', 'Resources', 32);
     });
 
     // @verified 2026-04-24: pure static fiber plant is skipped when Static is off, Living on has no effect.
@@ -82,7 +82,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
         const entity = {id: 2, hX: 5, hY: 5, size: 3, tier: 4, charges: 0, stringType: 'Fiber', mobileTypeId: null, type: 14};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 5, 5, 'fiber_4_0', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 5, 5, 'fiber_4_0', 'Resources', 32);
     });
 
     // -------------------------------------------------------------------------
@@ -225,7 +225,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         );
         const entity = {id: 99, hX: 1, hY: 2, size: 3, tier: 3, charges: 1, stringType: family, mobileTypeId: -1, type: typeNumber};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 1, 2, `${imagePrefix}_3_1`, 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 1, 2, `${imagePrefix}_3_1`, 'Resources', 32);
     });
 
     // @verified 2026-04-24: lastVisibleCount reflects only harvestables passing the render gate.
@@ -260,7 +260,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getBool.mockReturnValue(false);
         const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_5_2', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_5_2', 'Resources', 32);
         expect(drawing.drawResourceBadge).not.toHaveBeenCalled();
     });
 
@@ -270,7 +270,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
         const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Fiber', 5, 2, false);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 32, 'Fiber', 5, 2, false);
         expect(drawing.DrawCustomImage).not.toHaveBeenCalled();
     });
 
@@ -286,7 +286,7 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
         const entity = {id: 99, hX: 1, hY: 2, size: 3, tier: 3, charges: 1, stringType, mobileTypeId: -1, type: typeNumber};
         drawing.invalidate(ctx, [entity]);
-        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 1, 2, 40, expectedCategory, 3, 1, false);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 1, 2, 32, expectedCategory, 3, 1, false);
     });
 
     // @verified 2026-05-01: badge mode falls back to DrawCustomImage when getResourceCategory returns null.
@@ -317,7 +317,7 @@ describe('HarvestablesDrawing render-time routing', () => {
 
         expect(drawing.drawResourceBadge).toHaveBeenCalled();
         const call = drawing.drawResourceBadge.mock.calls[0];
-        expect(call[3]).toBe(40);                  // baseSize
+        expect(call[3]).toBe(32);                  // baseSize
         expect(call[4]).toBe('Fiber');             // category
         expect(typeof call[5]).toBe('number');     // tier
         expect(typeof call[6]).toBe('number');     // enchant

--- a/web/scripts/drawings/_HarvestablesDrawing.test.js
+++ b/web/scripts/drawings/_HarvestablesDrawing.test.js
@@ -9,6 +9,7 @@ vi.mock('../utils/SettingsSync.js', () => ({
     default: {
         getBool: vi.fn(() => false),
         getJSON: vi.fn(() => null),
+        getFloat: vi.fn(() => null),
     },
 }));
 
@@ -19,6 +20,7 @@ const settingsSync = (await import('../utils/SettingsSync.js')).default;
 function buildDrawing() {
     const drawing = new HarvestablesDrawing();
     drawing.DrawCustomImage = vi.fn();
+    drawing.drawResourceBadge = vi.fn();
     drawing.transformPoint = vi.fn((x, y) => ({x, y}));
     drawing.interpolateEntity = vi.fn();
     drawing.drawText = vi.fn();
@@ -27,6 +29,7 @@ function buildDrawing() {
     drawing.calculateDistance = vi.fn(() => 10);
     drawing.calculateRealResources = vi.fn(() => 5);
     drawing.getScaledSize = vi.fn(s => s);
+    drawing.getMarkerSize = vi.fn(s => s);
     return drawing;
 }
 
@@ -245,5 +248,79 @@ describe('HarvestablesDrawing render-time routing', () => {
         settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
         drawing.invalidate(ctx, [{id: 2, hX: 1, hY: 2, size: 3, tier: 4, charges: 0, stringType: 'Fiber', mobileTypeId: -1, type: 14}]);
         expect(drawing.lastVisibleCount).toBe(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // Resource color badges toggle (settingResourceColorBadges)
+    // -------------------------------------------------------------------------
+
+    // @verified 2026-05-01: badges off (default) keeps the existing image rendering path.
+    test('settingResourceColorBadges=false renders the game icon as before', () => {
+        settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
+        settingsSync.getBool.mockReturnValue(false);
+        const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
+        drawing.invalidate(ctx, [entity]);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_5_2', 'Resources', 40);
+        expect(drawing.drawResourceBadge).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: badges on routes static harvestables to drawResourceBadge with the correct category.
+    test('settingResourceColorBadges=true draws a Fiber badge with tier+enchant for static harvestable', () => {
+        settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
+        drawing.invalidate(ctx, [entity]);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Fiber', 5, 2, false);
+        expect(drawing.DrawCustomImage).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: badge mode covers all 5 categories via getResourceCategory(stringType).
+    test.each([
+        ['Fiber', 14, 'settingStaticFiberEnchants', 'Fiber'],
+        ['Hide', 20, 'settingStaticHideEnchants', 'Hide'],
+        ['Log', 2, 'settingStaticWoodEnchants', 'Wood'],
+        ['Ore', 24, 'settingStaticOreEnchants', 'Ore'],
+        ['Rock', 8, 'settingStaticRockEnchants', 'Rock'],
+    ])('badge mode renders %s as category %s', (stringType, typeNumber, settingKey, expectedCategory) => {
+        settingsSync.getJSON.mockImplementation(key => key === settingKey ? allTrue() : null);
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        const entity = {id: 99, hX: 1, hY: 2, size: 3, tier: 3, charges: 1, stringType, mobileTypeId: -1, type: typeNumber};
+        drawing.invalidate(ctx, [entity]);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 1, 2, 40, expectedCategory, 3, 1, false);
+    });
+
+    // @verified 2026-05-01: badge mode falls back to DrawCustomImage when getResourceCategory returns null.
+    // Stub category resolution to null even though stringType passes the static filter, to exercise the safety branch.
+    test('badge mode falls back to DrawCustomImage when getResourceCategory returns null', () => {
+        settingsSync.getJSON.mockImplementation(key => key === 'settingStaticFiberEnchants' ? allTrue() : null);
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        drawing.getResourceCategory = vi.fn(() => null);
+        const entity = {id: 1, hX: 10, hY: 20, size: 3, tier: 5, charges: 2, stringType: 'Fiber', mobileTypeId: -1, type: 14};
+        drawing.invalidate(ctx, [entity]);
+        expect(drawing.drawResourceBadge).not.toHaveBeenCalled();
+        expect(drawing.DrawCustomImage).toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: pcap-derived full-flow test: real handler -> drawing chain produces a badge in badge mode.
+    test('pcap-derived full-flow: live Fiber critter renders as badge under settingResourceColorBadges', async () => {
+        const fx = await loadFixture('harvestables', 'single-spawn');
+        const msg = fx.messages.find(m => m.parameters['6'] === 529 && m.parameters['10'] > 0);
+        expect(msg).toBeDefined();
+        const p = normalizeParams(msg.parameters);
+
+        settingsSync.getJSON.mockImplementation(key => key === 'settingLivingFiberEnchants' ? allTrue() : null);
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+
+        const handler = new HarvestablesHandler(null);
+        handler.newHarvestableObject(p[0], p);
+        drawing.invalidate(ctx, handler.getHarvestableList());
+
+        expect(drawing.drawResourceBadge).toHaveBeenCalled();
+        const call = drawing.drawResourceBadge.mock.calls[0];
+        expect(call[3]).toBe(40);                  // baseSize
+        expect(call[4]).toBe('Fiber');             // category
+        expect(typeof call[5]).toBe('number');     // tier
+        expect(typeof call[6]).toBe('number');     // enchant
+        expect(call[7]).toBe(false);               // static, not living
     });
 });

--- a/web/scripts/drawings/_MistsWispDrawing.test.js
+++ b/web/scripts/drawings/_MistsWispDrawing.test.js
@@ -5,6 +5,7 @@ import {describe, test, expect, beforeEach, vi} from 'vitest';
 vi.mock('../utils/SettingsSync.js', () => ({
     default: {
         getBool: vi.fn(() => true),
+        getFloat: vi.fn(() => null),
     },
 }));
 

--- a/web/scripts/drawings/_MobsDrawing.test.js
+++ b/web/scripts/drawings/_MobsDrawing.test.js
@@ -10,6 +10,7 @@ vi.mock('../utils/SettingsSync.js', () => ({
         getBool: vi.fn(() => true),
         getJSON: vi.fn(() => null),
         getNumber: vi.fn((_k, d) => d ?? 0),
+        getFloat: vi.fn(() => null),
     },
 }));
 
@@ -36,6 +37,7 @@ describe('MobsDrawing living resource filter at render', () => {
         drawing.getEnemyColor = vi.fn(() => '#ffffff');
         drawing.getEnemyTypeName = vi.fn(() => 'unknown');
         drawing.getScaledSize = vi.fn(s => s);
+        drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
         settingsSync.getBool.mockReturnValue(true);
@@ -129,6 +131,7 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
         drawing.getEnemyColor = vi.fn(() => '#ffffff');
         drawing.getEnemyTypeName = vi.fn(() => 'unknown');
         drawing.getScaledSize = vi.fn(s => s);
+        drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
         settingsSync.getBool.mockReturnValue(true);
@@ -236,6 +239,7 @@ describe('MobsDrawing minimum HP filter for hostile mobs (settingShowMinimumHeal
         drawing.getEnemyColor = vi.fn(() => '#ffffff');
         drawing.getEnemyTypeName = vi.fn(() => 'unknown');
         drawing.getScaledSize = vi.fn(s => s);
+        drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
     });
@@ -316,6 +320,7 @@ describe('MobsDrawing hostile/drone/events filter at render (moved from spawn)',
         drawing.getEnemyColor = vi.fn(() => '#ffffff');
         drawing.getEnemyTypeName = vi.fn(() => 'unknown');
         drawing.getScaledSize = vi.fn(s => s);
+        drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
     });
@@ -384,5 +389,13 @@ describe('MobsDrawing hostile/drone/events filter at render (moved from spawn)',
         settingsSync.getBool.mockImplementation(key => key === 'settingNormalEnemy' || key === 'settingEnemiesHealthBar');
         drawing.invalidate(ctx, [hostile({id: 2})]);
         expect(drawing.lastVisibleCount).toBe(1);
+    });
+
+    // @verified 2026-05-01: hostile NPC marker uses getMarkerSize(6), tighter than the previous getScaledSize(7).
+    test('hostile NPC marker radius is getMarkerSize(6)', () => {
+        settingsSync.getBool.mockImplementation(key => key === 'settingNormalEnemy' || key === 'settingEnemiesHealthBar');
+        drawing.invalidate(ctx, [hostile({id: 1, type: EnemyType.Enemy})]);
+        expect(drawing.drawFilledCircle).toHaveBeenCalledWith(ctx, 10, 20, 6, expect.any(String));
+        expect(drawing.getMarkerSize).toHaveBeenCalledWith(6);
     });
 });

--- a/web/scripts/drawings/_MobsDrawing.test.js
+++ b/web/scripts/drawings/_MobsDrawing.test.js
@@ -40,7 +40,7 @@ describe('MobsDrawing living resource filter at render', () => {
         drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
-        settingsSync.getBool.mockReturnValue(true);
+        settingsSync.getBool.mockImplementation(key => key !== 'settingResourceColorBadges');
     });
 
     function livingMob({id = 1, tier = 4, enchant = 0, name = 'Fiber'} = {}) {
@@ -109,6 +109,63 @@ describe('MobsDrawing living resource filter at render', () => {
         drawing.invalidate(ctx, [hostile]);
         expect(drawing.drawFilledCircle).toHaveBeenCalled();
     });
+
+    // @verified 2026-05-01: settingResourceColorBadges=true on a living harvestable draws a badge with isLiving=true.
+    test('living Fiber e2 with settingResourceColorBadges=true draws a Fiber badge with gold border', () => {
+        drawing.drawResourceBadge = vi.fn();
+        settingsSync.getJSON.mockImplementation(key =>
+            key === 'settingLivingFiberEnchants'
+                ? {e0: Array(8).fill(false), e1: Array(8).fill(false), e2: [false, false, false, true, false, false, false, false], e3: Array(8).fill(false), e4: Array(8).fill(false)}
+                : null
+        );
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        drawing.invalidate(ctx, [livingMob({tier: 4, enchant: 2})]);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Fiber', 4, 2, true);
+        expect(drawing.DrawCustomImage).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: living Skinnable Hide with badges on routes to Hide category badge.
+    test('living Hide e3 LivingSkinnable with settingResourceColorBadges=true draws a Hide badge', () => {
+        drawing.drawResourceBadge = vi.fn();
+        settingsSync.getJSON.mockImplementation(key =>
+            key === 'settingLivingHideEnchants'
+                ? {e0: Array(8).fill(false), e1: Array(8).fill(false), e2: Array(8).fill(false), e3: [false, false, false, false, true, false, false, false], e4: Array(8).fill(false)}
+                : null
+        );
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        drawing.invalidate(ctx, [livingMob({tier: 5, enchant: 3, name: 'Hide'})]);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Hide', 5, 3, true);
+    });
+
+    // @verified 2026-05-01: badge mode falls back to DrawCustomImage when getResourceCategory returns null on a living mob.
+    // Stub category resolution to null even though the living filter passes, to exercise the safety branch.
+    test('living mob badge mode falls back to DrawCustomImage when getResourceCategory returns null', () => {
+        drawing.drawResourceBadge = vi.fn();
+        drawing.getResourceCategory = vi.fn(() => null);
+        settingsSync.getJSON.mockImplementation(key =>
+            key === 'settingLivingFiberEnchants' ? {e0: Array(8).fill(true), e1: Array(8).fill(true), e2: Array(8).fill(true), e3: Array(8).fill(true), e4: Array(8).fill(true)} : null
+        );
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
+        drawing.invalidate(ctx, [livingMob({tier: 4, enchant: 0})]);
+        expect(drawing.drawResourceBadge).not.toHaveBeenCalled();
+        expect(drawing.DrawCustomImage).toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: hostile NPC is unaffected by settingResourceColorBadges (badges apply to living harvestables only).
+    test('hostile NPC stays as colored circle even when settingResourceColorBadges=true', () => {
+        drawing.drawResourceBadge = vi.fn();
+        settingsSync.getJSON.mockReturnValue(null);
+        settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges' || key === 'settingNormalEnemy' || key === 'settingEnemiesHealthBar');
+        const hostile = {
+            id: 2, typeId: 2067, hX: 10, hY: 20, tier: 5, enchantmentLevel: 0,
+            name: 'T5_MOB_ROAMING_KEEPER_CAMP_UNPROVEN_MALE', identified: true,
+            type: EnemyType.Enemy,
+            getCurrentHP: () => 100, maxHealth: 100,
+        };
+        drawing.invalidate(ctx, [hostile]);
+        expect(drawing.drawResourceBadge).not.toHaveBeenCalled();
+        expect(drawing.drawFilledCircle).toHaveBeenCalled();
+    });
 });
 
 describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead critters stay Living)', () => {
@@ -134,7 +191,7 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
         drawing.getMarkerSize = vi.fn(s => s);
         drawing.getScaledFontSize = vi.fn(s => s);
         ctx = {font: '', measureText: vi.fn(() => ({width: 12}))};
-        settingsSync.getBool.mockReturnValue(true);
+        settingsSync.getBool.mockImplementation(key => key !== 'settingResourceColorBadges');
         mobsHandler = new MobsHandler();
     });
 

--- a/web/scripts/drawings/_MobsDrawing.test.js
+++ b/web/scripts/drawings/_MobsDrawing.test.js
@@ -71,7 +71,7 @@ describe('MobsDrawing living resource filter at render', () => {
                 : null
         );
         drawing.invalidate(ctx, [livingMob({tier: 4, enchant: 2})]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_4_2', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_4_2', 'Resources', 32);
     });
 
     // @verified 2026-04-24: living Hide resolves via settingLivingHideEnchants correctly.
@@ -82,7 +82,7 @@ describe('MobsDrawing living resource filter at render', () => {
                 : null
         );
         drawing.invalidate(ctx, [livingMob({tier: 5, enchant: 3, name: 'Hide'})]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'hide_5_3', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'hide_5_3', 'Resources', 32);
     });
 
     // @verified 2026-04-24: tier-specific off still blocks even if enchant setting is on for other tiers.
@@ -120,7 +120,7 @@ describe('MobsDrawing living resource filter at render', () => {
         );
         settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
         drawing.invalidate(ctx, [livingMob({tier: 4, enchant: 2})]);
-        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Fiber', 4, 2, true);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 32, 'Fiber', 4, 2, true);
         expect(drawing.DrawCustomImage).not.toHaveBeenCalled();
     });
 
@@ -134,7 +134,7 @@ describe('MobsDrawing living resource filter at render', () => {
         );
         settingsSync.getBool.mockImplementation(key => key === 'settingResourceColorBadges');
         drawing.invalidate(ctx, [livingMob({tier: 5, enchant: 3, name: 'Hide'})]);
-        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 40, 'Hide', 5, 3, true);
+        expect(drawing.drawResourceBadge).toHaveBeenCalledWith(ctx, 10, 20, 32, 'Hide', 5, 3, true);
     });
 
     // @verified 2026-05-01: badge mode falls back to DrawCustomImage when getResourceCategory returns null on a living mob.
@@ -229,7 +229,7 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
         mobsHandler.NewMobEvent(p);
         drawing.invalidate(ctx, mobsHandler.getMobList(), []);
 
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, expect.any(Number), expect.any(Number), 'fiber_6_0', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, expect.any(Number), expect.any(Number), 'fiber_6_0', 'Resources', 32);
     });
 
     // @verified 2026-04-24: pcap-derived, Static filter has no effect on DEAD carcasses; turning Living off hides them.
@@ -256,7 +256,7 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
         mobsHandler.NewMobEvent(p);
         drawing.invalidate(ctx, mobsHandler.getMobList(), []);
 
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, expect.any(Number), expect.any(Number), 'fiber_5_0', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, expect.any(Number), expect.any(Number), 'fiber_5_0', 'Resources', 32);
     });
 
     // @verified 2026-04-24: synthetic, carcass with post-spawn enchant is gated by the matching cell.
@@ -274,7 +274,7 @@ describe('MobsDrawing DEAD critter routing (user live-test 2026-04-24: dead crit
             getCurrentHP: () => 100, maxHealth: 100,
         };
         drawing.invalidate(ctx, [dead]);
-        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_7_2', 'Resources', 40);
+        expect(drawing.DrawCustomImage).toHaveBeenCalledWith(ctx, 10, 20, 'fiber_7_2', 'Resources', 32);
     });
 });
 

--- a/web/scripts/utils/DrawingUtils.js
+++ b/web/scripts/utils/DrawingUtils.js
@@ -41,6 +41,68 @@ export class DrawingUtils {
         context.fill();
     }
 
+    getResourceCategory(name) {
+        if (typeof name !== 'string' || !name) return null;
+        const n = name.toLowerCase();
+        if (n.includes('fiber')) return 'Fiber';
+        if (n.includes('hide')) return 'Hide';
+        if (n.includes('wood') || n.includes('log')) return 'Wood';
+        if (n.includes('ore')) return 'Ore';
+        if (n.includes('rock')) return 'Rock';
+        return null;
+    }
+
+    getResourceCategoryColor(category) {
+        switch (category) {
+            case 'Fiber': return '#4CAF50';
+            case 'Hide':  return '#A1887F';
+            case 'Wood':  return '#8D6E63';
+            case 'Ore':   return '#42A5F5';
+            case 'Rock':  return '#9C27B0';
+            default:      return null;
+        }
+    }
+
+    drawResourceBadge(ctx, x, y, baseSize, category, tier, enchant, isLiving) {
+        const size = this.getMarkerSize(baseSize);
+        const color = this.getResourceCategoryColor(category) || '#4169E1';
+        const half = size / 2;
+
+        ctx.save();
+
+        ctx.fillStyle = color;
+        ctx.fillRect(x - half, y - half, size, size);
+
+        ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(x - half, y - half, size, size);
+
+        if (isLiving) {
+            ctx.strokeStyle = '#FFD700';
+            ctx.lineWidth = Math.max(2, this.getMarkerSize(2));
+            ctx.strokeRect(x - half, y - half, size, size);
+        }
+
+        const tierFontSize = this.getMarkerSize(baseSize * 0.55);
+        ctx.fillStyle = '#FFFFFF';
+        ctx.shadowColor = 'rgba(0,0,0,0.7)';
+        ctx.shadowBlur = 3;
+        ctx.font = `bold ${tierFontSize}px ${this.fontFamily}`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        if (enchant > 0) {
+            ctx.fillText(`T${tier}`, x - size * 0.12, y);
+            const enchantFontSize = this.getMarkerSize(baseSize * 0.30);
+            ctx.font = `bold ${enchantFontSize}px ${this.fontFamily}`;
+            ctx.fillText(`+${enchant}`, x + size * 0.28, y - size * 0.18);
+        } else {
+            ctx.fillText(`T${tier}`, x, y);
+        }
+
+        ctx.restore();
+    }
+
     lerp(a, b, t) { return a + (b - a) * t; }
 
     interpolateEntity(entity, lpX, lpY, t) {

--- a/web/scripts/utils/DrawingUtils.js
+++ b/web/scripts/utils/DrawingUtils.js
@@ -184,9 +184,9 @@ export class DrawingUtils {
         const rectHeight = this.getScaledSize(14);
         const radius = this.getScaledSize(4);
 
-        const offset8 = this.getScaledSize(8);
-        const offset6 = this.getScaledSize(6);
-        const offset20 = this.getScaledSize(20);
+        const offset8 = this.getMarkerSize(8);
+        const offset6 = this.getMarkerSize(6);
+        const offset20 = this.getMarkerSize(20);
 
         const positions = {
             'bottom-right': { x: x + offset8, y: y + offset6 },
@@ -248,8 +248,8 @@ export class DrawingUtils {
         const rectWidth = textWidth + (padding * 2);
         const rectHeight = this.getScaledSize(12);
         const radius = this.getScaledSize(3);
-        const rectX = x - rectWidth - this.getScaledSize(8);
-        const rectY = y - this.getScaledSize(20);
+        const rectX = x - rectWidth - this.getMarkerSize(8);
+        const rectY = y - this.getMarkerSize(20);
 
         let color;
         if (realDistance < 10) color = "rgba(0,200,0,0.85)";
@@ -288,7 +288,7 @@ export class DrawingUtils {
         const hpPercent = Math.max(0, Math.min(100, (currentHP / maxHP) * 100));
         const fillWidth = (width * hpPercent) / 100;
         const barX = x - width / 2;
-        const barY = y + this.getScaledSize(16);
+        const barY = y + this.getMarkerSize(16);
 
         ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
         ctx.fillRect(barX, barY, width, height);

--- a/web/scripts/utils/DrawingUtils.js
+++ b/web/scripts/utils/DrawingUtils.js
@@ -17,8 +17,13 @@ export class DrawingUtils {
         if (typeof window !== 'undefined' && window.innerWidth < 640) return 0.9;
         return settingsSync.getFloat('settingRadarZoom') || 1.0;
     }
+    getIconSizeMultiplier() {
+        const v = settingsSync.getFloat('settingIconSize');
+        return v && !Number.isNaN(v) ? v : 1.0;
+    }
     getCanvasScale() { return this.getCanvasSize() / 500; }
     getScaledSize(baseSize) { return baseSize * this.getZoomLevel() * this.getCanvasScale(); }
+    getMarkerSize(baseSize) { return this.getScaledSize(baseSize) * this.getIconSizeMultiplier(); }
     getScaledFontSize(baseFontSize, minFontSize = 7) { return Math.max(minFontSize, baseFontSize * this.getZoomLevel() * this.getCanvasScale()); }
     getCanvasSize() {
         if (typeof document !== 'undefined') {
@@ -57,10 +62,10 @@ export class DrawingUtils {
         const folderR = (!folder) ? "" : folder + "/";
         const src = "/images/" + folderR + imageName + ".webp";
         const preloadedImage = imageCache.GetPreloadedImage(src, folder);
-        const scaledSize = this.getScaledSize(size);
+        const scaledSize = this.getMarkerSize(size);
 
         if (preloadedImage === null) {
-            this.drawFilledCircle(ctx, x, y, this.getScaledSize(10), "#4169E1");
+            this.drawFilledCircle(ctx, x, y, this.getMarkerSize(10), "#4169E1");
             return;
         }
 

--- a/web/scripts/utils/_DrawingUtils.test.js
+++ b/web/scripts/utils/_DrawingUtils.test.js
@@ -1,0 +1,127 @@
+// synthetic: unit tests on DrawingUtils helpers (size scaling, image rendering, badge primitives).
+
+import {describe, test, expect, beforeEach, vi} from 'vitest';
+
+vi.mock('./SettingsSync.js', () => ({
+    default: {
+        getFloat: vi.fn(() => null),
+        getNumber: vi.fn(() => 500),
+        getBool: vi.fn(() => false),
+        getJSON: vi.fn(() => null),
+    },
+}));
+
+vi.mock('./ImageCache.js', () => ({
+    default: {
+        GetPreloadedImage: vi.fn(),
+        preloadImageAndAddToList: vi.fn(() => Promise.resolve()),
+    },
+}));
+
+const {DrawingUtils} = await import('./DrawingUtils.js');
+const settingsSync = (await import('./SettingsSync.js')).default;
+const imageCache = (await import('./ImageCache.js')).default;
+
+describe('DrawingUtils marker scaling helpers', () => {
+    let utils;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        utils = new DrawingUtils();
+        utils.getZoomLevel = vi.fn(() => 1.0);
+        utils.getCanvasScale = vi.fn(() => 1.0);
+    });
+
+    // @verified 2026-05-01: default returns 1.0 when settingIconSize is unset (backward compat).
+    test('getIconSizeMultiplier returns 1.0 when settingIconSize is unset', () => {
+        settingsSync.getFloat.mockReturnValue(null);
+        expect(utils.getIconSizeMultiplier()).toBe(1.0);
+    });
+
+    // @verified 2026-05-01: returns the configured value when settingIconSize is set.
+    test('getIconSizeMultiplier returns configured value', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 1.5 : null);
+        expect(utils.getIconSizeMultiplier()).toBe(1.5);
+    });
+
+    // @verified 2026-05-01: NaN/0 fallback to 1.0 to keep markers visible.
+    test('getIconSizeMultiplier falls back to 1.0 when value is 0 or NaN', () => {
+        settingsSync.getFloat.mockReturnValue(0);
+        expect(utils.getIconSizeMultiplier()).toBe(1.0);
+        settingsSync.getFloat.mockReturnValue(NaN);
+        expect(utils.getIconSizeMultiplier()).toBe(1.0);
+    });
+
+    // @verified 2026-05-01: getMarkerSize composes getScaledSize with the icon multiplier.
+    test('getMarkerSize equals base * iconSize * zoom * canvasScale', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 2.0 : null);
+        utils.getZoomLevel = vi.fn(() => 1.5);
+        utils.getCanvasScale = vi.fn(() => 0.8);
+        expect(utils.getMarkerSize(40)).toBeCloseTo(40 * 2.0 * 1.5 * 0.8);
+    });
+
+    // @verified 2026-05-01: with default multiplier and unit zoom/scale, getMarkerSize returns base.
+    test('getMarkerSize returns base when all factors are 1', () => {
+        settingsSync.getFloat.mockReturnValue(null);
+        expect(utils.getMarkerSize(40)).toBe(40);
+        expect(utils.getMarkerSize(7)).toBe(7);
+    });
+
+    // @verified 2026-05-01: getScaledSize unchanged, does not include the icon multiplier (overlay sizing).
+    test('getScaledSize does not apply iconSize multiplier (overlays unaffected)', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 2.0 : null);
+        utils.getZoomLevel = vi.fn(() => 1.5);
+        utils.getCanvasScale = vi.fn(() => 0.8);
+        expect(utils.getScaledSize(40)).toBeCloseTo(40 * 1.5 * 0.8);
+    });
+});
+
+describe('DrawingUtils.DrawCustomImage uses marker scaling', () => {
+    let utils;
+    let ctx;
+    let preloadedImage;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        utils = new DrawingUtils();
+        utils.getZoomLevel = vi.fn(() => 1.0);
+        utils.getCanvasScale = vi.fn(() => 1.0);
+        utils.drawFilledCircle = vi.fn();
+        ctx = {drawImage: vi.fn()};
+        preloadedImage = {width: 1, height: 1};
+    });
+
+    // @verified 2026-05-01: with a preloaded image, ctx.drawImage uses getMarkerSize-derived size.
+    test('drawImage size equals getMarkerSize(size) when iconSize=1.0', () => {
+        settingsSync.getFloat.mockReturnValue(null);
+        imageCache.GetPreloadedImage.mockReturnValue(preloadedImage);
+        utils.DrawCustomImage(ctx, 100, 100, 'fiber_5_2', 'Resources', 40);
+        expect(ctx.drawImage).toHaveBeenCalledWith(preloadedImage, 100 - 20, 100 - 20, 40, 40);
+    });
+
+    // @verified 2026-05-01: iconSize=2.0 doubles the rendered image size, not the overlay size.
+    test('drawImage size scales with iconSize multiplier', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 2.0 : null);
+        imageCache.GetPreloadedImage.mockReturnValue(preloadedImage);
+        utils.DrawCustomImage(ctx, 100, 100, 'fiber_5_2', 'Resources', 40);
+        expect(ctx.drawImage).toHaveBeenCalledWith(preloadedImage, 100 - 40, 100 - 40, 80, 80);
+    });
+
+    // @verified 2026-05-01: when the image is missing (null), the loading-fallback circle uses getMarkerSize too.
+    test('loading-fallback circle uses getMarkerSize(10) and the royal blue color', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 1.5 : null);
+        imageCache.GetPreloadedImage.mockReturnValue(null);
+        utils.DrawCustomImage(ctx, 100, 100, 'fiber_5_2', 'Resources', 40);
+        expect(utils.drawFilledCircle).toHaveBeenCalledWith(ctx, 100, 100, 15, '#4169E1');
+        expect(ctx.drawImage).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-05-01: undefined imageName is a no-op (existing contract).
+    test('DrawCustomImage is a no-op when imageName is undefined', () => {
+        utils.DrawCustomImage(ctx, 100, 100, undefined, 'Resources', 40);
+        expect(ctx.drawImage).not.toHaveBeenCalled();
+        expect(utils.drawFilledCircle).not.toHaveBeenCalled();
+    });
+});

--- a/web/scripts/utils/_DrawingUtils.test.js
+++ b/web/scripts/utils/_DrawingUtils.test.js
@@ -125,3 +125,128 @@ describe('DrawingUtils.DrawCustomImage uses marker scaling', () => {
         expect(utils.drawFilledCircle).not.toHaveBeenCalled();
     });
 });
+
+describe('DrawingUtils.getResourceCategory', () => {
+    let utils;
+
+    beforeEach(() => {
+        utils = new DrawingUtils();
+    });
+
+    // @verified 2026-05-01: substring matching covers all 5 resource families.
+    test.each([
+        ['Fiber', 'Fiber'],
+        ['fiber_5_2', 'Fiber'],
+        ['Hide', 'Hide'],
+        ['hide_4_0', 'Hide'],
+        ['Wood', 'Wood'],
+        ['Log', 'Wood'],
+        ['Logs', 'Wood'],
+        ['log_6_3', 'Wood'],
+        ['Ore', 'Ore'],
+        ['ore_7_2', 'Ore'],
+        ['Rock', 'Rock'],
+        ['rock_3_1', 'Rock'],
+    ])('getResourceCategory(%j) returns %j', (input, expected) => {
+        expect(utils.getResourceCategory(input)).toBe(expected);
+    });
+
+    // @verified 2026-05-01: unknown names return null so call sites can fall back.
+    test('returns null for unknown names', () => {
+        expect(utils.getResourceCategory('mystery')).toBeNull();
+        expect(utils.getResourceCategory('')).toBeNull();
+        expect(utils.getResourceCategory(null)).toBeNull();
+        expect(utils.getResourceCategory(undefined)).toBeNull();
+        expect(utils.getResourceCategory(42)).toBeNull();
+    });
+});
+
+describe('DrawingUtils.getResourceCategoryColor', () => {
+    let utils;
+
+    beforeEach(() => {
+        utils = new DrawingUtils();
+    });
+
+    // @verified 2026-05-01: color mapping per spec (Fiber green, Hide tan, Wood brown, Ore blue, Rock purple).
+    test.each([
+        ['Fiber', '#4CAF50'],
+        ['Hide', '#A1887F'],
+        ['Wood', '#8D6E63'],
+        ['Ore', '#42A5F5'],
+        ['Rock', '#9C27B0'],
+    ])('getResourceCategoryColor(%j) returns %j', (category, expected) => {
+        expect(utils.getResourceCategoryColor(category)).toBe(expected);
+    });
+
+    // @verified 2026-05-01: unknown category returns null so call sites can fall back to default color.
+    test('returns null for unknown category', () => {
+        expect(utils.getResourceCategoryColor('Mystery')).toBeNull();
+        expect(utils.getResourceCategoryColor(null)).toBeNull();
+    });
+});
+
+describe('DrawingUtils.drawResourceBadge', () => {
+    let utils;
+    let ctx;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        utils = new DrawingUtils();
+        utils.getZoomLevel = vi.fn(() => 1.0);
+        utils.getCanvasScale = vi.fn(() => 1.0);
+        settingsSync.getFloat.mockReturnValue(null);
+        ctx = {
+            save: vi.fn(),
+            restore: vi.fn(),
+            fillRect: vi.fn(),
+            strokeRect: vi.fn(),
+            fillText: vi.fn(),
+            measureText: vi.fn(() => ({width: 12})),
+            font: '',
+            fillStyle: '',
+            strokeStyle: '',
+            lineWidth: 0,
+            shadowColor: '',
+            shadowBlur: 0,
+            textAlign: '',
+            textBaseline: '',
+        };
+    });
+
+    // @verified 2026-05-01: standard static badge fills the body and renders T<tier> text only.
+    test('static Fiber T6 e0 fills body and draws T6 text only', () => {
+        utils.drawResourceBadge(ctx, 100, 100, 40, 'Fiber', 6, 0, false);
+
+        expect(ctx.fillRect).toHaveBeenCalledWith(80, 80, 40, 40);
+        expect(ctx.fillText).toHaveBeenCalledTimes(1);
+        expect(ctx.fillText.mock.calls[0][0]).toBe('T6');
+        expect(ctx.strokeRect).toHaveBeenCalledTimes(1);
+    });
+
+    // @verified 2026-05-01: enchanted badge appends a +<enchant> suffix as a second text call.
+    test('enchanted Fiber T6 e2 draws both T6 and +2 text', () => {
+        utils.drawResourceBadge(ctx, 100, 100, 40, 'Fiber', 6, 2, false);
+
+        expect(ctx.fillText).toHaveBeenCalledTimes(2);
+        const texts = ctx.fillText.mock.calls.map(c => c[0]);
+        expect(texts).toContain('T6');
+        expect(texts).toContain('+2');
+    });
+
+    // @verified 2026-05-01: living variants draw an extra gold border on top of the standard one.
+    test('living variant adds an extra gold strokeRect on top of the standard border', () => {
+        utils.drawResourceBadge(ctx, 100, 100, 40, 'Fiber', 6, 0, true);
+
+        expect(ctx.strokeRect).toHaveBeenCalledTimes(2);
+    });
+
+    // @verified 2026-05-01: badge size obeys getMarkerSize so the icon-size slider scales it.
+    test('badge size respects getMarkerSize (iconSize multiplier)', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 1.5 : null);
+        utils.drawResourceBadge(ctx, 100, 100, 40, 'Fiber', 6, 0, false);
+
+        expect(ctx.fillRect).toHaveBeenCalledWith(70, 70, 60, 60);
+    });
+});
+

--- a/web/scripts/utils/_DrawingUtils.test.js
+++ b/web/scripts/utils/_DrawingUtils.test.js
@@ -186,6 +186,65 @@ describe('DrawingUtils.getResourceCategoryColor', () => {
     });
 });
 
+describe('DrawingUtils icon-anchored overlays shift with iconSize', () => {
+    let utils;
+    let ctx;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        utils = new DrawingUtils();
+        utils.getZoomLevel = vi.fn(() => 1.0);
+        utils.getCanvasScale = vi.fn(() => 1.0);
+        ctx = {
+            save: vi.fn(),
+            restore: vi.fn(),
+            beginPath: vi.fn(),
+            moveTo: vi.fn(),
+            lineTo: vi.fn(),
+            quadraticCurveTo: vi.fn(),
+            closePath: vi.fn(),
+            fill: vi.fn(),
+            stroke: vi.fn(),
+            fillRect: vi.fn(),
+            strokeRect: vi.fn(),
+            fillText: vi.fn(),
+            createLinearGradient: vi.fn(() => ({addColorStop: vi.fn()})),
+            measureText: vi.fn(() => ({width: 12})),
+            font: '',
+            fillStyle: '',
+            strokeStyle: '',
+            lineWidth: 0,
+            shadowColor: '',
+            shadowBlur: 0,
+            textAlign: '',
+            textBaseline: '',
+        };
+    });
+
+    // @verified 2026-05-01: healthbar y-anchor scales with iconSize so it does not overlap the larger icon.
+    test('drawHealthBar barY shifts with iconSize multiplier', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 2.0 : null);
+        utils.drawHealthBar(ctx, 100, 100, 50, 100, 60, 10);
+
+        // First fillRect call is the bar background at y + getMarkerSize(16) = 100 + 32 = 132
+        expect(ctx.fillRect).toHaveBeenCalled();
+        const firstCall = ctx.fillRect.mock.calls[0];
+        expect(firstCall[1]).toBe(132);
+    });
+
+    // @verified 2026-05-01: count badge anchor offsets scale with iconSize so it sits next to the larger icon.
+    test('drawResourceCountBadge offsets scale with iconSize multiplier', () => {
+        settingsSync.getFloat.mockImplementation(key => key === 'settingIconSize' ? 2.0 : null);
+        utils.drawResourceCountBadge(ctx, 100, 100, 5, 'bottom-right');
+
+        // The rounded-rect path starts at moveTo(rectX + radius, rectY) where rectX = x + offset8 = 100 + 16 = 116
+        expect(ctx.moveTo).toHaveBeenCalled();
+        const firstMove = ctx.moveTo.mock.calls[0];
+        // rectX = 116 (was 108 with getScaledSize), so first moveTo x is 116 + radius
+        expect(firstMove[0]).toBeGreaterThan(115);
+    });
+});
+
 describe('DrawingUtils.drawResourceBadge', () => {
     let utils;
     let ctx;


### PR DESCRIPTION
## Summary

- New global Icon Size slider (0.5x-2.0x, default 1.0x) on the radar page that scales entity markers (images and hostile NPC circles) without affecting overlay text, healthbars, or cluster rings. Introduces `getMarkerSize` alongside the existing `getScaledSize`. Tightens the hostile NPC marker radius from 7 to 6.
- New Resource Color Badges toggle in the settings Display section. When enabled, harvestables (static + living) render as colored tier squares (Fiber green, Hide tan, Wood brown, Ore blue, Rock purple) with `T<tier>+<enchant>` text. Living variants get a gold border. Default off.
- Bonus while editing the settings page: the Network card is now collapsible (state persisted via `collapse-settings-network`).

Closes #98.

## Test plan

- [x] Default settings: rendering identical to before, hostile NPC circles slightly tighter (7 to 6).
- [x] Drag Icon Size to 1.5x: all images and hostile NPC circles 50% larger, text and healthbars unchanged.
- [x] Toggle Resource Color Badges ON: harvestables render as colored squares with tier+enchant; living variants have a gold border; toggle OFF returns to game icons.
- [x] Network card on settings page now collapses/expands; state persists across reloads.
- [x] No console errors in DevTools.