### PR TITLE
feat(ui): add glowing player breadcrumbs trail to radar canvas

### DIFF
--- a/internal/templates/pages/settings.gohtml
+++ b/internal/templates/pages/settings.gohtml
@@ -135,6 +135,28 @@
                     </label>
                 </div>
             </div>
+
+            <!-- Player Trail Settings (sub-section) -->
+            <div class="mt-4 p-4 rounded-lg bg-base-300">
+                <label class="flex items-center gap-3 cursor-pointer group">
+                    <input type="checkbox" id="settingPlayerTrail" class="checkbox checkbox-primary checkbox-sm">
+                    <span class="text-base-content/80 group-hover:text-base-content transition-colors flex items-center gap-2">
+                        <i data-lucide="footprints" class="w-4 h-4 text-base-content/50"></i>
+                        Player Trail
+                    </span>
+                    <div class="tooltip" data-tip="Draw a fading neon trail behind the player indicating where you have walked.">
+                        <i data-lucide="info" class="w-4 h-4 opacity-50"></i>
+                    </div>
+                </label>
+                <div class="mt-3 ml-8 flex flex-wrap gap-4">
+                    <label class="flex items-center gap-2">
+                        <span class="text-base-content/60 text-xs">Duration</span>
+                        <input id="settingPlayerTrailDuration" type="number" min="30" max="600" step="30" placeholder="180"
+                               class="input input-bordered input-xs w-20">
+                        <span class="text-base-content/50 text-xs">seconds</span>
+                    </label>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -458,6 +480,10 @@
             bindCheckbox("settingResourceClusters");
             bindNumber("settingClusterRadius", 30);
             bindNumber("settingClusterMinSize", 2);
+
+            // Player Trail settings
+            bindCheckbox("settingPlayerTrail");
+            bindNumber("settingPlayerTrailDuration", 180);
 
             // Category filters (Logging section)
             bindCheckbox("categorySystem");

--- a/web/scripts/utils/RadarRenderer.js
+++ b/web/scripts/utils/RadarRenderer.js
@@ -26,6 +26,7 @@ export class RadarRenderer {
         this.lastFrameTime = 0;
         this.lastClusterUpdate = 0;
         this.cachedClusters = null;
+        this.playerPath = [];
     }
 
     /**
@@ -44,6 +45,12 @@ export class RadarRenderer {
      * @param {number} y - Player Y coordinate
      */
     setLocalPlayerPosition(x, y) {
+        // Track absolute player movement history
+        const lastPoint = this.playerPath[this.playerPath.length - 1];
+        if (!lastPoint || this.drawingUtils.calculateDistance(lastPoint.x, lastPoint.y, x, y) >= 1.0) {
+            this.playerPath.push({ x, y, time: Date.now() });
+        }
+
         this.lpX = x;
         this.lpY = y;
     }
