### PR TITLE
feat: logging coherence + in-process pcap recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,5 @@ HELPER PACKAGE/
 /docs/SESSION_BOOTSTRAP.md
 
 # Local full-session Photon captures (never committed, always anonymized then split)
-capture.pcap
-capture.anon.pcap
-capture-*.pcap
-capture_*.pcap
+captures/
 /network.json

--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -106,7 +106,7 @@ func runApp(cfg Config) bool {
 
 	manager := capture.NewManager(ctx)
 
-	app, err := newApp(appDir, cfg, ctx, cancel, manager, allIfaces)
+	app, err := newApp(appDir, cfg, ctx, cancel, manager, allIfaces, cfgPersisted.Logging.ServerLogsEnabled)
 	if err != nil {
 		cancel()
 		manager.Close(context.Background())
@@ -192,8 +192,9 @@ func newApp(
 	cancel context.CancelFunc,
 	manager *capture.Manager,
 	allIfaces []capture.NetworkInterface,
+	serverLogsEnabled bool,
 ) (*App, error) {
-	log := logger.New("./logs")
+	log := logger.New("./logs", serverLogsEnabled)
 	wsHandler := server.NewWebSocketHandler(log)
 
 	httpServer, err := createHTTPServer(cfg.devMode, appDir, wsHandler, log, Version, manager, allIfaces)

--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -32,6 +32,7 @@ var (
 const (
 	serverPort      = 5001
 	shutdownTimeout = 10 * time.Second
+	pcapCaptureDir  = "./logs/captures"
 )
 
 type App struct {
@@ -115,6 +116,15 @@ func runApp(cfg Config) bool {
 
 	if err := manager.Reconfigure(target); err != nil {
 		logger.PrintWarn("NET", "Some interfaces failed to open: %v", err)
+	}
+
+	if cfgPersisted.Logging.PcapRecording {
+		if err := manager.StartRecording(pcapCaptureDir); err != nil {
+			logger.PrintWarn("PKT", "pcap recording could not start: %v", err)
+			_ = capture.MutateConfig(appDir, func(cfg *capture.Config) {
+				cfg.Logging.PcapRecording = false
+			})
+		}
 	}
 
 	dashboard := ui.NewDashboard(Version, serverPort, cfg.devMode, capture.LANAddresses(), nil)
@@ -234,7 +244,7 @@ func createHTTPServer(
 ) (*server.HTTPServer, error) {
 	if devMode {
 		logger.PrintInfo("MODE", "Development mode: reading files from disk")
-		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version, mgr, allIfaces)
+		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version, mgr, allIfaces, mgr, pcapCaptureDir)
 	}
 	logger.PrintInfo("MODE", "Production mode: using embedded assets")
 	return server.NewHTTPServer(
@@ -251,6 +261,8 @@ func createHTTPServer(
 		mgr,
 		allIfaces,
 		appDir,
+		mgr,
+		pcapCaptureDir,
 	)
 }
 

--- a/docs/plans/2026-04-24-logging-coherence-design.md
+++ b/docs/plans/2026-04-24-logging-coherence-design.md
@@ -1,0 +1,257 @@
+# Logging Coherence Design
+
+**Date**: 2026-04-24
+**Status**: Spec approved, ready for implementation plan
+
+## Problem
+
+Three issues today on the logging surface:
+
+1. **Directory promise vs reality**. `internal/logger/logger.go` creates `sessions/`, `errors/`, `debug/` at boot. In practice everything ends up in `sessions/`. `errors/` only fills when `Logger.Error` runs server-side AND the toggle is on. `debug/` is never written.
+2. **Toggle vs behaviour**. The UI toggle "Server side recording" (`settingServerLogsEnabled`) gates only `Logger.Log` for backend Go entries. Frontend logs sent via `settingLogToServer` keep flowing into `sessions/` regardless. Toggle wording suggests a master file-write switch; reality is a partial backend gate.
+3. **Boot incoherence**. The frontend pushes `settingServerLogsEnabled` from `localStorage` to the backend on every page load via `/api/settings/server-logs`. Until that POST lands, the backend sits at the constructor default (`false`). One-shot scripts and the first events of a session can be silently dropped or written depending on race timing.
+
+A fourth opportunity surfaced during the same review: the user often takes external `tcpdump` captures to debug parser issues. The backend already receives every UDP packet via libpcap. Recording could be done in-process and gated by a UI toggle, removing the round-trip through external tooling.
+
+## Scope
+
+- Restructure log routing so each directory has a clear, source-based meaning.
+- Move the persisted source of truth for the logging toggles from `localStorage` to `network.json` so the backend boots with the correct state.
+- Add an in-process pcap recorder gated by a new toggle.
+
+Out of scope:
+- Log rotation by size or time (one file per session start for `sessions/` and `debug/`, daily rotation already exists for `errors/`).
+- Anonymization of recorded pcap files. Existing `tools/anonymize-pcap` covers post-processing.
+- Frontend log levels and category filters (already work, no change).
+
+## Architecture
+
+### Output channels
+
+| Source              | Level                | `sessions/` | `debug/` | `errors/` | Conditions                                         |
+|---------------------|----------------------|-------------|----------|-----------|----------------------------------------------------|
+| Backend Go          | DEBUG / INFO / WARN  | yes         | no       | no        | `settingServerLogsEnabled`                         |
+| Backend Go          | ERROR / CRITICAL     | yes if gate | no       | yes       | `sessions/` gated, `errors/` always-on             |
+| Frontend (`/api`)   | DEBUG / INFO / WARN  | no          | yes      | no        | `settingLogToServer` + frontend filters            |
+| Frontend (`/api`)   | ERROR / CRITICAL     | no          | yes      | yes       | same as DEBUG/INFO/WARN                            |
+
+Notes:
+- An ERROR/CRITICAL on the backend lands in two files at once when the gate is on: `sessions/` for the chronological context, `errors/` for the post-mortem aggregator. The duplicate is intentional.
+- The frontend never writes to `sessions/`. Mixing the two streams in a single file was the original confusion. They now live apart.
+- `errors/` for backend stays always-on. A server crash leaves a trace even when file logging is otherwise off.
+- `errors/` for frontend follows `settingLogToServer`. If the user has chosen to keep frontend events local, an error stays local too.
+
+### File naming and rotation
+
+| Directory   | File                                  | Rotation                      |
+|-------------|---------------------------------------|-------------------------------|
+| `sessions/` | `session_<YYYY-MM-DDTHH-MM-SS>.jsonl` | One per backend start         |
+| `debug/`    | `front_<YYYY-MM-DDTHH-MM-SS>.jsonl`   | One per backend start         |
+| `errors/`   | `errors_<YYYY-MM-DD>.log`             | Daily (existing)              |
+| `captures/` | `capture_<YYYY-MM-DDTHH-MM-SS>.pcap`  | One per recording ON cycle    |
+
+`debug/` aligns its timestamp on the backend start so a session and its frontend trace pair by name.
+
+### Configuration persistence
+
+`network.json` becomes the source of truth for both logging toggles:
+
+```json
+{
+  "captureInterfaces": [...],
+  "logging": {
+    "serverLogsEnabled": false,
+    "pcapRecording": false
+  }
+}
+```
+
+A `network.json` without the `logging` key keeps working: defaults are `false` for both fields. No breaking change for existing installs.
+
+### Boot flow
+
+1. `cmd/radar/main.go` calls `capture.ReadConfig(appDir)`.
+2. The returned `Config.Logging.ServerLogsEnabled` is passed to `logger.New(logsDir, enabled)`. The default constructor signature changes to take the boolean.
+3. The returned `Config.Logging.PcapRecording` is passed to the `Capturer`. If true, `Capturer.StartRecording(filepath.Join(logsDir, "captures"))` is called before `Start`.
+4. The frontend, on settings page load, calls `GET /api/settings/logging`. The response populates `localStorage` for both keys (`settingServerLogsEnabled`, `settingPcapRecording`). The UI checkboxes then bind from `localStorage`.
+5. A `change` event on either checkbox calls `POST /api/settings/logging` with the partial body. The handler updates `network.json` (atomic write via `WriteConfig`) and applies the change in runtime (Logger or Capturer).
+
+The endpoint `/api/settings/server-logs` is replaced by the unified `/api/settings/logging` GET/POST. The single-toggle endpoint is removed in the same change.
+
+## Components
+
+### `internal/capture/network_config.go`
+
+Add the `Logging` struct field on `Config`:
+
+```go
+type LoggingConfig struct {
+    ServerLogsEnabled bool `json:"serverLogsEnabled"`
+    PcapRecording     bool `json:"pcapRecording"`
+}
+
+type Config struct {
+    CaptureInterfaces []PersistedInterface `json:"captureInterfaces"`
+    Logging           LoggingConfig        `json:"logging"`
+}
+```
+
+`ReadConfig`/`WriteConfig` use `encoding/json` round-trip; the existing tests cover the migration of unknown fields with the standard library default (silently ignored, zero values applied).
+
+### `internal/logger/logger.go`
+
+Constructor takes the initial enabled state:
+
+```go
+func New(logsDir string, enabled bool) *Logger
+```
+
+Routing changes:
+- `WriteLogs(logs)` (frontend stream): write each entry to the current `front_<TS>.jsonl` file inside `debug/`. If `entry.level` is `ERROR` or `CRITICAL`, also append to `errors/errors_<DATE>.log`.
+- `Log(level, ...)` (backend self-log): if `enabled`, append to `sessions/session_<TS>.jsonl`. If level is `ERROR` or `CRITICAL`, append to `errors/errors_<DATE>.log` regardless of `enabled`.
+- The dedicated `Error` path keeps its always-on write to `errors/`. The current behaviour where `Error` ALSO routes through `Log` (and thus skips the session file when disabled) keeps that semantic: errors never lose their post-mortem trace.
+
+Buffer split: the existing single buffer is replaced by two buffers, `serverBuffer` and `clientBuffer`. The flush ticker iterates each buffer and writes to its target file. Errors are appended to `errors/` synchronously inside the producer (already the case for `Error`); same path for client ERROR/CRITICAL inside `WriteLogs`.
+
+### `internal/capture/pcap.go`
+
+Add three methods to `Capturer`:
+
+```go
+func (c *Capturer) StartRecording(dir string) error
+func (c *Capturer) StopRecording() error
+func (c *Capturer) IsRecording() bool
+```
+
+State held under a new mutex:
+- `recordFile *os.File`
+- `recordWriter *pcapgo.Writer`
+
+`processPacket` writes to the recorder under the mutex when `recordWriter != nil`. The packet is written with the original capture metadata (timestamp from the gopacket frame, full snaplen, link type from the live handle).
+
+`Close` calls `StopRecording` if a recording is in progress.
+
+Errors:
+- Open failure on `StartRecording` returns an error to the caller. The HTTP handler responds 500 and leaves the runtime state at false; `network.json` is not updated.
+- Open failure at boot (when `network.json` had `pcapRecording: true` but the file cannot be created): main.go logs a `[PKT]` warning, leaves the capturer in non-recording state, and writes `pcapRecording: false` back to `network.json` so the UI reflects the runtime state. The radar still starts.
+- Write errors during `processPacket` increment a counter and emit `[PKT] pcap recorder write error: %v` once per 100, identical to the parsing-error log throttling.
+
+### `internal/server/http.go`
+
+Two endpoints:
+
+`GET /api/settings/logging`:
+
+```json
+{
+  "serverLogsEnabled": false,
+  "pcapRecording": false
+}
+```
+
+`POST /api/settings/logging` accepts a partial body:
+
+```json
+{ "serverLogsEnabled": true }
+```
+
+or both fields. Missing fields keep their current value. Implementation:
+1. Read current `network.json`.
+2. Apply the diff to `cfg.Logging`.
+3. Write `network.json` atomically.
+4. Apply runtime changes:
+   - `serverLogsEnabled` -> `app.logger.SetEnabled(value)`.
+   - `pcapRecording` -> `app.capturer.StartRecording(...)` or `StopRecording()`.
+5. Respond `200` with the new full state.
+
+The existing `POST /api/settings/server-logs` handler is removed.
+
+### `web/scripts/utils/Utils.js` (or wherever settings boot lives)
+
+On settings page init, before binding any of the two toggles:
+
+```js
+const resp = await fetch('/api/settings/logging');
+const cfg = await resp.json();
+settingsSync.setBool('settingServerLogsEnabled', cfg.serverLogsEnabled);
+settingsSync.setBool('settingPcapRecording', cfg.pcapRecording);
+```
+
+The change handlers POST the new value:
+
+```js
+addListener(el, 'change', async (e) => {
+    const body = { [field]: e.target.checked };
+    await fetch('/api/settings/logging', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+});
+```
+
+The current bespoke handler around `settingServerLogsEnabled` collapses into the same generic `change` listener pattern.
+
+### `internal/templates/pages/settings.gohtml`
+
+Three tooltip rewrites:
+
+| Toggle id                     | New tooltip                                                                              |
+|-------------------------------|------------------------------------------------------------------------------------------|
+| `settingLogToConsole`         | "Print logs in the browser DevTools console."                                            |
+| `settingLogToServer`          | "Send frontend logs to the backend (saved to `logs/debug/`; errors go to `logs/errors/` too)." |
+| `settingServerLogsEnabled`    | "Save backend (Go) logs to `logs/sessions/`. Errors are always saved to `logs/errors/`." |
+
+New checkbox `settingPcapRecording` with tooltip:
+"Record the raw network capture to `logs/captures/`. Useful for debugging without running tcpdump externally."
+
+A short note above the toggles: "Logs land in `logs/sessions/`, `logs/debug/`, `logs/errors/`. Errors are always saved on the backend side."
+
+## Tests
+
+### Go
+
+`internal/capture/network_config_test.go`:
+- `LoggingConfig` round-trip (write then read, fields match).
+- `network.json` without `logging` key reads back as zero values.
+
+`internal/logger/logger_test.go` (new):
+- `enabled=false` + `Log(INFO)` -> session file empty.
+- `enabled=false` + `Error(...)` -> session file empty, error file has the entry.
+- `enabled=true` + `Log(INFO)` -> session file has the entry, error file empty.
+- `enabled=true` + `Error(...)` -> session file has the entry AND error file has the entry.
+- `WriteLogs([{level:DEBUG}, {level:ERROR}])` -> debug file has both, error file has only the ERROR.
+
+`internal/capture/pcap_record_test.go` (new):
+- `StartRecording` with a valid dir creates `capture_<TS>.pcap` and writes a valid pcap header (read back with `pcap.OpenOffline`).
+- After `StartRecording`, calling `processPacket` with a synthetic packet writes a record; reading the file back yields one packet with the same payload bytes.
+- `StopRecording` closes the file cleanly; reopening the file as a reader succeeds.
+- `Close` while recording stops the recorder.
+
+`internal/server/http_test.go` (extended or new file):
+- `GET /api/settings/logging` returns the persisted state.
+- `POST /api/settings/logging` partial update writes only the included field.
+- `POST` failure path (e.g. invalid JSON) returns 400 and leaves the file untouched.
+
+### Frontend
+
+No new logic in `web/scripts/logger.js`; existing test coverage stays. The settings boot fetch is straightforward fetch + setBool, covered by manual smoke (no new Vitest test added).
+
+## Migration
+
+- Existing `sessions/*.jsonl` files are left in place. The directory keeps receiving server logs; frontend logs no longer mix in.
+- The first restart after the change creates the first `debug/front_<TS>.jsonl`. Existing `debug/` directory stays untouched (was empty).
+- `errors/` keeps its daily rotation pattern. Existing files remain valid.
+- `captures/` is created on first `StartRecording` call (not at boot).
+- `localStorage.settingServerLogsEnabled` is overwritten by the value from `network.json` on the first settings page load. Users who had the toggle off see it stay off; users who had it on see it stay on (because `network.json` was being POSTed to from `localStorage` before the change).
+
+## Open questions
+
+None.
+
+## Self-review
+
+Placeholder scan: clean, no TBD/TODO.
+Internal consistency: routing matrix matches code descriptions in Components section.
+Scope check: three points of work (routing, persistence, pcap recorder) share enough surface (settings UI, network.json, logger code path) to belong in one plan. Splitting would force two near-identical migration sections.
+Ambiguity: ERROR routing rules stated explicitly in the matrix; tooltip wording provided verbatim; API contracts defined with example bodies.

--- a/docs/plans/2026-04-24-logging-coherence-plan.md
+++ b/docs/plans/2026-04-24-logging-coherence-plan.md
@@ -1,0 +1,508 @@
+# Logging Coherence Implementation Plan
+
+> **For agentic workers:** Execute task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each task is one commit. Code blocks are intentionally omitted from steps; rely on the task description, the design doc, and read the existing code before writing. The point is for you to remain free to adapt to surprises in the codebase.
+
+**Goal:** Realign log output channels with the UI toggles, persist logging config in `network.json` so the backend boots in a coherent state, and add an in-process pcap recorder gated by a UI toggle.
+
+**Architecture:** Three source-based log directories (`sessions/` server, `debug/` frontend, `errors/` ERROR+CRITICAL post-mortem) plus a new `captures/` for raw pcap recordings. Backend reads the persisted toggles at boot. A unified `/api/settings/logging` endpoint replaces the bespoke `/api/settings/server-logs`.
+
+**Tech Stack:** Go 1.22+, gopacket+pcapgo, segmentio/encoding/json, Vitest 4.x, vanilla JS frontend.
+
+**Spec:** `docs/plans/2026-04-24-logging-coherence-design.md`
+
+---
+
+## Project conventions to honour throughout
+
+These are non-negotiable and apply to every task in this plan. They come from `CLAUDE.md` and the user's persistent feedback.
+
+- **TDD strict, red-green-refactor.** Production code without a failing test written first gets deleted and rewritten. Run the test, see it fail with the right error, then implement, then see it pass. No exception "for trivial code". The discipline catches the case where the test was wrong all along.
+- **TDD directed by intent.** Tests assert the user-expected behaviour, never the buggy one currently in code. When adding a test to existing code, state the expected outcome from the spec, not from the current implementation. If the test fails, the code has a bug.
+- **No worktrees.** Work on a feature branch directly in the main repo (`feat/logging-coherence`). The user's preference overrides the CLAUDE.md Rule 7 worktree mention.
+- **One intent per commit.** Each task lands as one commit. Refactors, doc tweaks, "while I'm here" cleanups belong in separate commits. The "while I'm here" pattern broke the project before; do not repeat it.
+- **Minimal comments.** Default to none. Add a comment only when the WHY is non-obvious (a hidden constraint, a workaround for a specific bug, a surprise). Never cite tasks, issues, sibling commit SHAs, or "added for the X flow" rationale; that belongs in the PR description.
+- **No AI writing tells.** No em-dash, no "crucial / essential / seamless / leverage / utilize / delve / it is worth noting". Short direct sentences. Bullets only for real parallel items. Applies to docs, commit messages, code comments.
+- **No `Co-Authored-By: Claude` trailer.** Absolute rule. Ever.
+- **Verification before completion.** No "done" claim without fresh command output as evidence. After each task, run the relevant Go test, the Vitest suite, golangci-lint, and `npm run lint`. Save the green output before moving on.
+- **Modern Go syntax (1.22+).** Generics, `range over int`, `errors.Is/As`, method-pattern HTTP routing where applicable. No legacy.
+- **Run golangci-lint, not just `go vet`.** CI uses `.golangci.yml`. Local pre-push must mirror: `golangci-lint run ./...` exits 0.
+- **Push coverage by variant.** When testing a switch (level, source, gate state), enumerate every distinct case the user could realistically hit, not one happy-path sample. The test grid for the routing matrix in Task 3 is concrete.
+- **Synthetic tests are not proof.** A passing unit test on a mocked routing function is not enough. Pair it with at least one integration test that walks the real chain from `Logger.WriteLogs` to the file on disk. Same for pcap recording: round-trip through `pcap.OpenOffline` to confirm the file is readable.
+- **Trust user observations.** If live behaviour contradicts a test or a spec, question the test/spec first. Live is ground truth.
+- **Commit message style.** Conventional commits prefix (`feat`, `fix`, `refactor`, `test`, `chore`, `docs`). Subject under 70 chars. Body in short sentences explaining the WHY, never restating the diff. No co-author trailer.
+
+## Verification commands
+
+Memorise these. Run them at the end of every task.
+
+- Go tests: `go test ./...`
+- Go lint: `golangci-lint run ./...`
+- Go build: `go build ./...`
+- JS tests: `npx vitest run`
+- JS lint: `npx eslint web/scripts internal/templates`
+
+The full set must exit 0 before the commit step in any task.
+
+## File map
+
+| File | Touched by tasks | Responsibility |
+|---|---|---|
+| `internal/capture/network_config.go` | 1 | Schema for `network.json`. New `LoggingConfig` field on `Config`. |
+| `internal/capture/network_config_test.go` | 1 | Round-trip test for the new field. |
+| `internal/logger/logger.go` | 2, 3, 4 | Logger struct, constructor signature, file routing rules. |
+| `internal/logger/logger_test.go` | 2, 3, 4 | New file. Routing matrix coverage. |
+| `internal/capture/pcap.go` | 7 | Capturer with optional pcap recorder hooks. |
+| `internal/capture/pcap_record_test.go` | 7 | New file. Recording start/stop/round-trip via `pcap.OpenOffline`. |
+| `internal/server/http.go` | 5 | `/api/settings/logging` GET+POST. Removes `/api/settings/server-logs`. |
+| `internal/server/http_test.go` (or new) | 5 | Endpoint tests. |
+| `cmd/radar/main.go` | 2, 8 | Wire logger constructor with config flag. Wire pcap recording at boot + via API. |
+| `internal/templates/pages/settings.gohtml` | 6, 9 | Bind new checkbox, fetch settings from backend, tooltip rewording. |
+| `internal/templates/layouts/base.gohtml` | 6 | Drop the existing localStorage-driven server-logs POST on page load. |
+| `web/scripts/utils/SettingsSync.js` (read-only) | 6 | Confirm setBool API used to mirror backend state. |
+
+---
+
+## Task 1: Extend `network.json` schema with `Logging`
+
+**Files:**
+- Modify: `internal/capture/network_config.go`
+- Modify: `internal/capture/network_config_test.go`
+
+**Why first:** every later task depends on this struct being available.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test in `network_config_test.go` named `TestConfig_LoggingRoundTrip` that:
+- Creates a temp dir.
+- Calls `WriteConfig` with a `Config` whose `Logging.ServerLogsEnabled = true` and `Logging.PcapRecording = true`.
+- Calls `ReadConfig` on the same dir.
+- Asserts both fields come back as `true`.
+
+Add a second test `TestConfig_MissingLoggingKey` that writes a `network.json` body containing only `captureInterfaces` (no `logging` key), calls `ReadConfig`, and asserts the returned `cfg.Logging.ServerLogsEnabled` and `cfg.Logging.PcapRecording` are both `false` (zero-value default).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/capture/ -run TestConfig_Logging -v`
+Expected: FAIL because the `Logging` field does not exist on `Config`.
+
+- [ ] **Step 3: Implement**
+
+In `network_config.go`:
+- Add a new exported `LoggingConfig` struct with two `bool` fields: `ServerLogsEnabled` (json tag `serverLogsEnabled`) and `PcapRecording` (json tag `pcapRecording`).
+- Add a `Logging LoggingConfig` field on the existing `Config` struct with json tag `logging`.
+- Do not change `ReadConfig` / `WriteConfig` signatures; the standard library handles the missing-key case via zero values.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/capture/ -run TestConfig -v`
+Expected: PASS for the two new tests AND every existing test in `network_config_test.go`.
+
+Then run the full suite: `go test ./...` and `golangci-lint run ./...`. Both must exit 0.
+
+- [ ] **Step 5: Commit**
+
+Branch: ensure you are on `feat/logging-coherence`. Create it from `main` if it does not exist yet.
+
+Commit subject: `feat(config): add logging section to network.json schema`
+Commit body: one or two sentences on the why (boot-time persistence of the two logging toggles).
+
+---
+
+## Task 2: Logger constructor takes initial enabled state
+
+**Files:**
+- Modify: `internal/logger/logger.go`
+- Modify: `cmd/radar/main.go`
+- Create: `internal/logger/logger_test.go`
+
+**Why:** decouples the logger boot state from a separate API call. Future tasks rely on the new signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/logger/logger_test.go` with a test `TestNew_RespectsInitialEnabled` that calls `logger.New(t.TempDir(), true)`, then `IsEnabled()`, and asserts `true`. Add a sibling test `TestNew_RespectsInitialDisabled` that mirrors with `false`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/logger/ -run TestNew_Respects -v`
+Expected: FAIL because `New` currently takes a single argument.
+
+- [ ] **Step 3: Implement**
+
+Change the `New` signature to `func New(logsDir string, enabled bool) *Logger`. Set `l.enabled = enabled` before any other side effect. Keep all other behaviour identical (initialise dirs, create session file, start flush loop).
+
+In `cmd/radar/main.go`:
+- Read the config via `capture.ReadConfig(appDir)` early in `setup`.
+- Pass `cfg.Logging.ServerLogsEnabled` to `logger.New`.
+
+Drop the existing log line `Logger.SetEnabled(...)` if `main.go` was setting it manually based on a different source; from now on the constructor is the single boot-time setter.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/logger/ -run TestNew_Respects -v` and the full Go suite. All must pass.
+Run: `go build ./...`. Must exit 0.
+Run: `golangci-lint run ./...`. Must exit 0.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `refactor(logger): accept initial enabled state in constructor`
+
+---
+
+## Task 3: Split frontend logs into `debug/` with ERROR/CRITICAL also routed to `errors/`
+
+**Files:**
+- Modify: `internal/logger/logger.go`
+- Modify: `internal/logger/logger_test.go`
+
+**Why:** today `WriteLogs` dumps everything into `sessions/`. After this task, frontend events live in their own file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `logger_test.go`:
+
+- `TestWriteLogs_RoutesToDebugFile`: build a logger in a temp dir with `enabled=false` (irrelevant for client side), call `WriteLogs([{level:"DEBUG", category:"X", event:"e", data:{}}])`, call `Flush`, then assert that the `debug/front_<TS>.jsonl` file exists and contains exactly one line whose JSON has `level == "DEBUG"`. Assert the matching `sessions/` file is empty.
+
+- `TestWriteLogs_ErrorAlsoRoutesToErrorsFile`: build a logger, call `WriteLogs([{level:"ERROR", category:"X", event:"e", data:{}}])`, flush, assert the `debug/front_<TS>.jsonl` has one line AND the `errors/errors_<DATE>.log` has one line whose body mentions `X.e`.
+
+- `TestWriteLogs_CriticalAlsoRoutesToErrorsFile`: same as above with `level:"CRITICAL"`.
+
+- `TestWriteLogs_MixedBatch_RoutesPerLevel`: send `[{level:"INFO"}, {level:"WARN"}, {level:"ERROR"}, {level:"CRITICAL"}]`. Assert: `debug/` has 4 lines; `errors/` has 2 lines (only ERROR + CRITICAL).
+
+Use the helper `os.ReadFile` and JSON line counting. Read the existing file naming pattern from `createSessionFile()` for the `<TS>` placeholder; the new helper should mirror that.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/logger/ -run TestWriteLogs -v`
+Expected: all four FAIL because `debug/` is never written today.
+
+- [ ] **Step 3: Implement**
+
+In `logger.go`:
+- Add a `currentDebugFile` field initialised next to `currentSessionFile`. Naming: `debug/front_<same TS>.jsonl` so a session file and its debug peer pair by name.
+- Add a `clientBuffer []interface{}` next to the existing buffer (rename the existing one to `serverBuffer` to make the split explicit).
+- `WriteLogs` appends to `clientBuffer` only.
+- `Log` appends to `serverBuffer` only (already the only producer of `Log`-shaped entries).
+- `Flush` flushes both buffers: `serverBuffer` to `currentSessionFile`, `clientBuffer` to `currentDebugFile`. Wrap each write in an `OpenFile` + `Close` like the existing flush.
+- Inside `WriteLogs`, before appending, scan each entry. If `level` is `ERROR` or `CRITICAL`, also write a one-line entry to `errors/errors_<DATE>.log` synchronously (same shape as the current `Error` writer). Use the entry's category and event in the line for grep-friendliness.
+
+Keep `Error` (server side) untouched in this task. Task 4 covers it.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/logger/ -v`. All tests pass (existing + new).
+Run: `go test ./...` and lint. Must exit 0.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `feat(logger): route frontend logs to debug/ and mirror errors`
+
+---
+
+## Task 4: Backend ERROR/CRITICAL always lands in `errors/`, sessions/ stays gated
+
+**Files:**
+- Modify: `internal/logger/logger.go`
+- Modify: `internal/logger/logger_test.go`
+
+**Why:** post-mortem trace must survive a disabled toggle.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `logger_test.go`:
+
+- `TestLog_ErrorWritesToErrorsEvenWhenDisabled`: build logger with `enabled=false`, call `Logger.Error("CAT", "ev", data, ctx)`, assert `errors/errors_<DATE>.log` has one line. Assert `sessions/session_<TS>.jsonl` is empty (or has zero lines containing `CAT.ev`).
+
+- `TestLog_CriticalWritesToErrorsEvenWhenDisabled`: same with `Logger.Critical(...)`.
+
+- `TestLog_ErrorWhenEnabledHitsBothFiles`: `enabled=true`, call `Error`, assert both files have one matching line.
+
+- `TestLog_InfoWhenDisabledWritesNothing`: `enabled=false`, call `Info`, assert `sessions/` empty AND `errors/` empty.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/logger/ -run TestLog_ -v`
+Expected: at least the two "even when disabled" cases FAIL, because `Error` currently routes through `Log` first which short-circuits when disabled, so the `errors/` write is also gated.
+
+- [ ] **Step 3: Implement**
+
+Restructure `Error` and `Critical` in `logger.go`:
+- Always perform the `errors/errors_<DATE>.log` append, regardless of `l.enabled`. Move that write to the top of the function.
+- Then call `Log(level, ...)` for the chronological session file write. `Log` keeps its existing `enabled` gate, which means the session file is updated only when on.
+
+Confirm `Critical` exists and follows the same pattern; if not, mirror the change.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/logger/ -v`. All pass.
+Run: `go test ./...` and lint. Exit 0.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `feat(logger): keep errors/ always-on for ERROR and CRITICAL`
+
+---
+
+## Task 5: Unified `/api/settings/logging` endpoint
+
+**Files:**
+- Modify: `internal/server/http.go`
+- Modify (or create): `internal/server/http_test.go`
+
+**Why:** single source of truth for the two toggles, replaces the bespoke `/api/settings/server-logs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Tests with `httptest.NewServer` and the existing route registration helpers:
+
+- `TestSettingsLogging_GetReturnsCurrentConfig`: seed `network.json` in a temp `appDir` with `Logging.ServerLogsEnabled=true, PcapRecording=false`. Boot the server. `GET /api/settings/logging`. Assert HTTP 200 and JSON body `{"serverLogsEnabled":true,"pcapRecording":false}`.
+
+- `TestSettingsLogging_PostUpdatesPersistAndApply`: seed both toggles to false. POST `{"serverLogsEnabled":true}`. Assert HTTP 200, response echoes the new full state, `network.json` on disk now has `serverLogsEnabled: true, pcapRecording: false`, and `logger.IsEnabled() == true`.
+
+- `TestSettingsLogging_PostPartialBody`: seed `serverLogsEnabled=true, pcapRecording=false`. POST `{"pcapRecording":true}`. Assert `serverLogsEnabled` is still `true` after the call (untouched by partial update).
+
+- `TestSettingsLogging_PostInvalidJson`: POST with malformed body. Assert HTTP 400, `network.json` unchanged.
+
+- `TestSettingsServerLogs_LegacyEndpointIsGone`: GET or POST `/api/settings/server-logs`. Assert HTTP 404.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/server/ -run TestSettingsLogging -v`
+Expected: FAIL across the board because the endpoint does not exist yet.
+
+- [ ] **Step 3: Implement**
+
+In `http.go`:
+- Register handler for `/api/settings/logging`. Use Go 1.22 method-pattern routing (`s.mux.HandleFunc("GET /api/settings/logging", ...)` and `"POST /api/settings/logging"`). No external router.
+- The handler captures the `appDir`, the `Logger`, and the `Capturer` references at registration time (closures or a small struct method, whichever fits the existing pattern).
+- GET: read current `network.json`, return `cfg.Logging` as JSON.
+- POST: decode the partial body into a struct with two pointer fields (`*bool` each) so absent fields stay nil. Read current config. For each non-nil pointer, apply the new value. Write config atomically. Then propagate to runtime: call `logger.SetEnabled(...)` if `serverLogsEnabled` changed; call `capturer.StartRecording(captureDir)` or `StopRecording()` if `pcapRecording` changed (Task 8 wires this; for this task an `if pointer != nil` no-op stub for the capturer side is fine, replaced in Task 8).
+- On any IO error, respond 500 and do not partially apply runtime changes.
+
+Remove the old `/api/settings/server-logs` registration and its handler function entirely.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/server/ -v`. All pass.
+Run: `go test ./...` and lint. Exit 0.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `feat(http): unify logging settings endpoint`
+
+---
+
+## Task 6: Frontend boot fetches `/api/settings/logging`
+
+**Files:**
+- Modify: `internal/templates/pages/settings.gohtml`
+- Modify: `internal/templates/layouts/base.gohtml`
+
+**Why:** localStorage is no longer the source of truth. The UI reflects the backend.
+
+- [ ] **Step 1: Manual reproduction first**
+
+Run the radar locally. Open DevTools Network tab. Reload the settings page. You should see the existing POST to `/api/settings/server-logs` from `base.gohtml:57-61` firing on every page load. Note this is what the new flow replaces.
+
+- [ ] **Step 2: Implement**
+
+In `base.gohtml`:
+- Remove the block that POSTs `settingServerLogsEnabled` from localStorage on every page load (around lines 55-65). The fetch in `settings.gohtml` is the only path now.
+
+In `settings.gohtml`:
+- At the top of the settings init function (where the existing `bindCheckbox` calls live), insert an `await fetch('/api/settings/logging')` call. Parse the JSON. Call `settingsSync.setBool('settingServerLogsEnabled', resp.serverLogsEnabled)` and `settingsSync.setBool('settingPcapRecording', resp.pcapRecording)` BEFORE any `bindCheckbox` for these two keys runs.
+- Replace the bespoke `addListener(serverLogsEl, "change", async ...)` block with a generic helper that POSTs `/api/settings/logging` with the partial body `{ <field>: el.checked }`. Apply the same helper to the new `settingPcapRecording` checkbox (Task 9 adds the HTML element).
+- Errors from the fetch are non-fatal: log to console, fall back to the localStorage value, leave the checkbox in its last-known state. Do not throw.
+
+- [ ] **Step 3: Manual verification**
+
+Reload the settings page. DevTools Network tab shows one GET to `/api/settings/logging` and zero POSTs at boot. Toggle either checkbox: a single POST appears with the partial body. Refresh the page: the checkbox state matches the value previously POSTed (because `network.json` persists it).
+
+Run `npx eslint web/scripts internal/templates`. Must exit 0.
+
+- [ ] **Step 4: Commit**
+
+Commit subject: `feat(ui): fetch logging settings from backend on settings page load`
+
+---
+
+## Task 7: Capturer pcap recording (Start/Stop/Is)
+
+**Files:**
+- Modify: `internal/capture/pcap.go`
+- Create: `internal/capture/pcap_record_test.go`
+
+**Why:** in-process pcap eliminates the need for external tcpdump runs while debugging.
+
+- [ ] **Step 1: Write the failing tests**
+
+Tests in `pcap_record_test.go`. Use `pcap.OpenOffline` to verify file readability after writing.
+
+- `TestStartRecording_CreatesReadableFile`: build a `Capturer` (you may need a small constructor variant for tests that takes a synthetic pcap handle from `pcap.OpenOffline` of a tiny fixture, or pass `nil` and only test the recorder path; pick whichever fits the existing test setup, see how `internal/photon/live_pcap_test.go` builds its parser harness for inspiration). Call `StartRecording(t.TempDir())`. Assert that a file matching `capture_*.pcap` exists in the dir. Open it via `pcap.OpenOffline`; assert it returns no error and reports a non-zero linktype.
+
+- `TestStartRecording_TwiceIsAnError`: call `StartRecording` twice without intervening `StopRecording`. Second call returns an error.
+
+- `TestStopRecording_BeforeStartIsNoOp`: call `StopRecording` on a fresh capturer. Returns nil error.
+
+- `TestProcessPacket_WritesToRecorder`: feed two synthetic packets through the capturer's packet handler while recording. Stop. Open the file with `pcap.OpenOffline`. Read packets via `gopacket.NewPacketSource` and assert exactly two packets are read with the expected payload bytes.
+
+- `TestClose_StopsRecording`: start recording, then call `c.Close()`. Reopen the file via `pcap.OpenOffline`. Assert the file is well-formed (no error). Implies `Close` flushed and closed the writer.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/capture/ -run TestStartRecording -run TestStopRecording -run TestProcessPacket_Writes -run TestClose_StopsRecording -v`
+Expected: all FAIL because the methods do not exist.
+
+- [ ] **Step 3: Implement**
+
+In `pcap.go`:
+- Add fields to the `Capturer` struct: `recordMu sync.Mutex`, `recordFile *os.File`, `recordWriter *pcapgo.Writer` (import the gopacket pcapgo package), `recordWriteErrors uint64`.
+- `StartRecording(dir string) error`: under the mutex, return an error if `recordWriter != nil`. Make sure `dir` exists (`MkdirAll`). Build path `capture_<TS>.pcap` using the same timestamp format as the logger (`2006-01-02T15-04-05` with `:` replaced by `-`). Create the file. Construct a `pcapgo.NewWriter`. Call `WriteFileHeader` with the link type from `c.handle.LinkType()` and a snaplen matching the existing `SnapLen` constant. On any error path, close partial state and return the error.
+- `StopRecording() error`: under the mutex. Return nil if not recording. Close the file. Set both fields to nil.
+- `IsRecording() bool`: read under the mutex.
+- Modify `processPacket(packet gopacket.Packet)`: after the existing UDP/payload handling, if `c.recordWriter != nil`, take the mutex and call `WritePacket(packet.Metadata().CaptureInfo, packet.Data())`. On error, increment `recordWriteErrors` and emit a throttled `[PKT] pcap recorder write error: %v` log every 100 errors (mirror the parsing-error throttle pattern in `handlePacket` at `cmd/radar/main.go:312`).
+- Modify `Close()`: call `StopRecording()` before closing the handle.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/capture/ -v`. All pass.
+Run: `go test ./...` and lint. Exit 0.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `feat(pcap): in-process pcap recording on capturer`
+
+---
+
+## Task 8: Wire pcap recording at boot and through the API
+
+**Files:**
+- Modify: `cmd/radar/main.go`
+- Modify: `internal/server/http.go`
+- Modify: `internal/server/http_test.go`
+
+**Why:** make the new toggle reach the runtime and survive restarts.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `http_test.go`:
+- `TestSettingsLogging_PostStartsRecording`: seed `network.json` with `pcapRecording=false`, boot a server with a real `Capturer` (or a small mockable interface; if introducing the interface is too large for this task, build a real Capturer over a tiny fixture pcap as in Task 7's tests). POST `{"pcapRecording": true}`. Assert `capturer.IsRecording() == true` and a file appears under `logs/captures/`.
+- `TestSettingsLogging_PostStopsRecording`: same setup but the capturer is already recording. POST `{"pcapRecording": false}`. Assert `capturer.IsRecording() == false`.
+
+In `cmd/radar/main.go`:
+- Boot path test is harder without significant rework. Skip a Go-level test for the boot path here; cover via manual smoke at Step 4. The HTTP-level tests above lock in the runtime propagation.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/server/ -run TestSettingsLogging_Post -v`
+Expected: the `pcapRecording` cases FAIL because Task 5 left a stub.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/radar/main.go`:
+- After `Capturer` is constructed and before `Start`, check `cfg.Logging.PcapRecording`. If true, call `c.StartRecording(filepath.Join(logsDir, "captures"))`. If the call returns an error, log a warning via `logger.PrintWarn("PKT", "pcap recording could not start: %v", err)`, set `cfg.Logging.PcapRecording = false`, and call `capture.WriteConfig(appDir, cfg)` so the persisted state matches reality on the next boot. Continue starting the radar.
+
+In `internal/server/http.go`:
+- Replace the Task 5 stub for the capturer side with the real call. When the POST diff includes `pcapRecording: true`, call `capturer.StartRecording(...)`. When `false`, call `capturer.StopRecording()`. On error, respond 500 and do not write `network.json`. Only write the config after the runtime change succeeds.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./...` and lint. Exit 0.
+
+Manual smoke: launch the radar with `pcapRecording: true` in `network.json`. Watch for the start log. Confirm a `logs/captures/capture_*.pcap` file appears and grows while the radar runs. Stop the radar. Open the file with `wireshark` or `tcpdump -r` and confirm packets are present. Then set the file's `pcapRecording` to a path that cannot be written (read-only dir) and reboot: confirm the warning log fires and `network.json` gets rewritten with `false`.
+
+- [ ] **Step 5: Commit**
+
+Commit subject: `feat: wire pcap recording at boot and via /api/settings/logging`
+
+---
+
+## Task 9: UI tooltips and new pcap checkbox
+
+**Files:**
+- Modify: `internal/templates/pages/settings.gohtml`
+
+**Why:** make the UI reflect the new semantics so the user stops being surprised.
+
+- [ ] **Step 1: Implement**
+
+Locate the three logging-related toggles in `settings.gohtml`:
+- `settingLogToConsole`
+- `settingLogToServer`
+- `settingServerLogsEnabled`
+
+Update each tooltip to the wording fixed in the spec:
+- `settingLogToConsole`: "Print logs in the browser DevTools console."
+- `settingLogToServer`: "Send frontend logs to the backend (saved to `logs/debug/`; errors go to `logs/errors/` too)."
+- `settingServerLogsEnabled`: "Save backend (Go) logs to `logs/sessions/`. Errors are always saved to `logs/errors/`."
+
+Add a new checkbox `settingPcapRecording` next to `settingServerLogsEnabled` with the same daisyUI styling pattern. Tooltip: "Record the raw network capture to `logs/captures/`. Useful for debugging without running tcpdump externally."
+
+Add a one-line note above the four toggles: "Logs land in `logs/sessions/`, `logs/debug/`, `logs/errors/`. Errors are always saved on the backend side."
+
+- [ ] **Step 2: Verify**
+
+Run `npx eslint web/scripts internal/templates`. Exit 0.
+
+Manual smoke: open the settings page in the browser. Hover each tooltip; confirm the new wording. Toggle `settingPcapRecording` and watch the network tab for the POST. Confirm a capture file is created under `logs/captures/`.
+
+- [ ] **Step 3: Commit**
+
+Commit subject: `feat(ui): add pcap recording toggle and reword logging tooltips`
+
+---
+
+## Task 10: Final verification sweep
+
+**Files:**
+- None (read-only).
+
+**Why:** lock in the green state before merging.
+
+- [ ] **Step 1: Run the full verification grid**
+
+Run each, save the output:
+- `go test ./...`
+- `golangci-lint run ./...`
+- `go build ./...`
+- `npx vitest run`
+- `npx eslint web/scripts internal/templates`
+
+All five must exit 0. If any fails, return to the relevant task and fix; do not patch over with a "while I'm here" change.
+
+- [ ] **Step 2: Manual smoke checklist**
+
+Run the radar end-to-end:
+- Backend boots, reads `network.json`, applies both toggles to the runtime.
+- Settings page on first load: GET `/api/settings/logging` returns the persisted state. Both checkboxes match.
+- Toggle `settingServerLogsEnabled` on. POST goes through. Trigger a few backend log calls (move around in game). Watch `logs/sessions/session_*.jsonl` grow.
+- Toggle `settingServerLogsEnabled` off. POST goes through. Force a backend ERROR (kill a dependency, observe a parsing error, etc.). Watch `logs/errors/errors_<DATE>.log` grow even though `sessions/` is silent.
+- Toggle `settingLogToServer` on. Trigger frontend logs (open the radar UI, click around). Watch `logs/debug/front_*.jsonl` grow. Trigger a frontend error (e.g. a known broken path) and confirm the error appears in BOTH `logs/debug/` AND `logs/errors/`.
+- Toggle `settingPcapRecording` on. Watch `logs/captures/capture_*.pcap` appear and grow. Open it with `wireshark` to confirm packets.
+- Restart the radar. Confirm both toggles boot in the same state they were left in.
+
+- [ ] **Step 3: Pre-PR checklist**
+
+- `git log origin/main..HEAD` shows one commit per task (10 commits expected).
+- `git diff origin/main..HEAD` is reviewable. No stray files (capture pcaps, mise.toml, .playwright-mcp).
+- No `Co-Authored-By: Claude` trailer in any commit.
+- No em-dash, no banned AI words in any code, comment, or commit message. Run `grep -rE "crucial|essential|seamless|leverage|utilize|delve|worth noting|—" --include="*.go" --include="*.js" --include="*.gohtml" --include="*.md"` and confirm zero matches in the changed surface.
+- The PR description is short: a Summary section (3-5 bullets), a Test plan section (the manual smoke checklist above), and nothing else. No commit-by-commit recap.
+
+- [ ] **Step 4: Push and open PR**
+
+Push `feat/logging-coherence`. Open the PR with the short description. Wait for CI green before merging.
+
+---
+
+## Self-review
+
+**Spec coverage:** every routing rule, persistence rule, API contract, file naming convention, and pcap recording behaviour from `2026-04-24-logging-coherence-design.md` maps to one or more tasks above. Tooltip wording lives in Task 9; routing matrix split is covered by Tasks 3 and 4; the unified API and the legacy endpoint removal are both in Task 5.
+
+**Placeholder scan:** no TBD/TODO/"implement later" patterns. Tests are described by behaviour and assertion content rather than by literal code, per the user's instruction; the engineer is expected to write the actual test code following the description plus the existing testing conventions in `internal/logger`, `internal/capture`, and `internal/server`.
+
+**Type consistency:** `LoggingConfig`, `Config.Logging`, `Logger.New(logsDir, enabled)`, `Capturer.StartRecording(dir)`, `StopRecording()`, `IsRecording()`, `/api/settings/logging`, `settingPcapRecording`. Every name appears identically across the tasks that reference it.
+
+**Risk areas to watch:**
+- Task 3 splits the buffer in `Logger`. Existing flush behaviour is preserved; race conditions on the new client buffer require the same `bufferMu` discipline as the server one.
+- Task 7 uses gopacket's `pcapgo.NewWriter`. Confirm the link type returned by `c.handle.LinkType()` matches what `WriteFileHeader` expects; common values are `layers.LinkTypeEthernet` (Ethernet) and may be `layers.LinkTypeNull` on some adapters. Trust whatever the live handle reports; do not hardcode.
+- Task 8 boot-time failure path rewrites `network.json`. Ensure the rewrite happens AFTER the warning log, AFTER setting the runtime flag to false, and uses the same atomic `WriteConfig` helper so a crash mid-write cannot corrupt the file.

--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/nospy/albion-openradar/internal/logger"
 )
 
 type Status string
@@ -35,12 +37,14 @@ var managerStartWorker = startWorker
 type Manager struct {
 	parentCtx context.Context
 
-	mu         sync.Mutex
-	active     map[string]*managedCapturer
-	wg         sync.WaitGroup
-	onPacket   PacketHandler
-	lastErrors map[string]string
-	closed     bool
+	mu               sync.Mutex
+	active           map[string]*managedCapturer
+	wg               sync.WaitGroup
+	onPacket         PacketHandler
+	lastErrors       map[string]string
+	closed           bool
+	recordingEnabled bool
+	recordingDir     string
 }
 
 type managedCapturer struct {
@@ -94,6 +98,11 @@ func (m *Manager) Reconfigure(target []NetworkInterface) error {
 		mc := &managedCapturer{cap: c, startedAt: time.Now(), cancel: c.cancel}
 		m.active[name] = mc
 		delete(m.lastErrors, name)
+		if m.recordingEnabled {
+			if rErr := c.StartRecording(m.recordingDir); rErr != nil {
+				m.lastErrors[name] = rErr.Error()
+			}
+		}
 		managerStartWorker(c, &m.wg, func(n string, e error) {
 			m.mu.Lock()
 			m.lastErrors[n] = e.Error()
@@ -118,6 +127,51 @@ func (m *Manager) Reconfigure(target []NetworkInterface) error {
 		return fmt.Errorf("partial open failures: %v", openErrs)
 	}
 	return nil
+}
+
+// StartRecording enables recording on all active capturers and on any future
+// ones added via Reconfigure. If a capturer fails to start, the error is
+// logged as a warning and the others continue.
+func (m *Manager) StartRecording(dir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordingEnabled = true
+	m.recordingDir = dir
+	var firstErr error
+	for name, mc := range m.active {
+		if err := mc.cap.StartRecording(dir); err != nil {
+			logger.PrintWarn("PKT", "pcap recording could not start on %s: %v", name, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %w", name, err)
+			}
+		}
+	}
+	return firstErr
+}
+
+// StopRecording disables recording on all active capturers.
+func (m *Manager) StopRecording() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordingEnabled = false
+	m.recordingDir = ""
+	var firstErr error
+	for name, mc := range m.active {
+		if err := mc.cap.StopRecording(); err != nil {
+			logger.PrintWarn("PKT", "pcap recording could not stop on %s: %v", name, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %w", name, err)
+			}
+		}
+	}
+	return firstErr
+}
+
+// IsRecording reports whether the Manager has recording enabled.
+func (m *Manager) IsRecording() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.recordingEnabled
 }
 
 // BytesReceived sums per-handle bytes across active capturers.

--- a/internal/capture/manager_test.go
+++ b/internal/capture/manager_test.go
@@ -146,3 +146,99 @@ func TestManagerNoGoroutineLeak(t *testing.T) {
 		t.Errorf("workerExited=%d, want %d (goroutine leak)", got, want)
 	}
 }
+
+func TestManager_StartRecording_PropagatesToActive(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	if err := m.Reconfigure([]NetworkInterface{{Name: "a", Device: "a"}}); err != nil {
+		t.Fatalf("Reconfigure: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := m.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+
+	m.mu.Lock()
+	mc := m.active["a"]
+	m.mu.Unlock()
+	if mc == nil {
+		t.Fatal("active capturer 'a' not found")
+	}
+	if !mc.cap.IsRecording() {
+		t.Error("capturer 'a' is not recording after Manager.StartRecording")
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManager_StartRecording_AppliesToFutureCapturers(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+
+	dir := t.TempDir()
+	if err := m.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording before Reconfigure: %v", err)
+	}
+
+	if err := m.Reconfigure([]NetworkInterface{{Name: "b", Device: "b"}}); err != nil {
+		t.Fatalf("Reconfigure: %v", err)
+	}
+
+	m.mu.Lock()
+	mc := m.active["b"]
+	m.mu.Unlock()
+	if mc == nil {
+		t.Fatal("active capturer 'b' not found")
+	}
+	if !mc.cap.IsRecording() {
+		t.Error("capturer 'b' added after StartRecording is not recording")
+	}
+
+	m.Close(context.Background())
+}
+
+func TestManager_StopRecording_StopsAllActive(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	if err := m.Reconfigure([]NetworkInterface{
+		{Name: "c", Device: "c"},
+		{Name: "d", Device: "d"},
+	}); err != nil {
+		t.Fatalf("Reconfigure: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := m.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+
+	if err := m.StopRecording(); err != nil {
+		t.Fatalf("StopRecording: %v", err)
+	}
+
+	m.mu.Lock()
+	caps := make([]*Capturer, 0, len(m.active))
+	for _, mc := range m.active {
+		caps = append(caps, mc.cap)
+	}
+	m.mu.Unlock()
+
+	for _, c := range caps {
+		if c.IsRecording() {
+			t.Errorf("capturer %s is still recording after StopRecording", c.iface.Name)
+		}
+	}
+
+	if m.IsRecording() {
+		t.Error("Manager.IsRecording() still true after StopRecording")
+	}
+
+	m.Close(context.Background())
+}

--- a/internal/capture/manager_test.go
+++ b/internal/capture/manager_test.go
@@ -1,13 +1,56 @@
 package capture
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
 )
+
+func filepathGlob(t *testing.T, dir, pattern string) ([]string, error) {
+	t.Helper()
+	return filepath.Glob(filepath.Join(dir, pattern))
+}
+
+func assertSinglePayload(t *testing.T, path string, want []byte) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	reader, err := pcapgo.NewReader(f)
+	if err != nil {
+		t.Fatalf("pcapgo.NewReader on %s: %v", path, err)
+	}
+
+	src := gopacket.NewPacketSource(reader, reader.LinkType())
+	got := 0
+	for pkt := range src.Packets() {
+		got++
+		udp, ok := pkt.Layer(layers.LayerTypeUDP).(*layers.UDP)
+		if !ok {
+			t.Errorf("%s: packet %d has no UDP layer", path, got)
+			continue
+		}
+		if !bytes.Equal(udp.Payload, want) {
+			t.Errorf("%s: payload = %q, want %q", path, udp.Payload, want)
+		}
+	}
+	if got != 1 {
+		t.Errorf("%s recorded %d packets, want 1", path, got)
+	}
+}
 
 func newStubCapturer(iface NetworkInterface) *Capturer {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -198,6 +241,59 @@ func TestManager_StartRecording_AppliesToFutureCapturers(t *testing.T) {
 	if !mc.cap.IsRecording() {
 		t.Error("capturer 'b' added after StartRecording is not recording")
 	}
+
+	m.Close(context.Background())
+}
+
+// TestManager_StartRecording_MultiInterface_PerCapturerFiles confirms that
+// when multiple interfaces are selected, each Capturer writes to its own
+// pcap file with the sanitized interface name in the filename, and that
+// packets fed to one Capturer never appear in another's file.
+//
+// synthetic: stub Capturers (nil handle) plus in-process UDP packets.
+func TestManager_StartRecording_MultiInterface_PerCapturerFiles(t *testing.T) {
+	defer withStubFactory(t, nil)()
+
+	m := NewManager(context.Background())
+	m.OnPacket(func([]byte) {})
+	if err := m.Reconfigure([]NetworkInterface{
+		{Name: "alpha", Device: "alpha"},
+		{Name: "beta", Device: "beta"},
+	}); err != nil {
+		t.Fatalf("Reconfigure: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := m.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+
+	m.mu.Lock()
+	alpha := m.active["alpha"].cap
+	beta := m.active["beta"].cap
+	m.mu.Unlock()
+
+	alphaPayload := []byte("from-alpha")
+	betaPayload := []byte("from-beta")
+	alpha.processPacket(buildUDPPacket(t, alphaPayload))
+	beta.processPacket(buildUDPPacket(t, betaPayload))
+
+	if err := m.StopRecording(); err != nil {
+		t.Fatalf("StopRecording: %v", err)
+	}
+
+	alphaMatches, _ := filepathGlob(t, dir, "capture_*_alpha.pcap")
+	betaMatches, _ := filepathGlob(t, dir, "capture_*_beta.pcap")
+
+	if len(alphaMatches) != 1 {
+		t.Fatalf("want 1 alpha capture file, got %d: %v", len(alphaMatches), alphaMatches)
+	}
+	if len(betaMatches) != 1 {
+		t.Fatalf("want 1 beta capture file, got %d: %v", len(betaMatches), betaMatches)
+	}
+
+	assertSinglePayload(t, alphaMatches[0], alphaPayload)
+	assertSinglePayload(t, betaMatches[0], betaPayload)
 
 	m.Close(context.Background())
 }

--- a/internal/capture/network_config.go
+++ b/internal/capture/network_config.go
@@ -61,6 +61,16 @@ func WriteConfig(appDir string, cfg Config) error {
 	return nil
 }
 
+// MutateConfig reads the config, applies the mutator, and writes atomically.
+func MutateConfig(appDir string, mutate func(*Config)) error {
+	cfg, err := ReadConfig(appDir)
+	if err != nil {
+		return err
+	}
+	mutate(&cfg)
+	return WriteConfig(appDir, cfg)
+}
+
 type IPResolver func(ip string) (PersistedInterface, error)
 
 func MigrateIPTxt(appDir string, resolve IPResolver) (bool, error) {

--- a/internal/capture/network_config.go
+++ b/internal/capture/network_config.go
@@ -18,8 +18,14 @@ type PersistedInterface struct {
 	Description string `json:"description"`
 }
 
+type LoggingConfig struct {
+	ServerLogsEnabled bool `json:"serverLogsEnabled"`
+	PcapRecording     bool `json:"pcapRecording"`
+}
+
 type Config struct {
 	CaptureInterfaces []PersistedInterface `json:"captureInterfaces"`
+	Logging           LoggingConfig        `json:"logging"`
 }
 
 func ReadConfig(appDir string) (Config, error) {

--- a/internal/capture/network_config_test.go
+++ b/internal/capture/network_config_test.go
@@ -221,6 +221,70 @@ func TestMigrateMalformedConfigErrors(t *testing.T) {
 	}
 }
 
+func TestConfigLoggingRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Logging: LoggingConfig{
+			ServerLogsEnabled: true,
+			PcapRecording:     true,
+		},
+	}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if !got.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled: got false, want true")
+	}
+	if !got.Logging.PcapRecording {
+		t.Error("Logging.PcapRecording: got false, want true")
+	}
+}
+
+func TestConfigMissingLoggingKey(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`{"captureInterfaces":[]}`)
+	if err := os.WriteFile(filepath.Join(dir, "network.json"), body, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if got.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled: got true, want false (zero value)")
+	}
+	if got.Logging.PcapRecording {
+		t.Error("Logging.PcapRecording: got true, want false (zero value)")
+	}
+}
+
+func TestConfigLoggingExplicitFalseRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Logging: LoggingConfig{
+			ServerLogsEnabled: false,
+			PcapRecording:     false,
+		},
+	}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if got.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled: got true, want false")
+	}
+	if got.Logging.PcapRecording {
+		t.Error("Logging.PcapRecording: got true, want false")
+	}
+}
+
 func TestWriteConfigOverwritesAtomically(t *testing.T) {
 	dir := t.TempDir()
 	cfg1 := Config{CaptureInterfaces: []PersistedInterface{{Name: "A", Description: "First"}}}

--- a/internal/capture/network_config_test.go
+++ b/internal/capture/network_config_test.go
@@ -285,6 +285,37 @@ func TestConfigLoggingExplicitFalseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMutateConfig_PreservesUntouchedFields(t *testing.T) {
+	dir := t.TempDir()
+	seed := Config{
+		CaptureInterfaces: []PersistedInterface{{Name: "X", Description: "Y"}},
+		Logging:           LoggingConfig{ServerLogsEnabled: true, PcapRecording: true},
+	}
+	if err := WriteConfig(dir, seed); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	if err := MutateConfig(dir, func(c *Config) {
+		c.Logging.PcapRecording = false
+	}); err != nil {
+		t.Fatalf("MutateConfig: %v", err)
+	}
+
+	got, err := ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if len(got.CaptureInterfaces) != 1 || got.CaptureInterfaces[0].Name != "X" {
+		t.Errorf("CaptureInterfaces changed: %+v", got.CaptureInterfaces)
+	}
+	if !got.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled was reset; MutateConfig must preserve untouched fields")
+	}
+	if got.Logging.PcapRecording {
+		t.Error("Logging.PcapRecording: want false after mutation, got true")
+	}
+}
+
 func TestWriteConfigOverwritesAtomically(t *testing.T) {
 	dir := t.TempDir()
 	cfg1 := Config{CaptureInterfaces: []PersistedInterface{{Name: "A", Description: "First"}}}

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -2,7 +2,10 @@ package capture
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -10,6 +13,9 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/pcapgo"
+
+	"github.com/nospy/albion-openradar/internal/logger"
 )
 
 const (
@@ -37,6 +43,11 @@ type Capturer struct {
 	closeOnce sync.Once
 
 	bytesReceived uint64
+
+	recordMu          sync.Mutex
+	recordFile        *os.File
+	recordWriter      *pcapgo.Writer
+	recordWriteErrors uint64
 }
 
 // captureFactory is overridable in tests; restore via t.Cleanup.
@@ -94,6 +105,7 @@ func (c *Capturer) Close() {
 		if c.cancel != nil {
 			c.cancel()
 		}
+		c.StopRecording() //nolint:errcheck // file close error is non-actionable during shutdown
 		if c.handle != nil {
 			c.handle.Close()
 		}
@@ -111,7 +123,77 @@ func (c *Capturer) Stats() (*pcap.Stats, error) {
 	return c.handle.Stats()
 }
 
+// StartRecording begins writing all packets to a new capture_<TS>.pcap in dir.
+// Returns an error if already recording or if the file cannot be created.
+func (c *Capturer) StartRecording(dir string) error {
+	c.recordMu.Lock()
+	defer c.recordMu.Unlock()
+
+	if c.recordWriter != nil {
+		return errors.New("recording already in progress")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create recording dir: %w", err)
+	}
+
+	ts := time.Now().Format("2006-01-02T15-04-05")
+	path := filepath.Join(dir, fmt.Sprintf("capture_%s.pcap", ts))
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create recording file: %w", err)
+	}
+
+	w := pcapgo.NewWriter(f)
+	var linkType layers.LinkType
+	if c.handle != nil {
+		linkType = c.handle.LinkType()
+	} else {
+		linkType = layers.LinkTypeEthernet
+	}
+	if err := w.WriteFileHeader(SnapLen, linkType); err != nil {
+		f.Close()
+		return fmt.Errorf("write pcap header: %w", err)
+	}
+
+	c.recordFile = f
+	c.recordWriter = w
+	return nil
+}
+
+// StopRecording flushes and closes the current recording. Returns nil if not recording.
+func (c *Capturer) StopRecording() error {
+	c.recordMu.Lock()
+	defer c.recordMu.Unlock()
+
+	if c.recordWriter == nil {
+		return nil
+	}
+	err := c.recordFile.Close()
+	c.recordFile = nil
+	c.recordWriter = nil
+	return err
+}
+
+// IsRecording reports whether a recording is currently active.
+func (c *Capturer) IsRecording() bool {
+	c.recordMu.Lock()
+	defer c.recordMu.Unlock()
+	return c.recordWriter != nil
+}
+
 func (c *Capturer) processPacket(p gopacket.Packet) {
+	c.recordMu.Lock()
+	if c.recordWriter != nil {
+		if err := c.recordWriter.WritePacket(p.Metadata().CaptureInfo, p.Data()); err != nil {
+			n := atomic.AddUint64(&c.recordWriteErrors, 1)
+			if n%100 == 1 {
+				logger.PrintWarn("PKT", "pcap recorder write error: %v", err)
+			}
+		}
+	}
+	c.recordMu.Unlock()
+
 	udpLayer := p.Layer(layers.LayerTypeUDP)
 	if udpLayer == nil {
 		return

--- a/internal/capture/pcap.go
+++ b/internal/capture/pcap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/nospy/albion-openradar/internal/logger"
 )
+
+var reUnsafeFilename = regexp.MustCompile(`[^A-Za-z0-9_\-]`)
 
 const (
 	AlbionPort  = 5056
@@ -123,7 +126,17 @@ func (c *Capturer) Stats() (*pcap.Stats, error) {
 	return c.handle.Stats()
 }
 
-// StartRecording begins writing all packets to a new capture_<TS>.pcap in dir.
+// sanitizeIfaceName replaces characters not in [A-Za-z0-9_-] with underscores.
+// Returns "unknown" if the result is empty.
+func sanitizeIfaceName(name string) string {
+	s := reUnsafeFilename.ReplaceAllString(name, "_")
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// StartRecording begins writing all packets to a new capture_<TS>_<iface>.pcap in dir.
 // Returns an error if already recording or if the file cannot be created.
 func (c *Capturer) StartRecording(dir string) error {
 	c.recordMu.Lock()
@@ -137,7 +150,8 @@ func (c *Capturer) StartRecording(dir string) error {
 	}
 
 	ts := time.Now().Format("2006-01-02T15-04-05")
-	path := filepath.Join(dir, fmt.Sprintf("capture_%s.pcap", ts))
+	iface := sanitizeIfaceName(c.iface.Name)
+	path := filepath.Join(dir, fmt.Sprintf("capture_%s_%s.pcap", ts, iface))
 
 	f, err := os.Create(path)
 	if err != nil {

--- a/internal/capture/pcap_record_test.go
+++ b/internal/capture/pcap_record_test.go
@@ -1,0 +1,241 @@
+package capture
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/pcapgo"
+)
+
+// pcap-derived: fixture from internal/photon/testdata/fragments.pcap (real Albion capture).
+const photonFixture = "../photon/testdata/fragments.pcap"
+
+// newCapturerFromOffline opens a pcap fixture to obtain a real *pcap.Handle
+// and returns a Capturer wired to it. The handle is closed by c.Close().
+func newCapturerFromOffline(t *testing.T, fixturePath string) *Capturer {
+	t.Helper()
+	handle, err := pcap.OpenOffline(fixturePath)
+	if err != nil {
+		t.Skipf("cannot open fixture %s: %v", fixturePath, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Capturer{
+		handle: handle,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func TestStartRecording_CreatesReadableFile(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+	defer c.Close()
+
+	sourceLinkType := c.handle.LinkType()
+
+	dir := t.TempDir()
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+	defer c.StopRecording() //nolint:errcheck // cleanup path in test
+
+	matches, err := filepath.Glob(filepath.Join(dir, "capture_*.pcap"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want exactly one capture_*.pcap, got %v", matches)
+	}
+
+	h, err := pcap.OpenOffline(matches[0])
+	if err != nil {
+		t.Fatalf("OpenOffline on recorded file: %v", err)
+	}
+	defer h.Close()
+	if h.LinkType() != sourceLinkType {
+		t.Errorf("recorded LinkType() = %v, want %v", h.LinkType(), sourceLinkType)
+	}
+}
+
+func TestStartRecording_TwiceIsAnError(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+	defer c.Close()
+
+	dir := t.TempDir()
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("first StartRecording: %v", err)
+	}
+	defer c.StopRecording() //nolint:errcheck // cleanup path in test
+
+	if err := c.StartRecording(dir); err == nil {
+		t.Fatal("second StartRecording: expected error, got nil")
+	}
+}
+
+func TestStopRecording_BeforeStartIsNoOp(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+	defer c.Close()
+
+	if err := c.StopRecording(); err != nil {
+		t.Fatalf("StopRecording on fresh capturer: %v", err)
+	}
+}
+
+// TestProcessPacket_WritesToRecorder feeds synthetic Ethernet+UDP packets
+// through the capturer's processPacket while recording, then verifies the
+// recorded file contains exactly those packets.
+//
+// synthetic: packets are constructed in-process; no live Albion traffic needed.
+func TestProcessPacket_WritesToRecorder(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+	defer c.Close()
+
+	dir := t.TempDir()
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+
+	payloads := [][]byte{
+		[]byte("hello"),
+		[]byte("world"),
+	}
+
+	for _, pl := range payloads {
+		pkt := buildUDPPacket(t, pl)
+		c.processPacket(pkt)
+	}
+
+	if err := c.StopRecording(); err != nil {
+		t.Fatalf("StopRecording: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "capture_*.pcap"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected one capture file, Glob returned %v err=%v", matches, err)
+	}
+
+	f, err := os.Open(matches[0])
+	if err != nil {
+		t.Fatalf("open recorded file: %v", err)
+	}
+	defer f.Close()
+
+	reader, err := pcapgo.NewReader(f)
+	if err != nil {
+		t.Fatalf("pcapgo.NewReader: %v", err)
+	}
+
+	src := gopacket.NewPacketSource(reader, reader.LinkType())
+	got := 0
+	for pkt := range src.Packets() {
+		if got >= len(payloads) {
+			t.Fatalf("more packets than expected in recording")
+		}
+		udpLayer := pkt.Layer(layers.LayerTypeUDP)
+		if udpLayer == nil {
+			t.Fatalf("packet %d: no UDP layer", got)
+		}
+		udp := udpLayer.(*layers.UDP)
+		if !bytes.Equal(udp.Payload, payloads[got]) {
+			t.Errorf("packet %d payload = %q, want %q", got, udp.Payload, payloads[got])
+		}
+		got++
+	}
+	if got != len(payloads) {
+		t.Errorf("recorded %d packets, want %d", got, len(payloads))
+	}
+}
+
+func TestClose_StopsRecording(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+
+	dir := t.TempDir()
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+
+	payload := []byte("closepkt")
+	pkt := buildUDPPacket(t, payload)
+	c.processPacket(pkt)
+
+	c.Close()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "capture_*.pcap"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected one capture file after Close, got %v err=%v", matches, err)
+	}
+
+	f, err := os.Open(matches[0])
+	if err != nil {
+		t.Fatalf("open recorded file after Close: %v", err)
+	}
+	defer f.Close()
+
+	reader, err := pcapgo.NewReader(f)
+	if err != nil {
+		t.Fatalf("pcapgo.NewReader: %v", err)
+	}
+
+	src := gopacket.NewPacketSource(reader, reader.LinkType())
+	got := 0
+	for pkt := range src.Packets() {
+		udpLayer := pkt.Layer(layers.LayerTypeUDP)
+		if udpLayer == nil {
+			t.Fatalf("packet %d: no UDP layer", got)
+		}
+		udp := udpLayer.(*layers.UDP)
+		if !bytes.Equal(udp.Payload, payload) {
+			t.Errorf("packet %d payload = %q, want %q", got, udp.Payload, payload)
+		}
+		got++
+	}
+	if got != 1 {
+		t.Errorf("recorded %d packets, want 1", got)
+	}
+}
+
+// buildUDPPacket constructs a minimal Ethernet+IPv4+UDP packet carrying payload
+// on UDP src/dst port AlbionPort so processPacket's BPF-free path picks it up.
+func buildUDPPacket(t *testing.T, payload []byte) gopacket.Packet {
+	t.Helper()
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: false}
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0, 0, 0, 0, 0, 1},
+		DstMAC:       []byte{0, 0, 0, 0, 0, 2},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    []byte{127, 0, 0, 1},
+		DstIP:    []byte{127, 0, 0, 1},
+	}
+	udp := &layers.UDP{
+		SrcPort: AlbionPort,
+		DstPort: AlbionPort,
+	}
+	udp.SetNetworkLayerForChecksum(ip)
+
+	if err := gopacket.SerializeLayers(buf, opts, eth, ip, udp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("SerializeLayers: %v", err)
+	}
+
+	pkt := gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
+	ci := gopacket.CaptureInfo{
+		Timestamp:     time.Now(),
+		CaptureLength: len(buf.Bytes()),
+		Length:        len(buf.Bytes()),
+	}
+	pkt.Metadata().CaptureInfo = ci
+	return pkt
+}

--- a/internal/capture/pcap_record_test.go
+++ b/internal/capture/pcap_record_test.go
@@ -152,6 +152,83 @@ func TestProcessPacket_WritesToRecorder(t *testing.T) {
 	}
 }
 
+// TestStartRecording_AfterStop_RecordsToNewFile verifies that toggling
+// recording off then on produces a second file that actually receives
+// packets. Reproduces the live regression where files created via the
+// API toggle contained only a 24-byte header.
+//
+// synthetic: packets are constructed in-process; no live Albion traffic needed.
+func TestStartRecording_AfterStop_RecordsToNewFile(t *testing.T) {
+	c := newCapturerFromOffline(t, photonFixture)
+	defer c.Close()
+
+	dir := t.TempDir()
+
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("first StartRecording: %v", err)
+	}
+	first := []byte("first-cycle")
+	c.processPacket(buildUDPPacket(t, first))
+	if err := c.StopRecording(); err != nil {
+		t.Fatalf("first StopRecording: %v", err)
+	}
+
+	// Sleep long enough that the next call produces a distinct timestamp filename.
+	time.Sleep(1100 * time.Millisecond)
+
+	if err := c.StartRecording(dir); err != nil {
+		t.Fatalf("second StartRecording: %v", err)
+	}
+	second := []byte("second-cycle")
+	c.processPacket(buildUDPPacket(t, second))
+	if err := c.StopRecording(); err != nil {
+		t.Fatalf("second StopRecording: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "capture_*.pcap"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("want 2 capture files, got %d: %v", len(matches), matches)
+	}
+
+	wantedPayloads := map[string]bool{string(first): false, string(second): false}
+	for _, path := range matches {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open %s: %v", path, err)
+		}
+		reader, err := pcapgo.NewReader(f)
+		if err != nil {
+			f.Close()
+			t.Fatalf("pcapgo.NewReader on %s: %v", path, err)
+		}
+		src := gopacket.NewPacketSource(reader, reader.LinkType())
+		count := 0
+		for pkt := range src.Packets() {
+			udp, ok := pkt.Layer(layers.LayerTypeUDP).(*layers.UDP)
+			if !ok {
+				continue
+			}
+			if _, exists := wantedPayloads[string(udp.Payload)]; exists {
+				wantedPayloads[string(udp.Payload)] = true
+			}
+			count++
+		}
+		f.Close()
+		if count != 1 {
+			t.Errorf("%s recorded %d packets, want 1", path, count)
+		}
+	}
+
+	for payload, found := range wantedPayloads {
+		if !found {
+			t.Errorf("payload %q not found in any recorded file", payload)
+		}
+	}
+}
+
 func TestClose_StopsRecording(t *testing.T) {
 	c := newCapturerFromOffline(t, photonFixture)
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,15 +29,17 @@ type LogEntry struct {
 type Logger struct {
 	logsDir            string
 	currentSessionFile string
+	currentDebugFile   string
 	sessionStartTime   time.Time
 	enabled            bool
 	mu                 sync.Mutex
 
 	// Batching
-	buffer      []interface{}
-	bufferMu    sync.Mutex
-	flushTicker *time.Ticker
-	stopFlush   chan struct{}
+	serverBuffer []interface{}
+	clientBuffer []interface{}
+	bufferMu     sync.Mutex
+	flushTicker  *time.Ticker
+	stopFlush    chan struct{}
 
 	// Stats
 	totalEntries  uint64
@@ -51,7 +53,8 @@ func New(logsDir string, enabled bool) *Logger {
 		logsDir:          logsDir,
 		enabled:          enabled,
 		sessionStartTime: time.Now(),
-		buffer:           make([]interface{}, 0, MaxBufferSize),
+		serverBuffer:     make([]interface{}, 0, MaxBufferSize),
+		clientBuffer:     make([]interface{}, 0, MaxBufferSize),
 		stopFlush:        make(chan struct{}),
 	}
 	l.initializeDirectories()
@@ -123,18 +126,34 @@ func (l *Logger) createSessionFile() {
 		"sessions",
 		fmt.Sprintf("session_%s.jsonl", timestamp),
 	)
+	l.currentDebugFile = filepath.Join(
+		l.logsDir,
+		"debug",
+		fmt.Sprintf("front_%s.jsonl", timestamp),
+	)
 }
 
-// WriteLogs queues client logs for batched writing
+// WriteLogs queues client logs for batched writing and mirrors ERROR/CRITICAL synchronously.
 func (l *Logger) WriteLogs(logs []interface{}) {
 	if len(logs) == 0 {
 		return
 	}
 
+	for _, raw := range logs {
+		if m, ok := raw.(map[string]interface{}); ok {
+			level, _ := m["level"].(string)
+			if level == "ERROR" || level == "CRITICAL" {
+				category, _ := m["category"].(string)
+				event, _ := m["event"].(string)
+				l.writeErrorLine(category, event, m["data"])
+			}
+		}
+	}
+
 	l.bufferMu.Lock()
-	l.buffer = append(l.buffer, logs...)
+	l.clientBuffer = append(l.clientBuffer, logs...)
 	l.clientEntries += uint64(len(logs))
-	shouldFlush := len(l.buffer) >= MaxBufferSize
+	shouldFlush := len(l.clientBuffer) >= MaxBufferSize
 	l.bufferMu.Unlock()
 
 	if shouldFlush {
@@ -142,40 +161,57 @@ func (l *Logger) WriteLogs(logs []interface{}) {
 	}
 }
 
-// Flush writes buffered logs to file
+// Flush writes buffered logs to their respective files.
 func (l *Logger) Flush() {
 	l.bufferMu.Lock()
-	if len(l.buffer) == 0 {
+	serverBatch := l.serverBuffer
+	clientBatch := l.clientBuffer
+	if len(serverBatch) == 0 && len(clientBatch) == 0 {
 		l.bufferMu.Unlock()
 		return
 	}
-	batch := l.buffer
-	l.buffer = make([]interface{}, 0, MaxBufferSize)
+	l.serverBuffer = make([]interface{}, 0, MaxBufferSize)
+	l.clientBuffer = make([]interface{}, 0, MaxBufferSize)
 	l.bufferMu.Unlock()
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	f, err := os.OpenFile(l.currentSessionFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-
-	for _, log := range batch {
-		line, err := json.Marshal(log)
-		if err != nil {
-			continue
+	if len(serverBatch) > 0 {
+		f, err := os.OpenFile(l.currentSessionFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			for _, log := range serverBatch {
+				line, err := json.Marshal(log)
+				if err != nil {
+					continue
+				}
+				f.Write(line)
+				f.WriteString("\n")
+			}
+			f.Close()
 		}
-		f.Write(line)
-		f.WriteString("\n")
 	}
 
-	l.totalEntries += uint64(len(batch))
+	if len(clientBatch) > 0 {
+		f, err := os.OpenFile(l.currentDebugFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			for _, log := range clientBatch {
+				line, err := json.Marshal(log)
+				if err != nil {
+					continue
+				}
+				f.Write(line)
+				f.WriteString("\n")
+			}
+			f.Close()
+		}
+	}
+
+	l.totalEntries += uint64(len(serverBatch) + len(clientBatch))
 	l.totalBatches++
 }
 
-// Log queues a server-side log entry
+// Log queues a server-side log entry.
 func (l *Logger) Log(level, category, event string, data interface{}, context map[string]interface{}) {
 	l.mu.Lock()
 	if !l.enabled {
@@ -199,18 +235,13 @@ func (l *Logger) Log(level, category, event string, data interface{}, context ma
 	}
 
 	l.bufferMu.Lock()
-	l.buffer = append(l.buffer, entry)
+	l.serverBuffer = append(l.serverBuffer, entry)
 	l.serverEntries++
 	l.bufferMu.Unlock()
 }
 
-func (l *Logger) Error(category, event string, data interface{}, context map[string]interface{}) {
-	l.Log("ERROR", category, event, data, context)
-
-	// Also write to dedicated error file immediately
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
+// writeErrorLine appends one line to the daily errors file.
+func (l *Logger) writeErrorLine(category, event string, data interface{}) {
 	date := time.Now().Format("2006-01-02")
 	errorFile := filepath.Join(l.logsDir, "errors", fmt.Sprintf("errors_%s.log", date))
 
@@ -223,6 +254,11 @@ func (l *Logger) Error(category, event string, data interface{}, context map[str
 	dataJSON, _ := json.Marshal(data)
 	line := fmt.Sprintf("[%s] %s.%s: %s\n", time.Now().UTC().Format(time.RFC3339), category, event, string(dataJSON))
 	f.WriteString(line)
+}
+
+func (l *Logger) Error(category, event string, data interface{}, context map[string]interface{}) {
+	l.Log("ERROR", category, event, data, context)
+	l.writeErrorLine("[SERVER] "+category, event, data)
 }
 
 func (l *Logger) Debug(category, event string, data interface{}, context map[string]interface{}) {
@@ -242,24 +278,29 @@ func (l *Logger) Critical(category, event string, data interface{}, context map[
 }
 
 type LogStats struct {
-	TotalEntries  uint64 `json:"totalEntries"`
-	TotalBatches  uint64 `json:"totalBatches"`
-	ClientEntries uint64 `json:"clientEntries"`
-	ServerEntries uint64 `json:"serverEntries"`
-	BufferSize    int    `json:"bufferSize"`
+	TotalEntries     uint64 `json:"totalEntries"`
+	TotalBatches     uint64 `json:"totalBatches"`
+	ClientEntries    uint64 `json:"clientEntries"`
+	ServerEntries    uint64 `json:"serverEntries"`
+	BufferSize       int    `json:"bufferSize"`
+	ServerBufferSize int    `json:"serverBufferSize"`
+	ClientBufferSize int    `json:"clientBufferSize"`
 }
 
 func (l *Logger) GetStats() LogStats {
 	l.bufferMu.Lock()
-	bufSize := len(l.buffer)
+	serverBufSize := len(l.serverBuffer)
+	clientBufSize := len(l.clientBuffer)
 	l.bufferMu.Unlock()
 
 	return LogStats{
-		TotalEntries:  l.totalEntries,
-		TotalBatches:  l.totalBatches,
-		ClientEntries: l.clientEntries,
-		ServerEntries: l.serverEntries,
-		BufferSize:    bufSize,
+		TotalEntries:     l.totalEntries,
+		TotalBatches:     l.totalBatches,
+		ClientEntries:    l.clientEntries,
+		ServerEntries:    l.serverEntries,
+		BufferSize:       serverBufSize + clientBufSize,
+		ServerBufferSize: serverBufSize,
+		ClientBufferSize: clientBufSize,
 	}
 }
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -46,10 +46,10 @@ type Logger struct {
 	serverEntries uint64
 }
 
-func New(logsDir string) *Logger {
+func New(logsDir string, enabled bool) *Logger {
 	l := &Logger{
 		logsDir:          logsDir,
-		enabled:          false,
+		enabled:          enabled,
 		sessionStartTime: time.Now(),
 		buffer:           make([]interface{}, 0, MaxBufferSize),
 		stopFlush:        make(chan struct{}),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -257,8 +257,8 @@ func (l *Logger) writeErrorLine(category, event string, data interface{}) {
 }
 
 func (l *Logger) Error(category, event string, data interface{}, context map[string]interface{}) {
-	l.Log("ERROR", category, event, data, context)
 	l.writeErrorLine("[SERVER] "+category, event, data)
+	l.Log("ERROR", category, event, data, context)
 }
 
 func (l *Logger) Debug(category, event string, data interface{}, context map[string]interface{}) {
@@ -274,6 +274,7 @@ func (l *Logger) Warn(category, event string, data interface{}, context map[stri
 }
 
 func (l *Logger) Critical(category, event string, data interface{}, context map[string]interface{}) {
+	l.writeErrorLine("[SERVER] "+category, event, data)
 	l.Log("CRITICAL", category, event, data, context)
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -143,6 +143,133 @@ func TestWriteLogs_MixedBatch_RoutesPerLevel(t *testing.T) {
 	}
 }
 
+func TestLog_ErrorWritesToErrorsEvenWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.Error("CAT", "ev", map[string]interface{}{"k": 1}, nil)
+	l.Flush()
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "CAT.ev") {
+		t.Fatalf("errors line: want CAT.ev, got %q", errLines[0])
+	}
+
+	sessionLines := readSessionLines(t, dir)
+	for _, line := range sessionLines {
+		if strings.Contains(line, "CAT") && strings.Contains(line, "ev") {
+			t.Fatalf("sessions file: unexpected CAT.ev entry when disabled: %q", line)
+		}
+	}
+}
+
+func TestLog_CriticalWritesToErrorsEvenWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.Critical("CAT", "ev", map[string]interface{}{"k": 1}, nil)
+	l.Flush()
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "CAT.ev") {
+		t.Fatalf("errors line: want CAT.ev, got %q", errLines[0])
+	}
+
+	sessionLines := readSessionLines(t, dir)
+	for _, line := range sessionLines {
+		if strings.Contains(line, "CAT") && strings.Contains(line, "ev") {
+			t.Fatalf("sessions file: unexpected CAT.ev entry when disabled: %q", line)
+		}
+	}
+}
+
+func TestLog_ErrorWhenEnabledHitsBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, true)
+	defer l.Stop()
+
+	l.Error("CAT", "ev", map[string]interface{}{"k": 1}, nil)
+	l.Flush()
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "CAT.ev") {
+		t.Fatalf("errors line: want CAT.ev, got %q", errLines[0])
+	}
+
+	sessionLines := readSessionLines(t, dir)
+	found := false
+	for _, line := range sessionLines {
+		if strings.Contains(line, "CAT") && strings.Contains(line, "ev") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("sessions file: want CAT.ev entry when enabled, got lines: %v", sessionLines)
+	}
+}
+
+func TestLog_CriticalWhenEnabledHitsBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, true)
+	defer l.Stop()
+
+	l.Critical("CAT", "ev", map[string]interface{}{"k": 1}, nil)
+	l.Flush()
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "CAT.ev") {
+		t.Fatalf("errors line: want CAT.ev, got %q", errLines[0])
+	}
+
+	sessionLines := readSessionLines(t, dir)
+	found := false
+	for _, line := range sessionLines {
+		if strings.Contains(line, "CAT") && strings.Contains(line, "ev") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("sessions file: want CAT.ev entry when enabled, got lines: %v", sessionLines)
+	}
+}
+
+func TestLog_InfoWhenDisabledWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.Info("CAT", "ev", map[string]interface{}{"k": 1}, nil)
+	l.Flush()
+
+	sessionLines := readSessionLines(t, dir)
+	for _, line := range sessionLines {
+		if strings.Contains(line, "CAT") && strings.Contains(line, "ev") {
+			t.Fatalf("sessions file: unexpected CAT.ev entry when disabled: %q", line)
+		}
+	}
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 0 {
+		t.Fatalf("errors file: want 0 lines, got %d: %v", len(errLines), errLines)
+	}
+}
+
 func readDebugLines(t *testing.T, dir string) []string {
 	t.Helper()
 	return readNonEmptyLinesFromDir(t, filepath.Join(dir, "debug"))

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,6 +1,10 @@
 package logger
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,4 +24,160 @@ func TestNew_RespectsInitialDisabled(t *testing.T) {
 	if l.IsEnabled() {
 		t.Fatal("IsEnabled: got true, want false")
 	}
+}
+
+func TestWriteLogs_RoutesToDebugFile(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.WriteLogs([]interface{}{
+		map[string]interface{}{"level": "DEBUG", "category": "X", "event": "e", "data": map[string]interface{}{}},
+	})
+	l.Flush()
+
+	debugLines := readDebugLines(t, dir)
+	if len(debugLines) != 1 {
+		t.Fatalf("debug file: want 1 line, got %d", len(debugLines))
+	}
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(debugLines[0]), &entry); err != nil {
+		t.Fatalf("debug line not valid JSON: %v", err)
+	}
+	if entry["level"] != "DEBUG" {
+		t.Fatalf("level: want DEBUG, got %v", entry["level"])
+	}
+
+	sessionLines := readSessionLines(t, dir)
+	if len(sessionLines) != 0 {
+		t.Fatalf("sessions file: want 0 lines, got %d", len(sessionLines))
+	}
+}
+
+func TestWriteLogs_ErrorAlsoRoutesToErrorsFile(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.WriteLogs([]interface{}{
+		map[string]interface{}{"level": "ERROR", "category": "X", "event": "e", "data": map[string]interface{}{}},
+	})
+	l.Flush()
+
+	debugLines := readDebugLines(t, dir)
+	if len(debugLines) != 1 {
+		t.Fatalf("debug file: want 1 line, got %d", len(debugLines))
+	}
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "X.e") {
+		t.Fatalf("errors line: want X.e, got %q", errLines[0])
+	}
+}
+
+func TestWriteLogs_CriticalAlsoRoutesToErrorsFile(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.WriteLogs([]interface{}{
+		map[string]interface{}{"level": "CRITICAL", "category": "X", "event": "e", "data": map[string]interface{}{}},
+	})
+	l.Flush()
+
+	debugLines := readDebugLines(t, dir)
+	if len(debugLines) != 1 {
+		t.Fatalf("debug file: want 1 line, got %d", len(debugLines))
+	}
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 1 {
+		t.Fatalf("errors file: want 1 line, got %d", len(errLines))
+	}
+	if !strings.Contains(errLines[0], "X.e") {
+		t.Fatalf("errors line: want X.e, got %q", errLines[0])
+	}
+}
+
+func TestWriteLogs_MixedBatch_RoutesPerLevel(t *testing.T) {
+	dir := t.TempDir()
+	l := New(dir, false)
+	defer l.Stop()
+
+	l.WriteLogs([]interface{}{
+		map[string]interface{}{"level": "INFO", "category": "INFO_CAT", "event": "info_evt", "data": nil},
+		map[string]interface{}{"level": "WARN", "category": "WARN_CAT", "event": "warn_evt", "data": nil},
+		map[string]interface{}{"level": "ERROR", "category": "ERR_CAT", "event": "err_evt", "data": nil},
+		map[string]interface{}{"level": "CRITICAL", "category": "CRIT_CAT", "event": "crit_evt", "data": nil},
+	})
+	l.Flush()
+
+	debugLines := readDebugLines(t, dir)
+	if len(debugLines) != 4 {
+		t.Fatalf("debug file: want 4 lines, got %d", len(debugLines))
+	}
+
+	errLines := readErrorLines(t, dir)
+	if len(errLines) != 2 {
+		t.Fatalf("errors file: want 2 lines, got %d", len(errLines))
+	}
+
+	hasErr := false
+	hasCrit := false
+	for _, line := range errLines {
+		if strings.Contains(line, "ERR_CAT.err_evt") {
+			hasErr = true
+		}
+		if strings.Contains(line, "CRIT_CAT.crit_evt") {
+			hasCrit = true
+		}
+	}
+	if !hasErr {
+		t.Fatalf("errors file: no line containing ERR_CAT.err_evt; lines: %v", errLines)
+	}
+	if !hasCrit {
+		t.Fatalf("errors file: no line containing CRIT_CAT.crit_evt; lines: %v", errLines)
+	}
+}
+
+func readDebugLines(t *testing.T, dir string) []string {
+	t.Helper()
+	return readNonEmptyLinesFromDir(t, filepath.Join(dir, "debug"))
+}
+
+func readSessionLines(t *testing.T, dir string) []string {
+	t.Helper()
+	return readNonEmptyLinesFromDir(t, filepath.Join(dir, "sessions"))
+}
+
+func readErrorLines(t *testing.T, dir string) []string {
+	t.Helper()
+	return readNonEmptyLinesFromDir(t, filepath.Join(dir, "errors"))
+}
+
+func readNonEmptyLinesFromDir(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", dir, err)
+	}
+	var lines []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.TrimSpace(line) != "" {
+				lines = append(lines, line)
+			}
+		}
+	}
+	return lines
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"testing"
+)
+
+func TestNew_RespectsInitialEnabled(t *testing.T) {
+	l := New(t.TempDir(), true)
+	defer l.Stop()
+
+	if !l.IsEnabled() {
+		t.Fatal("IsEnabled: got false, want true")
+	}
+}
+
+func TestNew_RespectsInitialDisabled(t *testing.T) {
+	l := New(t.TempDir(), false)
+	defer l.Stop()
+
+	if l.IsEnabled() {
+		t.Fatal("IsEnabled: got true, want false")
+	}
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -47,6 +47,8 @@ func NewHTTPServer(
 	mgr NetworkManager,
 	allInterfaces []capture.NetworkInterface,
 	appDir string,
+	recorder Recorder,
+	captureDir string,
 ) (*HTTPServer, error) {
 	// Extract subdirectories from embed.FS (they include the folder path)
 	imagesFS, err := fs.Sub(images, "web/images")
@@ -93,7 +95,7 @@ func NewHTTPServer(
 	if mgr != nil {
 		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
-	s.settingsAPI = NewSettingsAPI(appDir, log)
+	s.settingsAPI = NewSettingsAPI(appDir, log, recorder, captureDir)
 	s.setupRoutes()
 	return s, nil
 }
@@ -107,6 +109,8 @@ func NewHTTPServerDev(
 	version string,
 	mgr NetworkManager,
 	allInterfaces []capture.NetworkInterface,
+	recorder Recorder,
+	captureDir string,
 ) (*HTTPServer, error) {
 	// Initialize template engine in dev mode (hot reload)
 	tmplDir := appDir + "/internal/templates"
@@ -133,7 +137,7 @@ func NewHTTPServerDev(
 	if mgr != nil {
 		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
-	s.settingsAPI = NewSettingsAPI(appDir, log)
+	s.settingsAPI = NewSettingsAPI(appDir, log, recorder, captureDir)
 	s.setupRoutes()
 	return s, nil
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/encoding/json"
-
 	"github.com/nospy/albion-openradar/internal/capture"
 	"github.com/nospy/albion-openradar/internal/logger"
 	"github.com/nospy/albion-openradar/internal/templates"
@@ -32,10 +30,11 @@ type HTTPServer struct {
 	sounds  fs.FS
 	styles  fs.FS
 	// Template engine
-	tmpl       *templates.Engine
-	version    string
-	devMode    bool
-	networkAPI *NetworkAPI
+	tmpl        *templates.Engine
+	version     string
+	devMode     bool
+	networkAPI  *NetworkAPI
+	settingsAPI *SettingsAPI
 }
 
 // NewHTTPServer creates a new HTTP server with embedded assets (production mode)
@@ -94,6 +93,7 @@ func NewHTTPServer(
 	if mgr != nil {
 		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
+	s.settingsAPI = NewSettingsAPI(appDir, log)
 	s.setupRoutes()
 	return s, nil
 }
@@ -133,6 +133,7 @@ func NewHTTPServerDev(
 	if mgr != nil {
 		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
 	}
+	s.settingsAPI = NewSettingsAPI(appDir, log)
 	s.setupRoutes()
 	return s, nil
 }
@@ -193,7 +194,7 @@ func (s *HTTPServer) setupRoutes() {
 	)
 
 	// API endpoints
-	s.mux.HandleFunc("/api/settings/server-logs", s.handleServerLogs)
+	s.settingsAPI.Register(s.mux)
 	if s.networkAPI != nil {
 		s.networkAPI.Register(s.mux)
 	}
@@ -223,7 +224,7 @@ func (s *HTTPServer) renderPage(w http.ResponseWriter, r *http.Request, page str
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
 	// Check if this is an HTMX request (SPA navigation)
-	isHTMX := r.Header.Get("HX-Request") == "true"
+	isHTMX := r.Header.Get("Hx-Request") == "true"
 
 	var err error
 	if isHTMX {
@@ -367,39 +368,6 @@ func setContentType(w http.ResponseWriter, path string) {
 		w.Header().Set("Content-Type", "application/json")
 	case strings.HasSuffix(path, ".xml"):
 		w.Header().Set("Content-Type", "application/xml")
-	}
-}
-
-// handleServerLogs handles the server logs API
-func (s *HTTPServer) handleServerLogs(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
-	switch r.Method {
-	case http.MethodGet:
-		enabled := false
-		if s.logger != nil {
-			enabled = s.logger.IsEnabled()
-		}
-		_ = json.NewEncoder(w).Encode(map[string]bool{"enabled": enabled})
-
-	case http.MethodPost:
-		var req struct {
-			Enabled bool `json:"enabled"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, `{"error":"Invalid JSON"}`, http.StatusBadRequest)
-			return
-		}
-		if s.logger != nil {
-			s.logger.SetEnabled(req.Enabled)
-		}
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"success": true,
-			"enabled": s.logger != nil && s.logger.IsEnabled(),
-		})
-
-	default:
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 

--- a/internal/server/network_api.go
+++ b/internal/server/network_api.go
@@ -136,7 +136,9 @@ func (a *NetworkAPI) handleSelect(w http.ResponseWriter, r *http.Request) {
 	for _, i := range desired {
 		persisted = append(persisted, capture.PersistedInterface{Name: i.Name, Description: i.Description})
 	}
-	if err := capture.WriteConfig(a.appDir, capture.Config{CaptureInterfaces: persisted}); err != nil {
+	if err := capture.MutateConfig(a.appDir, func(cfg *capture.Config) {
+		cfg.CaptureInterfaces = persisted
+	}); err != nil {
 		http.Error(w, "persist: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/server/network_api_test.go
+++ b/internal/server/network_api_test.go
@@ -228,6 +228,42 @@ func TestNetworkAPI_StatePOSTIs405(t *testing.T) {
 	}
 }
 
+func TestNetworkSelect_PreservesLogging(t *testing.T) {
+	fm := &fakeManager{
+		allInterfaces: []capture.NetworkInterface{
+			{Name: "eth0", Description: "Ethernet", Address: "10.0.0.1"},
+		},
+	}
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{ServerLogsEnabled: true},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	api := NewNetworkAPI(fm, fm.allInterfaces, dir, func() []string { return nil })
+	mux := newTestMux(api)
+
+	body, _ := json.Marshal(map[string]any{"names": []string{"eth0"}})
+	req := httptest.NewRequest(http.MethodPost, "/api/network/interfaces", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, body=%s", rec.Code, rec.Body.String())
+	}
+	cfg, err := capture.ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !cfg.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled was reset by POST /api/network/interfaces")
+	}
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Name != "eth0" {
+		t.Errorf("CaptureInterfaces wrong: %+v", cfg.CaptureInterfaces)
+	}
+}
+
 // Proves the RWMutex fix: without it, concurrent reads of a.all while a writer
 // mutates the slice would race under -race.
 func TestNetworkAPI_RefreshConcurrentSafe(t *testing.T) {

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/segmentio/encoding/json"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+	"github.com/nospy/albion-openradar/internal/logger"
+)
+
+type SettingsAPI struct {
+	appDir string
+	logger *logger.Logger
+}
+
+func NewSettingsAPI(appDir string, log *logger.Logger) *SettingsAPI {
+	return &SettingsAPI{appDir: appDir, logger: log}
+}
+
+func (a *SettingsAPI) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/settings/logging", a.handleGet)
+	mux.HandleFunc("POST /api/settings/logging", a.handlePost)
+}
+
+func (a *SettingsAPI) handleGet(w http.ResponseWriter, _ *http.Request) {
+	cfg, err := capture.ReadConfig(a.appDir)
+	if err != nil {
+		http.Error(w, "read config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg.Logging)
+}
+
+type loggingPatch struct {
+	ServerLogsEnabled *bool `json:"serverLogsEnabled"`
+	PcapRecording     *bool `json:"pcapRecording"`
+}
+
+func (a *SettingsAPI) handlePost(w http.ResponseWriter, r *http.Request) {
+	var patch loggingPatch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	cfg, err := capture.ReadConfig(a.appDir)
+	if err != nil {
+		http.Error(w, "read config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if patch.ServerLogsEnabled != nil {
+		cfg.Logging.ServerLogsEnabled = *patch.ServerLogsEnabled
+	}
+	if patch.PcapRecording != nil {
+		cfg.Logging.PcapRecording = *patch.PcapRecording
+	}
+
+	if err := capture.WriteConfig(a.appDir, cfg); err != nil {
+		http.Error(w, "write config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if patch.ServerLogsEnabled != nil && a.logger != nil {
+		a.logger.SetEnabled(*patch.ServerLogsEnabled)
+	}
+
+	writeJSON(w, http.StatusOK, cfg.Logging)
+}

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -44,20 +44,16 @@ func (a *SettingsAPI) handlePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg, err := capture.ReadConfig(a.appDir)
-	if err != nil {
-		http.Error(w, "read config: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if patch.ServerLogsEnabled != nil {
-		cfg.Logging.ServerLogsEnabled = *patch.ServerLogsEnabled
-	}
-	if patch.PcapRecording != nil {
-		cfg.Logging.PcapRecording = *patch.PcapRecording
-	}
-
-	if err := capture.WriteConfig(a.appDir, cfg); err != nil {
+	var newLogging capture.LoggingConfig
+	if err := capture.MutateConfig(a.appDir, func(cfg *capture.Config) {
+		if patch.ServerLogsEnabled != nil {
+			cfg.Logging.ServerLogsEnabled = *patch.ServerLogsEnabled
+		}
+		if patch.PcapRecording != nil {
+			cfg.Logging.PcapRecording = *patch.PcapRecording
+		}
+		newLogging = cfg.Logging
+	}); err != nil {
 		http.Error(w, "write config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -66,5 +62,5 @@ func (a *SettingsAPI) handlePost(w http.ResponseWriter, r *http.Request) {
 		a.logger.SetEnabled(*patch.ServerLogsEnabled)
 	}
 
-	writeJSON(w, http.StatusOK, cfg.Logging)
+	writeJSON(w, http.StatusOK, newLogging)
 }

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -9,13 +9,28 @@ import (
 	"github.com/nospy/albion-openradar/internal/logger"
 )
 
-type SettingsAPI struct {
-	appDir string
-	logger *logger.Logger
+// Recorder is the subset of capture.Manager used by SettingsAPI to control pcap recording.
+type Recorder interface {
+	StartRecording(dir string) error
+	StopRecording() error
+	IsRecording() bool
 }
 
-func NewSettingsAPI(appDir string, log *logger.Logger) *SettingsAPI {
-	return &SettingsAPI{appDir: appDir, logger: log}
+type SettingsAPI struct {
+	appDir     string
+	logger     *logger.Logger
+	recorder   Recorder
+	captureDir string
+}
+
+// NewSettingsAPI creates a SettingsAPI. recorder may be nil (recording calls are skipped).
+func NewSettingsAPI(appDir string, log *logger.Logger, recorder Recorder, captureDir string) *SettingsAPI {
+	return &SettingsAPI{
+		appDir:     appDir,
+		logger:     log,
+		recorder:   recorder,
+		captureDir: captureDir,
+	}
 }
 
 func (a *SettingsAPI) Register(mux *http.ServeMux) {
@@ -60,6 +75,23 @@ func (a *SettingsAPI) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	if patch.ServerLogsEnabled != nil && a.logger != nil {
 		a.logger.SetEnabled(*patch.ServerLogsEnabled)
+	}
+
+	if patch.PcapRecording != nil && a.recorder != nil {
+		if *patch.PcapRecording {
+			if err := a.recorder.StartRecording(a.captureDir); err != nil {
+				logger.PrintWarn("PKT", "pcap recording could not start: %v", err)
+				_ = capture.MutateConfig(a.appDir, func(cfg *capture.Config) {
+					cfg.Logging.PcapRecording = false
+				})
+				http.Error(w, "pcap recording failed: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			if err := a.recorder.StopRecording(); err != nil {
+				logger.PrintWarn("PKT", "pcap recording could not stop: %v", err)
+			}
+		}
 	}
 
 	writeJSON(w, http.StatusOK, newLogging)

--- a/internal/server/settings_api_test.go
+++ b/internal/server/settings_api_test.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nospy/albion-openradar/internal/capture"
+	"github.com/nospy/albion-openradar/internal/logger"
+)
+
+func newSettingsTestMux(t *testing.T, dir string) (*http.ServeMux, *logger.Logger) {
+	t.Helper()
+	log := logger.New(t.TempDir(), false)
+	t.Cleanup(func() { log.Stop() })
+	api := NewSettingsAPI(dir, log)
+	mux := http.NewServeMux()
+	api.Register(mux)
+	return mux, log
+}
+
+func TestSettingsLogging_GetReturnsCurrentConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{ServerLogsEnabled: true, PcapRecording: false},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	mux, _ := newSettingsTestMux(t, dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/logging", http.NoBody)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["serverLogsEnabled"] != true {
+		t.Errorf("serverLogsEnabled=%v, want true", body["serverLogsEnabled"])
+	}
+	if body["pcapRecording"] != false {
+		t.Errorf("pcapRecording=%v, want false", body["pcapRecording"])
+	}
+}
+
+func TestSettingsLogging_PostUpdatesPersistAndApply(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{ServerLogsEnabled: false, PcapRecording: false},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	mux, log := newSettingsTestMux(t, dir)
+
+	body, _ := json.Marshal(map[string]any{"serverLogsEnabled": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["serverLogsEnabled"] != true {
+		t.Errorf("response serverLogsEnabled=%v, want true", resp["serverLogsEnabled"])
+	}
+	if resp["pcapRecording"] != false {
+		t.Errorf("response pcapRecording=%v, want false", resp["pcapRecording"])
+	}
+
+	cfg, err := capture.ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !cfg.Logging.ServerLogsEnabled {
+		t.Error("network.json: serverLogsEnabled not persisted as true")
+	}
+	if cfg.Logging.PcapRecording {
+		t.Error("network.json: pcapRecording changed unexpectedly")
+	}
+
+	if !log.IsEnabled() {
+		t.Error("logger.IsEnabled() == false, want true after POST")
+	}
+}
+
+func TestSettingsLogging_PostPartialBody(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{ServerLogsEnabled: true, PcapRecording: false},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	mux, _ := newSettingsTestMux(t, dir)
+
+	body, _ := json.Marshal(map[string]any{"pcapRecording": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	cfg, err := capture.ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !cfg.Logging.ServerLogsEnabled {
+		t.Error("serverLogsEnabled was reset; partial update must leave it untouched")
+	}
+	if !cfg.Logging.PcapRecording {
+		t.Error("pcapRecording not updated to true")
+	}
+}
+
+func TestSettingsLogging_PostInvalidJson(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{ServerLogsEnabled: true, PcapRecording: false},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	mux, _ := newSettingsTestMux(t, dir)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader([]byte("{not json")))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	cfg, err := capture.ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !cfg.Logging.ServerLogsEnabled {
+		t.Error("network.json was modified despite invalid JSON")
+	}
+}
+
+func TestSettingsServerLogs_LegacyEndpointIsGone(t *testing.T) {
+	dir := t.TempDir()
+	mux, _ := newSettingsTestMux(t, dir)
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		req := httptest.NewRequest(method, "/api/settings/server-logs", http.NoBody)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s /api/settings/server-logs: status %d, want 404", method, rec.Code)
+		}
+	}
+}

--- a/internal/server/settings_api_test.go
+++ b/internal/server/settings_api_test.go
@@ -5,17 +5,52 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/nospy/albion-openradar/internal/capture"
 	"github.com/nospy/albion-openradar/internal/logger"
 )
 
+// fakeRecorder is an in-memory Recorder for tests.
+type fakeRecorder struct {
+	mu        sync.Mutex
+	recording bool
+	startErr  error
+	stopErr   error
+}
+
+func (r *fakeRecorder) StartRecording(_ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startErr != nil {
+		return r.startErr
+	}
+	r.recording = true
+	return nil
+}
+
+func (r *fakeRecorder) StopRecording() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopErr != nil {
+		return r.stopErr
+	}
+	r.recording = false
+	return nil
+}
+
+func (r *fakeRecorder) IsRecording() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.recording
+}
+
 func newSettingsTestMux(t *testing.T, dir string) (*http.ServeMux, *logger.Logger) {
 	t.Helper()
 	log := logger.New(t.TempDir(), false)
 	t.Cleanup(func() { log.Stop() })
-	api := NewSettingsAPI(dir, log)
+	api := NewSettingsAPI(dir, log, nil, "")
 	mux := http.NewServeMux()
 	api.Register(mux)
 	return mux, log
@@ -191,5 +226,61 @@ func TestSettingsServerLogs_LegacyEndpointIsGone(t *testing.T) {
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("%s /api/settings/server-logs: status %d, want 404", method, rec.Code)
 		}
+	}
+}
+
+func TestSettingsLogging_PostStartsRecording(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{PcapRecording: false},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	log := logger.New(t.TempDir(), false)
+	t.Cleanup(func() { log.Stop() })
+	rec := &fakeRecorder{}
+	api := NewSettingsAPI(dir, log, rec, t.TempDir())
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	body, _ := json.Marshal(map[string]any{"pcapRecording": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if !rec.IsRecording() {
+		t.Error("recorder.IsRecording() == false after POST pcapRecording=true")
+	}
+}
+
+func TestSettingsLogging_PostStopsRecording(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		Logging: capture.LoggingConfig{PcapRecording: true},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	log := logger.New(t.TempDir(), false)
+	t.Cleanup(func() { log.Stop() })
+	rec := &fakeRecorder{recording: true}
+	api := NewSettingsAPI(dir, log, rec, t.TempDir())
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	body, _ := json.Marshal(map[string]any{"pcapRecording": false})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if rec.IsRecording() {
+		t.Error("recorder.IsRecording() == true after POST pcapRecording=false")
 	}
 }

--- a/internal/server/settings_api_test.go
+++ b/internal/server/settings_api_test.go
@@ -147,6 +147,39 @@ func TestSettingsLogging_PostInvalidJson(t *testing.T) {
 	}
 }
 
+func TestSettingsLogging_PostPreservesNetworkInterfaces(t *testing.T) {
+	dir := t.TempDir()
+	if err := capture.WriteConfig(dir, capture.Config{
+		CaptureInterfaces: []capture.PersistedInterface{{Name: "X"}},
+		Logging:           capture.LoggingConfig{ServerLogsEnabled: true},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	mux, _ := newSettingsTestMux(t, dir)
+
+	body, _ := json.Marshal(map[string]any{"pcapRecording": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/logging", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	cfg, err := capture.ReadConfig(dir)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if len(cfg.CaptureInterfaces) != 1 || cfg.CaptureInterfaces[0].Name != "X" {
+		t.Errorf("CaptureInterfaces changed: %+v", cfg.CaptureInterfaces)
+	}
+	if !cfg.Logging.ServerLogsEnabled {
+		t.Error("Logging.ServerLogsEnabled was reset by partial POST")
+	}
+	if !cfg.Logging.PcapRecording {
+		t.Error("Logging.PcapRecording not updated to true")
+	}
+}
+
 func TestSettingsServerLogs_LegacyEndpointIsGone(t *testing.T) {
 	dir := t.TempDir()
 	mux, _ := newSettingsTestMux(t, dir)

--- a/internal/templates/layouts/base.gohtml
+++ b/internal/templates/layouts/base.gohtml
@@ -51,19 +51,6 @@
 
         window.__globalsReady = true;
         document.dispatchEvent(new CustomEvent('globalsReady'));
-
-        (async () => {
-            try {
-                const serverLogsEnabled = settingsSync.getBool("settingServerLogsEnabled");
-                await fetch('/api/settings/server-logs', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ enabled: serverLogsEnabled })
-                });
-            } catch (error) {
-                console.error('[Layout] Error syncing server logs:', error);
-            }
-        })();
     </script>
 
     <script type="module" src="/scripts/logger.js"></script>

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -334,7 +334,7 @@
 
         let cleanup = [];
 
-        function initSettingsPage() {
+        async function initSettingsPage() {
             const settingsSync = window.settingsSync;
             cleanup = [];
 
@@ -390,6 +390,36 @@
                 }
             };
 
+            // Fetch logging state from backend and hydrate settingsSync before binding the checkboxes.
+            try {
+                const resp = await fetch('/api/settings/logging');
+                if (resp.ok) {
+                    const data = await resp.json();
+                    settingsSync.setBool("settingServerLogsEnabled", data.serverLogsEnabled);
+                    settingsSync.setBool("settingPcapRecording", data.pcapRecording);
+                }
+            } catch (err) {
+                console.error('Error fetching logging settings:', err);
+            }
+
+            function bindLoggingCheckbox(id, fieldName) {
+                const el = document.getElementById(id);
+                if (!el) return;
+                el.checked = settingsSync.getBool(id);
+                addListener(el, "change", async (e) => {
+                    settingsSync.setBool(id, e.target.checked);
+                    try {
+                        await fetch('/api/settings/logging', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({[fieldName]: e.target.checked})
+                        });
+                    } catch (err) {
+                        console.error('Error updating logging setting:', err);
+                    }
+                });
+            }
+
             // Map display setting
             bindCheckbox("settingShowMap");
 
@@ -422,24 +452,8 @@
             bindCheckbox("settingWsCoalescing");
             bindCheckbox("settingWsThrottling");
 
-            // Server-side logging (with API call)
-            const serverLogsEl = document.getElementById("settingServerLogsEnabled");
-            if (serverLogsEl) {
-                serverLogsEl.checked = settingsSync.getBool("settingServerLogsEnabled");
-                addListener(serverLogsEl, "change", async (e) => {
-                    const enabled = e.target.checked;
-                    settingsSync.setBool("settingServerLogsEnabled", enabled);
-                    try {
-                        await fetch('/api/settings/server-logs', {
-                            method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify({enabled})
-                        });
-                    } catch (error) {
-                        console.error('Error updating server logs setting:', error);
-                    }
-                });
-            }
+            bindLoggingCheckbox("settingServerLogsEnabled", "serverLogsEnabled");
+            bindLoggingCheckbox("settingPcapRecording", "pcapRecording");
 
             // Download debug logs
             const downloadBtn = document.getElementById('downloadLogsBtn');

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -390,34 +390,43 @@
                 }
             };
 
-            // Fetch logging state from backend and hydrate settingsSync before binding the checkboxes.
-            try {
-                const resp = await fetch('/api/settings/logging');
-                if (resp.ok) {
-                    const data = await resp.json();
-                    settingsSync.setBool("settingServerLogsEnabled", data.serverLogsEnabled);
-                    settingsSync.setBool("settingPcapRecording", data.pcapRecording);
+            async function fetchBackendSettings(endpoint) {
+                try {
+                    const resp = await fetch(endpoint);
+                    if (!resp.ok) {
+                        console.warn(`[Settings] ${endpoint} returned ${resp.status}, falling back to localStorage`);
+                        return null;
+                    }
+                    return await resp.json();
+                } catch (err) {
+                    console.warn(`[Settings] ${endpoint} fetch failed:`, err);
+                    return null;
                 }
-            } catch (err) {
-                console.error('Error fetching logging settings:', err);
             }
 
-            function bindLoggingCheckbox(id, fieldName) {
+            function bindBackendCheckbox(id, endpoint, fieldName) {
                 const el = document.getElementById(id);
                 if (!el) return;
                 el.checked = settingsSync.getBool(id);
                 addListener(el, "change", async (e) => {
-                    settingsSync.setBool(id, e.target.checked);
+                    const checked = e.target.checked;
+                    settingsSync.setBool(id, checked);
                     try {
-                        await fetch('/api/settings/logging', {
+                        await fetch(endpoint, {
                             method: 'POST',
                             headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify({[fieldName]: e.target.checked})
+                            body: JSON.stringify({[fieldName]: checked})
                         });
                     } catch (err) {
-                        console.error('Error updating logging setting:', err);
+                        console.warn(`[Settings] POST ${endpoint} failed:`, err);
                     }
                 });
+            }
+
+            const loggingSettings = await fetchBackendSettings('/api/settings/logging');
+            if (loggingSettings) {
+                settingsSync.setBool("settingServerLogsEnabled", loggingSettings.serverLogsEnabled);
+                settingsSync.setBool("settingPcapRecording", loggingSettings.pcapRecording);
             }
 
             // Map display setting
@@ -452,8 +461,8 @@
             bindCheckbox("settingWsCoalescing");
             bindCheckbox("settingWsThrottling");
 
-            bindLoggingCheckbox("settingServerLogsEnabled", "serverLogsEnabled");
-            bindLoggingCheckbox("settingPcapRecording", "pcapRecording");
+            bindBackendCheckbox("settingServerLogsEnabled", "/api/settings/logging", "serverLogsEnabled");
+            bindBackendCheckbox("settingPcapRecording", "/api/settings/logging", "pcapRecording");
 
             // Download debug logs
             const downloadBtn = document.getElementById('downloadLogsBtn');

--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -146,6 +146,7 @@
             Logging
         </div>
         <div class="collapse-content">
+            <p class="text-xs text-base-content/60 mt-1 pb-2">Logs land in <code>logs/sessions/</code>, <code>logs/debug/</code>, <code>logs/errors/</code>. Errors are always saved on the backend side.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-2">
                 <!-- Log Level -->
                 <div>
@@ -174,11 +175,17 @@
                             <input type="checkbox" id="settingLogToConsole" class="toggle toggle-primary toggle-sm">
                             <i data-lucide="terminal" class="w-4 h-4 text-base-content/50"></i>
                             <span class="text-base-content/80 text-sm group-hover:text-base-content">Browser Console (F12)</span>
+                            <div class="tooltip" data-tip="Print logs in the browser DevTools console.">
+                                <i data-lucide="info" class="w-3 h-3 opacity-50"></i>
+                            </div>
                         </label>
                         <label class="flex items-center gap-3 p-2 rounded bg-base-300 cursor-pointer group hover:bg-base-300/70">
                             <input type="checkbox" id="settingLogToServer" class="toggle toggle-primary toggle-sm">
                             <i data-lucide="server" class="w-4 h-4 text-base-content/50"></i>
                             <span class="text-base-content/80 text-sm group-hover:text-base-content">Server Logs (JSONL)</span>
+                            <div class="tooltip" data-tip="Send frontend logs to the backend (saved to logs/debug/; errors go to logs/errors/ too).">
+                                <i data-lucide="info" class="w-3 h-3 opacity-50"></i>
+                            </div>
                         </label>
                     </div>
                 </div>
@@ -249,9 +256,21 @@
                         <input type="checkbox" id="settingServerLogsEnabled"
                                class="toggle toggle-primary toggle-sm">
                         <i data-lucide="hard-drive" class="w-4 h-4 text-base-content/50"></i>
-                        <span class="text-base-content/80 text-sm group-hover:text-base-content">Server-side Recording</span>
+                        <span class="text-base-content/80 text-sm group-hover:text-base-content">Save Backend Logs</span>
                         <div class="tooltip"
-                             data-tip="Controls backend server logs written to logs/sessions/ directory.">
+                             data-tip="Save backend (Go) logs to logs/sessions/. Errors are always saved to logs/errors/.">
+                            <i data-lucide="info" class="w-3 h-3 opacity-50"></i>
+                        </div>
+                    </label>
+                </div>
+                <div class="mb-4">
+                    <label class="flex items-center gap-3 p-2 rounded bg-base-300 cursor-pointer group hover:bg-base-300/70">
+                        <input type="checkbox" id="settingPcapRecording"
+                               class="toggle toggle-primary toggle-sm">
+                        <i data-lucide="circle-dot" class="w-4 h-4 text-base-content/50"></i>
+                        <span class="text-base-content/80 text-sm group-hover:text-base-content">Record Network Capture (pcap)</span>
+                        <div class="tooltip"
+                             data-tip="Record the raw network capture to logs/captures/. Useful for debugging without running tcpdump externally.">
                             <i data-lucide="info" class="w-3 h-3 opacity-50"></i>
                         </div>
                     </label>


### PR DESCRIPTION
## Summary
- Source-based log routing: `sessions/` (backend), `debug/` (frontend), `errors/` (always-on for ERROR/CRITICAL on both sides).
- `network.json` is the source of truth for both logging toggles. Frontend boot fetches `/api/settings/logging` instead of pushing localStorage on every page load.
- New in-process pcap recorder on `Capturer` + Manager-level Start/Stop that propagates to all active capturers and to any added later via Reconfigure.
- Bug fix: `POST /api/network/interfaces` no longer wipes the Logging section (latent since the schema extension). Shared `capture.MutateConfig(appDir, fn)` helper makes this structurally impossible.
- UI: tooltips reworded to match real semantics, new `settingPcapRecording` toggle, label rename "Server-side Recording" → "Save Backend Logs".

## Test plan
- [x] Backend boots, applies `cfg.Logging.ServerLogsEnabled` and `cfg.Logging.PcapRecording` to the runtime.
- [x] Settings page first load: GET `/api/settings/logging` returns persisted state. Both checkboxes match.
- [x] Toggle backend logs on → POST goes through → `logs/sessions/session_*.jsonl` grows.
- [x] Toggle backend logs off → trigger backend ERROR → `logs/errors/errors_<DATE>.log` grows even though `sessions/` is silent.
- [x] Toggle frontend logs on → `logs/debug/front_*.jsonl` grows. Frontend ERROR appears in BOTH `debug/` AND `errors/`.
- [x] Toggle pcap recording on → `logs/captures/capture_*.pcap` appears. Open in Wireshark, packets present.
- [x] Restart radar → both toggles boot in the same state.
- [x] Change network interfaces → logging settings preserved.