### PR TITLE
fix(#117,#119): Brecilien Mist pvpType discriminant via op 473

### DIFF
--- a/web/scripts/__fixtures__/ws/mists/brec-op473-duo-lethal.json
+++ b/web/scripts/__fixtures__/ws/mists/brec-op473-duo-lethal.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "brec-op473-duo-lethal.json",
+  "handler": "mists",
+  "messages": [
+    {
+      "kind": "request",
+      "parameters": {
+        "0": 639142180996055908,
+        "1": 8,
+        "2": 4,
+        "253": 473
+      }
+    }
+  ]
+}

--- a/web/scripts/__fixtures__/ws/mists/brec-op473-solo-lethal.json
+++ b/web/scripts/__fixtures__/ws/mists/brec-op473-solo-lethal.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "brec-op473-solo-lethal.json",
+  "handler": "mists",
+  "messages": [
+    {
+      "kind": "request",
+      "parameters": {
+        "0": 639142123857865908,
+        "1": 8,
+        "2": 2,
+        "253": 473
+      }
+    }
+  ]
+}

--- a/web/scripts/__fixtures__/ws/mists/brec-op473-solo-nonlethal.json
+++ b/web/scripts/__fixtures__/ws/mists/brec-op473-solo-nonlethal.json
@@ -1,0 +1,14 @@
+{
+  "scenario": "brec-op473-solo-nonlethal.json",
+  "handler": "mists",
+  "messages": [
+    {
+      "kind": "request",
+      "parameters": {
+        "0": 639142120646035908,
+        "1": 8,
+        "253": 473
+      }
+    }
+  ]
+}

--- a/web/scripts/core/EventRouter.js
+++ b/web/scripts/core/EventRouter.js
@@ -13,6 +13,7 @@ function syncMapIsBZ() {
 
 // Map change debouncing
 const MAP_CHANGE_DEBOUNCE_MS = 4000;
+const MIST_CHOICE_TTL_MS = 30000;
 let lastMapChangeTime = 0;
 let pendingMistChoice = null;
 
@@ -82,6 +83,14 @@ function resolveMistOriginId(previousMapId) {
         : null;
 }
 
+function consumePendingMistChoice() {
+    if (!pendingMistChoice) return null;
+    const age = Date.now() - pendingMistChoice.ts;
+    const choice = age <= MIST_CHOICE_TTL_MS ? pendingMistChoice : null;
+    pendingMistChoice = null;
+    return choice;
+}
+
 function applyMapChange(newMapId, logEvent, extraLogFields = {}) {
     const previousMapId = map.id;
     map.id = newMapId;
@@ -89,12 +98,15 @@ function applyMapChange(newMapId, logEvent, extraLogFields = {}) {
     lastMapChangeTime = Date.now();
     if (typeof newMapId === 'string' && newMapId.startsWith('@MISTS@')) {
         const originId = resolveMistOriginId(previousMapId);
-        if (originId && zonesDatabase.setMistOverride(newMapId, originId)) {
+        const choice = consumePendingMistChoice();
+        const forcedPvpType = choice ? (choice.lethal ? 'black' : 'yellow') : undefined;
+        if (originId && zonesDatabase.setMistOverride(newMapId, originId, forcedPvpType)) {
             persistMistOverride(newMapId, originId);
         }
     } else {
         zonesDatabase.clearAllMistOverrides();
         clearMistOverridePersistence();
+        pendingMistChoice = null;
     }
     syncMapIsBZ();
     radarRenderer?.setMap?.(map);

--- a/web/scripts/core/EventRouter.js
+++ b/web/scripts/core/EventRouter.js
@@ -14,6 +14,7 @@ function syncMapIsBZ() {
 // Map change debouncing
 const MAP_CHANGE_DEBOUNCE_MS = 4000;
 let lastMapChangeTime = 0;
+let pendingMistChoice = null;
 
 // Local player position (relative coords)
 let lpX = 0.0;
@@ -201,6 +202,10 @@ export function setRadarRenderer(renderer) {
 
 export function getLocalPlayerPosition() {
     return {x: lpX, y: lpY};
+}
+
+export function _debugGetPendingMistChoice() {
+    return pendingMistChoice;
 }
 
 export function restoreMistOverrideFromSession() {
@@ -451,6 +456,17 @@ export function onRequest(Parameters) {
             });
         }
     }
+
+    if (Parameters[253] == OperationCodes.MistsUseStaticEntrance && Parameters[1] == 8) {
+        pendingMistChoice = {
+            ts: Date.now(),
+            lethal: Parameters[2] !== undefined,
+        };
+        window.logger?.info(CATEGORIES.MAP, 'MistChoicePending', {
+            lethal: pendingMistChoice.lethal,
+            mode: Parameters[2] ?? null,
+        });
+    }
 }
 
 export function onResponse(Parameters, clearHandlersCallback) {
@@ -474,6 +490,7 @@ export function reset() {
     window.lpX = 0;
     window.lpY = 0;
     lastMapChangeTime = 0;
+    pendingMistChoice = null;
 
     // Clear references to prevent memory leaks
     handlers = null;

--- a/web/scripts/core/_EventRouter.test.js
+++ b/web/scripts/core/_EventRouter.test.js
@@ -1102,4 +1102,38 @@ describe('EventRouter', () => {
             sessionStorage.clear();
         });
     });
+
+    // -------------------------------------------------------------------------
+    // MIST-117 op 473 discriminant onRequest
+    // -------------------------------------------------------------------------
+    describe('MIST-117 op 473 discriminant onRequest', () => {
+        // @verified 2026-05-12: capture 21-44-17 Mist#0 (Brecilien solo non-lethal).
+        // op 473 without param[2] caches a non-lethal pending choice.
+        test('onRequest op 473 without param[2] caches lethal=false', () => {
+            EventRouter.onRequest({0: 639142120646035908, 1: 8, 253: 473});
+
+            expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: false});
+        });
+
+        // @verified 2026-05-12: capture 21-44-17 Mist#1 (solo lethal, param[2]=2).
+        test('onRequest op 473 with param[2]=2 caches lethal=true (solo lethal)', () => {
+            EventRouter.onRequest({0: 639142123857865908, 1: 8, 2: 2, 253: 473});
+
+            expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: true});
+        });
+
+        // @verified 2026-05-12: capture 23-28-09 Mist#0 (duo lethal, param[2]=4).
+        test('onRequest op 473 with param[2]=4 caches lethal=true (duo lethal)', () => {
+            EventRouter.onRequest({0: 639142180996055908, 1: 8, 2: 4, 253: 473});
+
+            expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: true});
+        });
+
+        // @verified 2026-05-12: synthetic guard. op 473 with param[1] != 8 ignored (not a Brecilien NPC interaction).
+        test('onRequest op 473 with param[1] != 8 ignored', () => {
+            EventRouter.onRequest({0: 999, 1: 99, 253: 473});
+
+            expect(EventRouter._debugGetPendingMistChoice()).toBeNull();
+        });
+    });
 });

