### PR TITLE
fix(zones): force Roads of Avalon pvpType to black

### DIFF
--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -65,10 +65,24 @@ export class ZonesDatabase {
     const id = String(zoneId);
     if (this.overrides.has(id)) return this.overrides.get(id);
     // Try exact match first (handles TNL-XXX, YOURNAME-HIDEOUT, etc.)
-    if (this.zones[id]) return this.zones[id];
-    // Fallback: try base ID for compound numeric IDs like "1234-5"
-    const baseId = id.split("-")[0];
-    return this.zones[baseId] || null;
+    let raw = this.zones[id];
+    if (!raw) {
+      // Fallback: try base ID for compound numeric IDs like "1234-5"
+      const baseId = id.split("-")[0];
+      raw = this.zones[baseId] || null;
+    }
+    return this._applyAvalonRoadsRule(raw);
+  }
+
+  // Roads of Avalon are full-loot PvP regardless of origin. zones.json tags TUNNEL_ROYAL
+  // and TUNNEL_ROYAL_RED as safe/red, contradicted by
+  // https://wiki.albiononline.com/wiki/Roads_of_Avalon.
+  _applyAvalonRoadsRule(zone) {
+    if (!zone) return null;
+    if (zone.type === "TUNNEL_ROYAL" || zone.type === "TUNNEL_ROYAL_RED") {
+      return { ...zone, pvpType: "black" };
+    }
+    return zone;
   }
 
   setMistOverride(mistMapId, originZoneId) {

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -75,8 +75,7 @@ export class ZonesDatabase {
   }
 
   // Roads of Avalon are full-loot PvP regardless of origin. zones.json tags TUNNEL_ROYAL
-  // and TUNNEL_ROYAL_RED as safe/red, contradicted by
-  // https://wiki.albiononline.com/wiki/Roads_of_Avalon.
+  // and TUNNEL_ROYAL_RED as safe/red, overridden here.
   _applyAvalonRoadsRule(zone) {
     if (!zone) return null;
     if (zone.type === "TUNNEL_ROYAL" || zone.type === "TUNNEL_ROYAL_RED") {

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -99,3 +99,46 @@ describe('ZonesDatabase mist overrides', () => {
         expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('yellow');
     });
 });
+
+describe('ZonesDatabase Avalon Roads pvpType', () => {
+    // @verified 2026-05-07: source: Albion Online wiki (Roads of Avalon page) and live capture
+    // 2026-05-07T13-08-37 op 2 Join mapId="TNL-013". zones.json tags TUNNEL_ROYAL as
+    // pvpType:"safe" but the wiki rule is that all Avalon Roads are full-loot PvP (black).
+    test('TUNNEL_ROYAL is forced to black despite zones.json safe tag', () => {
+        expect(zonesDatabase.getPvpType('TNL-013')).toBe('black');
+        expect(zonesDatabase.isBlackZone('TNL-013')).toBe(true);
+        expect(zonesDatabase.isSafeZone('TNL-013')).toBe(false);
+    });
+
+    // @verified 2026-05-07: same wiki rule. zones.json tags TUNNEL_ROYAL_RED as red, must be black.
+    test('TUNNEL_ROYAL_RED is forced to black despite zones.json red tag', () => {
+        expect(zonesDatabase.getPvpType('TNL-023')).toBe('black');
+        expect(zonesDatabase.isBlackZone('TNL-023')).toBe(true);
+        expect(zonesDatabase.isRedZone('TNL-023')).toBe(false);
+    });
+
+    // @verified 2026-05-07: Hideout interiors stay safe. Player-owned hideouts inside Avalon are
+    // not PvP zones; only the surrounding Roads are.
+    test('TUNNEL_HIDEOUT keeps safe pvpType', () => {
+        expect(zonesDatabase.getPvpType('TNL-151')).toBe('safe');
+        expect(zonesDatabase.isSafeZone('TNL-151')).toBe(true);
+    });
+
+    // @verified 2026-05-07: regression guard. TUNNEL_LOW already correctly black in zones.json,
+    // make sure the post-processor does not break the working entries.
+    test('TUNNEL_LOW remains black (regression guard)', () => {
+        expect(zonesDatabase.getPvpType('TNL-058')).toBe('black');
+    });
+
+    // @verified 2026-05-07: regression guard. TUNNEL_BLACK_LOW already black in zones.json.
+    test('TUNNEL_BLACK_LOW remains black (regression guard)', () => {
+        expect(zonesDatabase.getPvpType('TNL-031')).toBe('black');
+    });
+
+    // @verified 2026-05-07: regression guard. Non-tunnel zones keep their original pvpType.
+    test('non-tunnel zones unaffected by Avalon override', () => {
+        expect(zonesDatabase.getPvpType('1000')).toBe('safe');
+        expect(zonesDatabase.getPvpType('0212')).toBe('yellow');
+        expect(zonesDatabase.getPvpType('3316')).toBe('black');
+    });
+});


### PR DESCRIPTION
## Summary

- `zones.json` tags `TUNNEL_ROYAL` (T4, 44 zones) as `safe` and `TUNNEL_ROYAL_RED` (T6, 16 zones) as `red`. Per multiple Albion guides, all Roads of Avalon are full-loot PvP regardless of the portal origin.
- Live capture (op 2 Join into `TNL-013`, Touos-Uoemtum, TUNNEL_ROYAL T4) confirmed the radar classified the Avalon Road as safe, suppressing the threat alarm.
- `ZonesDatabase.getZone` now overrides `pvpType` to `'black'` for `TUNNEL_ROYAL` / `TUNNEL_ROYAL_RED`. Hideout interiors (`TUNNEL_HIDEOUT`, `TUNNEL_HIDEOUT_DEEP`) keep `safe`. All other tunnel types were already black in `zones.json`.

## Sources

- [thegamer.com Roads of Avalon guide](https://www.thegamer.com/albion-online-guide-roads-of-avalon/): *"the Roads of Avalon also only have Black Zones. When you die to a player, you lose everything you had on your person."*
- [studioloot.com Types of Zones](https://www.studioloot.com/albion-online/articles/types-of-zones-in-albion-online/): *"Black zones can be found in the Outlands and the Roads of Avalon."*
- [albion.win Zones](https://albion.win/posts/zones/): *"Black Zones are located in the Outlands, Roads of Avalon, or the Mists."*

## Test plan
- [x] `npm test` 597/597 (6 new verified cases: TUNNEL_ROYAL, TUNNEL_ROYAL_RED, TUNNEL_HIDEOUT, TUNNEL_LOW regression, TUNNEL_BLACK_LOW regression, non-tunnel regression)
- [x] `npm run lint` clean
- [x] `go test ./...`, `go build ./...`, `golangci-lint run` clean
- [x] Live: enter a TUNNEL_ROYAL Avalon Road (e.g. via Royal portal), confirm the radar shows the black-zone badge and that hostile players trigger alarm + screen flash