@@ -54,6 +61,7 @@ export class RadarRenderer {
      */
     setMap(mapData) {
         this.map = mapData;
+        this.playerPath = []; // Clear trail on map change
     }
 
 
@@ -227,6 +235,10 @@ export class RadarRenderer {
         }
 
         if (context) {
+            if (settingsSync.getBool('settingPlayerTrail', true)) {
+                this.drawPlayerTrail(context);
+            }
+
             if (this.drawings.harvestablesDrawing && this.handlers.harvestablesHandler) {
                 this.drawings.harvestablesDrawing.invalidate(
                     context,
@@ -475,6 +487,58 @@ export class RadarRenderer {
         ctx.strokeStyle = `rgba(255, 50, 50, ${pulse})`;
         ctx.lineWidth = 5;
         ctx.strokeRect(3, 3, canvasSize - 6, canvasSize - 6);
+        ctx.restore();
+    }
+
+    /**
+     * Draw fading neon trail behind the player
+     * @param {CanvasRenderingContext2D} ctx - Draw canvas context
+     */
+    drawPlayerTrail(ctx) {
+        if (!this.playerPath || this.playerPath.length < 2) return;
+
+        const currentTime = Date.now();
+        const durationLimitMs = (settingsSync.getNumber('settingPlayerTrailDuration', 180) || 180) * 1000;
+
+        // Filter out old points
+        this.playerPath = this.playerPath.filter(point => (currentTime - point.time) <= durationLimitMs);
+
+        if (this.playerPath.length < 2) return;
+
+        ctx.save();
+        ctx.lineWidth = Math.max(1.5, this.drawingUtils.getScaledSize(2));
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+
+        // Set glow effect for neon aesthetic
+        ctx.shadowBlur = 4;
+        ctx.shadowColor = 'rgba(0, 212, 255, 0.8)';
+
+        for (let i = 0; i < this.playerPath.length - 1; i++) {
+            const p1 = this.playerPath[i];
+            const p2 = this.playerPath[i + 1];
+
+            // Convert absolute map coordinates to relative coordinate space centered on player
+            const relX1 = -1 * p1.x + this.lpX;
+            const relY1 = p1.y - this.lpY;
+            const relX2 = -1 * p2.x + this.lpX;
+            const relY2 = p2.y - this.lpY;
+
+            const pt1 = this.drawingUtils.transformPoint(relX1, relY1);
+            const pt2 = this.drawingUtils.transformPoint(relX2, relY2);
+
+            // Calculate fading opacity based on age of the starting point of the segment
+            const age = currentTime - p1.time;
+            const ageRatio = Math.max(0, Math.min(1, age / durationLimitMs));
+            const opacity = 0.7 * (1 - ageRatio);
+
+            ctx.beginPath();
+            ctx.moveTo(pt1.x, pt1.y);
+            ctx.lineTo(pt2.x, pt2.y);
+            ctx.strokeStyle = `rgba(0, 212, 255, ${opacity})`;
+            ctx.stroke();
+        }
+
         ctx.restore();
     }
 

--- a/web/scripts/utils/_RadarRenderer.test.js
+++ b/web/scripts/utils/_RadarRenderer.test.js
@@ -114,3 +114,91 @@ describe('RadarRenderer._collectClusterCandidates', () => {
         expect(renderer._collectClusterCandidates()).toHaveLength(1);
     });
 });
+
+describe('RadarRenderer Player Trail', () => {
+    let renderer;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        renderer = makeRenderer();
+        renderer.drawingUtils.calculateDistance = (x1, y1, x2, y2) => {
+            const dx = x2 - x1; const dy = y2 - y1;
+            return Math.sqrt(dx * dx + dy * dy);
+        };
+        renderer.drawingUtils.getScaledSize = vi.fn((x) => x);
+        renderer.drawingUtils.transformPoint = vi.fn((x, y) => ({ x: x + 100, y: y + 100 }));
+    });
+
+    test('initializes playerPath as empty array', () => {
+        expect(renderer.playerPath).toEqual([]);
+    });
+
+    test('adds position to playerPath when player moves', () => {
+        renderer.setLocalPlayerPosition(10, 10);
+        expect(renderer.playerPath).toHaveLength(1);
+        expect(renderer.playerPath[0].x).toBe(10);
+        expect(renderer.playerPath[0].y).toBe(10);
+
+        // Moving less than 1m shouldn't add a point
+        renderer.setLocalPlayerPosition(10.5, 10);
+        expect(renderer.playerPath).toHaveLength(1);
+
+        // Moving >= 1m should add a point
+        renderer.setLocalPlayerPosition(12, 10);
+        expect(renderer.playerPath).toHaveLength(2);
+        expect(renderer.playerPath[1].x).toBe(12);
+    });
+
+    test('clears playerPath on map change', () => {
+        renderer.setLocalPlayerPosition(10, 10);
+        renderer.setLocalPlayerPosition(20, 20);
+        expect(renderer.playerPath).toHaveLength(2);
+
+        renderer.setMap({ id: 'test_map' });
+        expect(renderer.playerPath).toEqual([]);
+    });
+
+    test('drawPlayerTrail filters expired points', () => {
+        const now = Date.now();
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+
+        renderer.playerPath = [
+            { x: 10, y: 10, time: now - 200 * 1000 }, // 200s old (expired, limit is 180s by default)
+            { x: 15, y: 15, time: now - 100 * 1000 }, // 100s old (keep)
+            { x: 20, y: 20, time: now }               // 0s old (keep)
+        ];
+
+        const ctx = {
+            save: vi.fn(),
+            restore: vi.fn(),
+            beginPath: vi.fn(),
+            moveTo: vi.fn(),
+            lineTo: vi.fn(),
+            stroke: vi.fn(),
+            lineWidth: 0,
+            lineCap: '',
+            lineJoin: '',
+            shadowBlur: 0,
+            shadowColor: '',
+            strokeStyle: ''
+        };
+
+        settingsSync.getNumber.mockReturnValue(180); // 180 seconds limit
+        renderer.drawPlayerTrail(ctx);
+
+        // Expired point should be removed
+        expect(renderer.playerPath).toHaveLength(2);
+        expect(renderer.playerPath[0].x).toBe(15);
+
+        // Should draw line segment connecting the 2 remaining points
+        expect(ctx.beginPath).toHaveBeenCalled();
+        expect(ctx.moveTo).toHaveBeenCalled();
+        expect(ctx.lineTo).toHaveBeenCalled();
+        expect(ctx.stroke).toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+});
+


### PR DESCRIPTION
- Implement absolute coordinate tracking for player movement history.
- Add settings toggle and duration configuration (seconds) in settings view.
- Draw fading neon cian trail segment-by-segment below resources overlay.
- Clear player trail history automatically on map change.
- Add unit tests for player path initialization, updates, map reset, and expiration.

## Description
Brief description of the changes.

## Type of Change
- [x] New feature

## Testing
How did you test these changes?

## Checklist
- [x] Code compiles without errors
- [x] Tested on Windows / Linux