--- a/web/scripts/core/_EventRouter.test.js
+++ b/web/scripts/core/_EventRouter.test.js
@@ -1110,21 +1110,21 @@ describe('EventRouter', () => {
         // @verified 2026-05-12: capture 21-44-17 Mist#0 (Brecilien solo non-lethal).
         // op 473 without param[2] caches a non-lethal pending choice.
         test('onRequest op 473 without param[2] caches lethal=false', () => {
-            EventRouter.onRequest({0: 639142120646035908, 1: 8, 253: 473});
+            EventRouter.onRequest({1: 8, 253: 473});
 
             expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: false});
         });
 
         // @verified 2026-05-12: capture 21-44-17 Mist#1 (solo lethal, param[2]=2).
         test('onRequest op 473 with param[2]=2 caches lethal=true (solo lethal)', () => {
-            EventRouter.onRequest({0: 639142123857865908, 1: 8, 2: 2, 253: 473});
+            EventRouter.onRequest({1: 8, 2: 2, 253: 473});
 
             expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: true});
         });
 
         // @verified 2026-05-12: capture 23-28-09 Mist#0 (duo lethal, param[2]=4).
         test('onRequest op 473 with param[2]=4 caches lethal=true (duo lethal)', () => {
-            EventRouter.onRequest({0: 639142180996055908, 1: 8, 2: 4, 253: 473});
+            EventRouter.onRequest({1: 8, 2: 4, 253: 473});
 
             expect(EventRouter._debugGetPendingMistChoice()).toMatchObject({lethal: true});
         });

--- a/web/scripts/core/_EventRouter.test.js
+++ b/web/scripts/core/_EventRouter.test.js
@@ -1136,4 +1136,48 @@ describe('EventRouter', () => {
             expect(EventRouter._debugGetPendingMistChoice()).toBeNull();
         });
     });
