### PR TITLE
Fix item ID mapping in ItemsDatabase (player equipment misrendered)

### DIFF
--- a/tools/update-ao-data.ts
+++ b/tools/update-ao-data.ts
@@ -81,64 +81,98 @@ type MinifiedHarvestables = Record<string, HarvestableTier[]>;
 // Minification Functions
 // ============================================================================
 
-function minifyItems(rawData: any): MinifiedItem[] {
-    const items: MinifiedItem[] = [];
-    const itemsRoot = rawData?.items;
-    if (!itemsRoot) return items;
+/**
+ * Build (id -> {uniqueName, itempower, ...}) map from items.txt + items.json.
+ * items.txt is the canonical source of (numericId, uniqueName) pairs.
+ * items.json provides itempower, tier, category for each uniqueName.
+ */
+async function buildItemsArray(itemsJsonRaw: any): Promise<(MinifiedItem | null)[]> {
+    // Step 1: Build uniqueName -> metadata lookup from items.json
+    const metaByName = new Map<string, {itempower: number, type: string, cat?: string, slot?: string, h2?: boolean}>();
+    const itemsRoot = itemsJsonRaw?.items;
 
-    const itemTypes = [
-        'simpleitem', 'equipmentitem', 'weapon', 'consumableitem',
-        'consumablefrominventoryitem', 'farmableitem', 'mount',
-        'furnitureitem', 'trackingitem', 'journalitem'
-    ];
+    if (itemsRoot) {
+        const itemTypes = [
+            'hideoutitem', 'trackingitem', 'farmableitem', 'simpleitem',
+            'consumableitem', 'consumablefrominventoryitem', 'equipmentitem',
+            'weapon', 'mount', 'furnitureitem', 'journalitem', 'labourercontract',
+            'mountskin', 'crystalleagueitem'
+        ];
 
-    for (const itemType of itemTypes) {
-        if (!itemsRoot[itemType]) continue;
+        for (const itemType of itemTypes) {
+            if (!itemsRoot[itemType]) continue;
+            const arr = Array.isArray(itemsRoot[itemType]) ? itemsRoot[itemType] : [itemsRoot[itemType]];
 
-        const typeItems = Array.isArray(itemsRoot[itemType])
-            ? itemsRoot[itemType]
-            : [itemsRoot[itemType]];
+            for (const item of arr) {
+                const uniqueName = item['@uniquename'];
+                if (!uniqueName) continue;
 
-        for (const item of typeItems) {
-            const uniqueName = item['@uniquename'];
-            if (!uniqueName) continue;
+                const baseMeta = {
+                    itempower: parseInt(item['@itempower'] || '0') || 0,
+                    type: itemType,
+                    cat: item['@shopcategory'] || undefined,
+                    slot: item['@slottype'] || undefined,
+                    h2: item['@twohanded'] === 'true' ? true : undefined,
+                };
+                metaByName.set(uniqueName, baseMeta);
 
-            const itempower = parseInt(item['@itempower'] || '0');
+                // Enchanted variants
+                if (item.enchantments?.enchantment) {
+                    const encs = Array.isArray(item.enchantments.enchantment)
+                        ? item.enchantments.enchantment
+                        : [item.enchantments.enchantment];
 
-            if (itempower > 0) {
-                const minItem: MinifiedItem = {n: uniqueName, p: itempower, t: itemType};
-                if (item['@shopcategory']) minItem.cat = item['@shopcategory'];
-                if (item['@slottype']) minItem.slot = item['@slottype'];
-                if (item['@twohanded'] === 'true') minItem.h2 = true;
-                items.push(minItem);
-            }
-
-            if (item.enchantments?.enchantment) {
-                const enchantments = Array.isArray(item.enchantments.enchantment)
-                    ? item.enchantments.enchantment
-                    : [item.enchantments.enchantment];
-
-                for (const enchant of enchantments) {
-                    const enchantLevel = parseInt(enchant['@enchantmentlevel'] || '0');
-                    const enchantPower = parseInt(enchant['@itempower'] || '0');
-
-                    if (enchantPower > 0) {
-                        const minItem: MinifiedItem = {
-                            n: `${uniqueName}@${enchantLevel}`,
-                            p: enchantPower,
-                            t: itemType
-                        };
-                        if (item['@shopcategory']) minItem.cat = item['@shopcategory'];
-                        if (item['@slottype']) minItem.slot = item['@slottype'];
-                        if (item['@twohanded'] === 'true') minItem.h2 = true;
-                        items.push(minItem);
+                    for (const enchant of encs) {
+                        const lvl = parseInt(enchant['@enchantmentlevel'] || '0') || 0;
+                        const power = parseInt(enchant['@itempower'] || '0') || 0;
+                        const enchName = `${uniqueName}@${lvl}`;
+                        metaByName.set(enchName, {
+                            ...baseMeta,
+                            itempower: power || baseMeta.itempower,
+                        });
                     }
                 }
             }
         }
     }
 
-    return items;
+    // Step 2: Download items.txt (canonical id -> uniqueName mapping)
+    const itemsTxtUrl = `${GITHUB_RAW_BASE}/formatted/items.txt`;
+    console.log(`📥 Downloading items.txt for canonical IDs...`);
+    const txtRes = await downloadFile(itemsTxtUrl);
+    if (txtRes.status !== DownloadStatus.SUCCESS || !txtRes.buffer) {
+        throw new Error(`Failed to download items.txt: ${txtRes.message}`);
+    }
+    const txtContent = txtRes.buffer.toString('utf-8');
+
+    // Step 3: Parse items.txt and build sparse array indexed by real Albion ID
+    // Format: "8952: T7_HEAD_PLATE_AVALON@2   : Avalonian Plate Helmet"
+    const result: (MinifiedItem | null)[] = [];
+    const lineRe = /^\s*(\d+)\s*:\s*([^\s:]+)/;
+
+    for (const rawLine of txtContent.split(/\r?\n/)) {
+        const m = rawLine.match(lineRe);
+        if (!m) continue;
+        const id = parseInt(m[1], 10);
+        const uniqueName = m[2];
+
+        // Fill gaps with null so array indices match real IDs
+        while (result.length < id) result.push(null);
+
+        const meta = metaByName.get(uniqueName);
+        const minItem: MinifiedItem = {
+            n: uniqueName,
+            p: meta?.itempower ?? 0,
+        };
+        if (meta?.type) minItem.t = meta.type;
+        if (meta?.cat) minItem.cat = meta.cat;
+        if (meta?.slot) minItem.slot = meta.slot;
+        if (meta?.h2) minItem.h2 = meta.h2;
+
+        result[id] = minItem;
+    }
+
+    return result;
 }
 
 function minifyMobs(rawData: any): MinifiedMob[] {
@@ -457,6 +491,46 @@ function formatSize(bytes: number): string {
     return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
 }
 
+
+async function downloadAndMinifyItems(): Promise<ProcessResult> {
+    const url = `${GITHUB_RAW_BASE}/items.json`;
+    const outputPath = path.join(OUTPUT_DIR, 'items.min.json');
+
+    console.log(`\n📥 Downloading items.json...`);
+    const res = await downloadFile(url);
+    if (res.status !== DownloadStatus.SUCCESS || !res.buffer) {
+        console.error(`❌ Failed to download items.json: ${res.message}`);
+        return {name: 'items.json', success: false, originalSize: 0, minifiedSize: 0};
+    }
+    const originalSize = res.buffer.length;
+    console.log(`✅ Downloaded items.json (${formatSize(originalSize)})`);
+
+    try {
+        const rawData = JSON.parse(res.buffer.toString('utf-8'));
+        const minified = await buildItemsArray(rawData);
+
+        const minifiedJson = JSON.stringify(minified);
+        fs.writeFileSync(outputPath, minifiedJson);
+
+        const minifiedSize = Buffer.byteLength(minifiedJson);
+        const reduction = ((1 - minifiedSize / originalSize) * 100).toFixed(1);
+        const nonNullCount = minified.filter(x => x !== null).length;
+
+        console.log(`💾 Saved items.min.json (${formatSize(minifiedSize)}, -${reduction}%, ${nonNullCount} non-null / ${minified.length} total slots)`);
+
+        return {
+            name: 'items.json',
+            success: true,
+            originalSize,
+            minifiedSize,
+            itemCount: nonNullCount,
+        };
+    } catch (error) {
+        console.error(`❌ Failed to process items.json: ${error}`);
+        return {name: 'items.json', success: false, originalSize, minifiedSize: 0};
+    }
+}
+
 async function main() {
     console.log('Albion Online Data Updater');
     console.log('==========================');
@@ -471,7 +545,7 @@ async function main() {
     const results: ProcessResult[] = [];
 
     // Process each data file with minification
-    results.push(await downloadAndMinify('items.json', minifyItems, 'items.min.json'));
+    results.push(await downloadAndMinifyItems());
     results.push(await downloadAndMinify('mobs.json', minifyMobs, 'mobs.min.json'));
     results.push(await downloadAndMinify('spells.json', minifySpells, 'spells.min.json'));
     results.push(await downloadAndMinify('harvestables.json', minifyHarvestables, 'harvestables.min.json'));
@@ -526,6 +600,9 @@ async function main() {
 
     process.exit(failCount > 0 ? 1 : 0);
 }
+
+
+
 
 main().catch(err => {
     console.error('❌ Fatal error:', err);

--- a/web/scripts/data/ItemsDatabase.js
+++ b/web/scripts/data/ItemsDatabase.js
@@ -30,31 +30,32 @@ export class ItemsDatabase {
 
             const items = await response.json();
 
-            if (!Array.isArray(items)) {
-                throw new Error('Invalid items.min.json structure: expected array');
-            }
+          if (!Array.isArray(items)) {
+    throw new Error('Invalid items.min.json structure: expected array');
+}
 
-            // Items are pre-filtered (itempower > 0) and sequential
-            // Index 0 = game ID 1, Index 1 = game ID 2, etc.
-            for (let i = 0; i < items.length; i++) {
-                const item = items[i];
-                const id = i + 1; // Game IDs start at 1
+// Array index = real Albion item ID (sparse array; null at unused IDs)
+for (let id = 0; id < items.length; id++) {
+    const item = items[id];
+    if (item === null || item === undefined) continue;
 
-                // Parse enchant from name (e.g., "T4_2H_SWORD@2" -> enchant 2)
-                let name = item.n;
-                let enchant = 0;
-                const atIndex = name.lastIndexOf('@');
-                if (atIndex > 0) {
-                    enchant = parseInt(name.substring(atIndex + 1)) || 0;
-                }
+    const name = item.n;
+    if (!name) continue;
 
-                this.items.set(id, {
-                    name: name,
-                    tier: this._extractTier(name),
-                    itempower: item.p,
-                    enchant: enchant
-                });
-            }
+    // Parse enchant from name (e.g., "T4_2H_SWORD@2" -> enchant 2)
+    let enchant = 0;
+    const atIndex = name.lastIndexOf('@');
+    if (atIndex > 0) {
+        enchant = parseInt(name.substring(atIndex + 1)) || 0;
+    }
+
+    this.items.set(id, {
+        name: name,
+        tier: this._extractTier(name),
+        itempower: item.p || 0,
+        enchant: enchant,
+    });
+}
 
             this.isLoaded = true;
             window.logger?.info(CATEGORIES.SYSTEM, 'ItemsLoaded', {count: this.items.size});

--- a/web/scripts/handlers/PlayersHandler.js
+++ b/web/scripts/handlers/PlayersHandler.js
@@ -119,26 +119,33 @@ export class PlayersHandler {
     }
 
     updateItems(id, Parameters) {
-        // eslint-disable-next-line no-useless-assignment
-        let items = null;
-        try {
-            items = Parameters[2];
-        } catch (error) {
-            window.logger?.warn(CATEGORIES.PLAYERS, 'UpdateItems_Failed', {
-                playerId: id,
-                error: error?.message
-            });
-            items = null;
-        }
-
-        if (items != null) {
-            const player = this.playersList.find(p => p.id === id);
-            if (player) {
-                player.items = items;
-                player.touch();
-            }
-        }
+    let equipment = null;
+    try {
+        equipment = Parameters[2];
+    } catch (error) {
+        window.logger?.warn(CATEGORIES.PLAYERS, 'UpdateItems_Failed', {
+            playerId: id,
+            error: error?.message
+        });
+        return;
     }
+
+    if (!Array.isArray(equipment) || equipment.length === 0) {
+        return;
+    }
+
+    const player = this.playersList.find(p => p.id === id);
+    if (!player) return;
+
+    player.equipments = equipment;
+    player.touch();
+
+    window.logger?.debug(CATEGORIES.PLAYERS, 'EquipmentUpdated', {
+        playerId: id,
+        nickname: player.nickname,
+        slotCount: equipment.length
+    });
+}
 
     handleNewPlayerEvent(id, Parameters) {
         // 🔍 Check if player detection is enabled
@@ -153,14 +160,31 @@ export class PlayersHandler {
         const equipments = Parameters[40] || null;
         const spells = Parameters[43] || null;
 
+
+
+
+
         const existingPlayer = this.playersList.find(player => player.id === id);
         const parsedMaxPlayers = settingsSync.getNumber('settingMaxPlayersDisplay', 50);
         const maxPlayers = Math.min(100, parsedMaxPlayers);
 
-        if (!existingPlayer && this.playersList.length < maxPlayers) {
-            const player = new Player(0, 0, id, nickname, guildName, faction, allianceName, equipments, spells);
-            this.playersList.push(player);
-        }
+        if (existingPlayer) {
+    // Upsert: tekrarlanan NewCharacter event'lerinde mutable alanları tazele
+    if (Array.isArray(equipments) && equipments.length > 0) {
+        existingPlayer.equipments = equipments;
+    }
+    if (Array.isArray(spells) && spells.length > 0) {
+        existingPlayer.spells = spells;
+    }
+    if (nickname !== undefined) existingPlayer.nickname = nickname;
+    if (guildName !== undefined) existingPlayer.guildName = guildName;
+    existingPlayer.allianceName = allianceName;
+    existingPlayer.faction = faction;
+    existingPlayer.touch();
+} else if (this.playersList.length < maxPlayers) {
+    const player = new Player(0, 0, id, nickname, guildName, faction, allianceName, equipments, spells);
+    this.playersList.push(player);
+}
 
         const mapId = window.currentMapId;
         const pvpType = zonesDatabase.getPvpType(mapId);


### PR DESCRIPTION
- Use formatted/items.txt as canonical source for Albion item IDs

- Drop itempower filter that shifted array positions

- Map index now equals real Albion ID (sparse array with nulls)

- Fix CharacterEquipmentChanged writing to wrong player field

- Add upsert path for repeat NewCharacter events

## Description
Brief description of the changes.
## Summary

Fixes player equipment displaying wrong icons (or no icons) on the radar UI. Root cause: `tools/update-ao-data.ts` produced an `items.min.json` whose array positions did not match Albion's real item IDs, because the minify pipeline filtered items by `itempower > 0` and iterated by type rather than by canonical document order.

## Root Cause

`ItemsDatabase.load()` assumed `array_index + 1 === real Albion item ID`. This assumption held for the first few items but drifted increasingly out of sync as filtered/reordered entries accumulated. By the mid-thousands the drift was complete; IDs above ~7400 didn't exist in the Map at all. Lookups like `getItemById(8952)` returned either wrong items or `undefined`.

## Changes

- **`tools/update-ao-data.ts`** — Rewrote `minifyItems()` as `buildItemsArray()` + `downloadAndMinifyItems()`. The pipeline now downloads `formatted/items.txt` from upstream as the canonical `(numericId, uniqueName)` source, and uses `items.json` only for metadata enrichment. Output is a sparse array indexed by real Albion ID, with `null` at unused slots. `itempower > 0` filtering removed.
- **`web/scripts/data/ItemsDatabase.js`** — Removed `id = i + 1` assumption. Array index is now read as the real Albion ID directly. Null-safe iteration skips empty slots.
- **`web/scripts/handlers/PlayersHandler.js`** — `updateItems()` now writes to `player.equipments` (was incorrectly writing to `player.items`, which nothing reads downstream). `handleNewPlayerEvent()` now upserts on existing players instead of silently dropping repeat `NewCharacter` events.

## Verification

After running `make update-ao-data` with the new script:
- `items.min.json` grew from 7423 entries → 12066 (matches Albion's current catalog)
- `getItemById(8952)` now correctly returns `T7_HEAD_PLATE_AVALON@2`
- Live tested with a known-gear player; radar UI now matches in-game equipment
- Equipment swaps mid-session now propagate correctly

## Notes for reviewers

- `items.min.json` and `items.min.json.gz` are build artifacts and not included in this PR — running `make update-ao-data` regenerates them with the new pipeline.
- Stale `items.min.json.gz` should be removed on first deploy, since the backend serves the gzip preferentially over the raw file.
- Suggested follow-up: a sanity assertion in `ItemsDatabase.load()` warning if Map size < ~10000 would have surfaced this immediately during development.
## Type of Change
- [+ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Testing
How did you test these changes?

## Checklist
- [ ] Code compiles without errors
-- Code did not compiled without errors. items.min.json.gz file reported and error and I delete that. It worked fine but not sure what it does
- [+ ] Tested on Windows
- [ ] Updated documentation if needed
