### PR TITLE
fix(network): rank LAN candidates so virtual NICs come last

### DIFF
--- a/internal/capture/network_addrs.go
+++ b/internal/capture/network_addrs.go
@@ -1,9 +1,10 @@
 package capture
 
-import "net"
+import (
+	"net"
+	"sort"
+)
 
-// rfc1918Nets is the parsed set of private IPv4 ranges defined in RFC 1918.
-// Parsed once at init to avoid re-parsing per call.
 var rfc1918Nets = func() []*net.IPNet {
 	cidrs := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 	out := make([]*net.IPNet, 0, len(cidrs))
@@ -16,9 +17,6 @@ var rfc1918Nets = func() []*net.IPNet {
 	return out
 }()
 
-// IsRFC1918 reports whether addr is a non-empty IPv4 string inside one of the
-// RFC 1918 private ranges (10/8, 172.16/12, 192.168/16). Loopback and link-local
-// addresses are excluded.
 func IsRFC1918(addr string) bool {
 	ip := net.ParseIP(addr)
 	if ip == nil {
@@ -36,27 +34,54 @@ func IsRFC1918(addr string) bool {
 	return false
 }
 
-// LANAddresses returns IPv4 RFC 1918 host addresses bound to local interfaces.
-// Used to print LAN URLs at startup and to populate /api/network/state.
+type lanCandidate struct {
+	name string
+	ip   string
+}
+
+func rankLANCandidates(in []lanCandidate) []string {
+	cp := make([]lanCandidate, len(in))
+	copy(cp, in)
+	sort.SliceStable(cp, func(i, j int) bool {
+		ci := Categorize(cp[i].name, "")
+		cj := Categorize(cp[j].name, "")
+		return categoryRank[ci] < categoryRank[cj]
+	})
+	out := make([]string, len(cp))
+	for i, c := range cp {
+		out[i] = c.ip
+	}
+	return out
+}
+
 func LANAddresses() []string {
-	addrs, err := net.InterfaceAddrs()
+	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil
 	}
-	out := make([]string, 0)
-	for _, a := range addrs {
-		ipnet, ok := a.(*net.IPNet)
-		if !ok {
+	cands := make([]lanCandidate, 0)
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-		ip4 := ipnet.IP.To4()
-		if ip4 == nil {
+		addrs, err := iface.Addrs()
+		if err != nil {
 			continue
 		}
-		s := ip4.String()
-		if IsRFC1918(s) {
-			out = append(out, s)
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip4 := ipnet.IP.To4()
+			if ip4 == nil {
+				continue
+			}
+			s := ip4.String()
+			if IsRFC1918(s) {
+				cands = append(cands, lanCandidate{name: iface.Name, ip: s})
+			}
 		}
 	}
-	return out
+	return rankLANCandidates(cands)
 }

--- a/internal/capture/network_addrs_test.go
+++ b/internal/capture/network_addrs_test.go
@@ -1,6 +1,9 @@
 package capture
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestIsRFC1918(t *testing.T) {
 	if !IsRFC1918("192.168.1.1") {
@@ -21,5 +24,42 @@ func TestLANAddressesReturnsRFC1918OnlyOrEmpty(t *testing.T) {
 			t.Errorf("LAN addr %q is not RFC1918", a)
 		}
 	}
-	// Empty slice is allowed (CI runners often have no RFC1918 IP).
+}
+
+func TestRankLANCandidates_PreferEthernetOverVirtual(t *testing.T) {
+	in := []lanCandidate{
+		{name: "vEthernet (Default Switch)", ip: "172.27.32.1"},
+		{name: "Ethernet", ip: "192.168.1.37"},
+		{name: "vEthernet (WSL)", ip: "172.30.208.1"},
+		{name: "Wi-Fi", ip: "192.168.2.50"},
+	}
+	got := rankLANCandidates(in)
+	want := []string{"192.168.1.37", "192.168.2.50", "172.27.32.1", "172.30.208.1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("rankLANCandidates: got %v want %v", got, want)
+	}
+}
+
+func TestRankLANCandidates_StableWithinCategory(t *testing.T) {
+	in := []lanCandidate{
+		{name: "vEthernet (Default Switch)", ip: "172.27.32.1"},
+		{name: "vEthernet (WSL)", ip: "172.30.208.1"},
+	}
+	got := rankLANCandidates(in)
+	want := []string{"172.27.32.1", "172.30.208.1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("stable order: got %v want %v", got, want)
+	}
+}
+
+func TestRankLANCandidates_UnknownNameFallsToOther(t *testing.T) {
+	in := []lanCandidate{
+		{name: "WeirdAdapterName", ip: "10.0.0.5"},
+		{name: "Ethernet", ip: "192.168.1.37"},
+	}
+	got := rankLANCandidates(in)
+	want := []string{"192.168.1.37", "10.0.0.5"}
+	if !slices.Equal(got, want) {
+		t.Errorf("unknown to Other: got %v want %v", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

- Recovers the rankLANCandidates fix that was lost during the PR #99 squash merge. Origin commit was `9743b37a` (2026-04-28, branch `feat/91-exitlag-loopback-mode`), which lived alongside ExitLag plumbing that didn't survive the squash.
- LANAddresses() now sorts RFC1918 candidates by interface category, so machines with Hyper-V or vEthernet adapters no longer get their virtual NIC picked over the physical Ethernet/Wi-Fi.
- Existing `categorize.go` already detects `hyper-v` / `vethernet` patterns. No new regex needed.

## Test plan

- [ ] On a machine with both a Hyper-V vEthernet (172.27.x or 172.31.x) and a physical Ethernet (192.168.x), the TUI shows the physical IP as the LAN URL, not the vEthernet one.
- [ ] `go test ./internal/capture/...` green (3 new unit tests added).
- [ ] No regression on `TestLANAddressesReturnsRFC1918OnlyOrEmpty`.