+
+    // -------------------------------------------------------------------------
+    // MIST-117 applyMapChange consumption
+    // -------------------------------------------------------------------------
+    describe('MIST-117 applyMapChange consumption', () => {
+        // @verified 2026-05-12: full pipeline op 473 lethal then Mist Join.
+        test('applyMapChange consumes pendingMistChoice and forces black on lethal', () => {
+            map.id = '5001';
+            EventRouter.onRequest({0: 1, 1: 8, 2: 2, 253: 473});
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '@MISTS@deadbeef-1', 9: [0, 0]}, clearHandlers);
+
+            expect(zonesDatabase.getPvpType('@MISTS@deadbeef-1')).toBe('black');
+        });
+
+        // @verified 2026-05-12: op 473 non-lethal then Mist Join, forced yellow despite safe origin.
+        test('applyMapChange consumes pendingMistChoice and forces yellow when non-lethal', () => {
+            map.id = '5001';
+            EventRouter.onRequest({0: 1, 1: 8, 253: 473});
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '@MISTS@deadbeef-2', 9: [0, 0]}, clearHandlers);
+
+            expect(zonesDatabase.getPvpType('@MISTS@deadbeef-2')).toBe('yellow');
+        });
+
+        // @verified 2026-05-12: synthetic. Choice older than 30s is ignored, fallback inheritance applies.
+        test('applyMapChange ignores expired pendingMistChoice (>30s)', () => {
+            map.id = '5001';
+            vi.useFakeTimers();
+            EventRouter.onRequest({0: 1, 1: 8, 2: 2, 253: 473});
+            vi.advanceTimersByTime(31000);
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '@MISTS@deadbeef-3', 9: [0, 0]}, clearHandlers);
+            vi.useRealTimers();
+
+            expect(zonesDatabase.getPvpType('@MISTS@deadbeef-3')).toBe('safe');
+        });
+
+        // @verified 2026-05-12: synthetic. Pending choice cleared after successful consumption.
+        test('applyMapChange clears pendingMistChoice after consumption', () => {
+            map.id = '5001';
+            EventRouter.onRequest({0: 1, 1: 8, 2: 2, 253: 473});
+            EventRouter.onResponse({253: OperationCodes.Join, 8: '@MISTS@deadbeef-4', 9: [0, 0]}, clearHandlers);
+
+            expect(EventRouter._debugGetPendingMistChoice()).toBeNull();
+        });
+    });
 });

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -84,7 +84,7 @@ export class ZonesDatabase {
     return zone;
   }
 
-  setMistOverride(mistMapId, originZoneId) {
+  setMistOverride(mistMapId, originZoneId, forcedPvpType) {
     const origin = this.getZone(originZoneId);
     if (!origin) {
       window.logger?.warn(CATEGORIES.MAP, "MistOverrideUnknownOrigin", {
@@ -96,7 +96,7 @@ export class ZonesDatabase {
     this.overrides.set(String(mistMapId), {
       name: `Mist of ${origin.name}`,
       type: "MISTS",
-      pvpType: origin.pvpType,
+      pvpType: forcedPvpType || origin.pvpType,
       tier: 0,
       file: origin.file,
       originZoneId: String(originZoneId),

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -98,6 +98,24 @@ describe('ZonesDatabase mist overrides', () => {
 
         expect(zonesDatabase.getPvpType('@MISTS@x')).toBe('yellow');
     });
+
+    // @verified 2026-05-12: source captures A/C/D op 473 param[2] discriminant.
+    // Brecilien city origin (safe) with explicit pvpType override = black for lethal Mists.
+    test('setMistOverride accepts forcedPvpType overriding origin pvpType', () => {
+        const ok = zonesDatabase.setMistOverride('@MISTS@brec-letal', '5001', 'black');
+
+        expect(ok).toBe(true);
+        expect(zonesDatabase.getPvpType('@MISTS@brec-letal')).toBe('black');
+        expect(zonesDatabase.getZoneName('@MISTS@brec-letal')).toBe('Mist of Brecilien');
+    });
+
+    // @verified 2026-05-12: backward compatibility check.
+    test('setMistOverride without forcedPvpType keeps origin pvpType', () => {
+        const ok = zonesDatabase.setMistOverride('@MISTS@brec-default', '5001');
+
+        expect(ok).toBe(true);
+        expect(zonesDatabase.getPvpType('@MISTS@brec-default')).toBe('safe');
+    });
 });
 
 describe('ZonesDatabase Avalon Roads pvpType', () => {


### PR DESCRIPTION
## Summary
- Intercept `op 473 MistsUseStaticEntrance` to discriminate Brecilien Mist class. `param[2]` absent => yellow non-lethal, present => black lethal (value encodes mode: 2=solo, 4=duo). Verified across 6 pcaps.
- `ZonesDatabase.setMistOverride` accepts optional `forcedPvpType` 3rd argument.
- `applyMapChange` consumes the cached choice with a 30s TTL when joining `@MISTS@*`, then forces pvpType via the override entry.
- Falls back to PR #103 inheritance for Royal yellow and BZ Mists when no `op 473` is observed (covers Avalon TUNNEL_ROYAL via PR #118).


## Test plan
- [x] `npm test` 607 pass
- [x] `npm run lint` clean
- [x] `go test ./...`, `go build ./...`, `golangci-lint run` clean
- [x] Live: Brec solo non-lethal => yellow banner + alarm on hostile
- [x] Live: Brec solo lethal => black banner + alarm
- [x] Live: Brec duo lethal => black banner + alarm
- [x] Live: Royal yellow Mist => yellow banner
- [x] Live: BZ Mist => black banner