### PR TITLE
fix(#146): replace duration caching with etag revalidation

### DIFF
--- a/cmd/radar/main.go
+++ b/cmd/radar/main.go
@@ -207,7 +207,7 @@ func newApp(
 	log := logger.New("./logs", serverLogsEnabled)
 	wsHandler := server.NewWebSocketHandler(log)
 
-	httpServer, err := createHTTPServer(cfg.devMode, appDir, wsHandler, log, Version, manager, allIfaces)
+	httpServer, err := createHTTPServer(cfg.devMode, appDir, wsHandler, log, Version, BuildTime, manager, allIfaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP server: %w", err)
 	}
@@ -239,12 +239,13 @@ func createHTTPServer(
 	wsHandler *server.WebSocketHandler,
 	log *logger.Logger,
 	version string,
+	buildTime string,
 	mgr *capture.Manager,
 	allIfaces []capture.NetworkInterface,
 ) (*server.HTTPServer, error) {
 	if devMode {
 		logger.PrintInfo("MODE", "Development mode: reading files from disk")
-		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version, mgr, allIfaces, mgr, pcapCaptureDir)
+		return server.NewHTTPServerDev(serverPort, appDir, wsHandler, log, version, buildTime, mgr, allIfaces, mgr, pcapCaptureDir)
 	}
 	logger.PrintInfo("MODE", "Production mode: using embedded assets")
 	return server.NewHTTPServer(
@@ -258,6 +259,7 @@ func createHTTPServer(
 		wsHandler,
 		log,
 		version,
+		buildTime,
 		mgr,
 		allIfaces,
 		appDir,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"embed"
@@ -32,9 +33,30 @@ type HTTPServer struct {
 	// Template engine
 	tmpl        *templates.Engine
 	version     string
+	assetID     string
 	devMode     bool
 	networkAPI  *NetworkAPI
 	settingsAPI *SettingsAPI
+}
+
+// buildID fingerprints the embedded assets. It is empty for an unversioned build,
+// whose Version stays "dev" and would collide with the next one. BuildTime is folded
+// in because two builds of the same git tag can embed different assets.
+func buildID(version, buildTime string) string {
+	if version == "" || version == "dev" {
+		return ""
+	}
+	return etagSafe(version + "-" + buildTime)
+}
+
+// etagSafe keeps only the bytes RFC 9110 allows inside an opaque-tag.
+func etagSafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r > 0x20 && r < 0x7f && r != '"' {
+			return r
+		}
+		return '-'
+	}, s)
 }
 
 // NewHTTPServer creates a new HTTP server with embedded assets (production mode)
@@ -44,6 +66,7 @@ func NewHTTPServer(
 	wsHandler *WebSocketHandler,
 	log *logger.Logger,
 	version string,
+	buildTime string,
 	mgr NetworkManager,
 	allInterfaces []capture.NetworkInterface,
 	appDir string,
@@ -91,6 +114,7 @@ func NewHTTPServer(
 		styles:    stylesFS,
 		tmpl:      tmpl,
 		version:   version,
+		assetID:   buildID(version, buildTime),
 	}
 	if mgr != nil {
 		s.networkAPI = NewNetworkAPI(mgr, allInterfaces, appDir, capture.LANAddresses)
@@ -107,6 +131,7 @@ func NewHTTPServerDev(
 	wsHandler *WebSocketHandler,
 	log *logger.Logger,
 	version string,
+	buildTime string,
 	mgr NetworkManager,
 	allInterfaces []capture.NetworkInterface,
 	recorder Recorder,
@@ -132,6 +157,7 @@ func NewHTTPServerDev(
 		styles:    os.DirFS(appDir + "/web/styles"),
 		tmpl:      tmpl,
 		version:   version,
+		assetID:   buildID(version, buildTime),
 		devMode:   true,
 	}
 	if mgr != nil {
@@ -144,17 +170,6 @@ func NewHTTPServerDev(
 
 // setupRoutes configures all HTTP routes
 func (s *HTTPServer) setupRoutes() {
-	// Cache durations. Dev mode disables scripts/styles caching so JS/CSS edits
-	// reach the browser on the next request without a 1h HTTP cache window.
-	imageCacheDuration := 24 * time.Hour
-	dataCacheDuration := 7 * 24 * time.Hour
-	scriptsCacheDuration := 1 * time.Hour
-	stylesCacheDuration := 1 * time.Hour
-	if s.devMode {
-		scriptsCacheDuration = 0
-		stylesCacheDuration = 0
-	}
-
 	// WebSocket endpoint
 	if s.wsHandler != nil {
 		s.mux.Handle("/ws", s.wsHandler)
@@ -179,29 +194,31 @@ func (s *HTTPServer) setupRoutes() {
 		})
 	}
 
-	// Static file handlers with caching
 	// Items and Spells: serve fallback image if not found
-	s.mux.Handle("/images/Items/", s.fsHandlerWithFallback("/images/Items/", s.images, "Items", "_default.webp", imageCacheDuration))
-	s.mux.Handle("/images/Spells/", s.fsHandlerWithFallback("/images/Spells/", s.images, "Spells", "_default.webp", imageCacheDuration))
-	// Other images: standard handler (cache 24h)
-	s.mux.Handle("/images/", s.fsHandler("/images/", s.images, imageCacheDuration, false))
-	// Scripts: cache 1h + gzip
-	s.mux.Handle("/scripts/", s.gzipFSHandlerDirect("/scripts/", s.scripts, scriptsCacheDuration))
-	s.mux.Handle("/sounds/", s.fsHandler("/sounds/", s.sounds, 0, false))
-	// Styles: cache 1h + gzip
-	s.mux.Handle("/styles/", s.gzipFSHandlerDirect("/styles/", s.styles, stylesCacheDuration))
+	s.mux.Handle("/images/Items/", s.fsHandlerWithFallback("/images/Items/", s.images, "Items", "_default.webp"))
+	s.mux.Handle("/images/Spells/", s.fsHandlerWithFallback("/images/Spells/", s.images, "Spells", "_default.webp"))
+	s.mux.Handle("/images/", s.fsHandler("/images/", s.images))
+	s.mux.Handle("/scripts/", s.gzipFSHandlerDirect("/scripts/", s.scripts))
+	s.mux.Handle("/sounds/", s.fsHandler("/sounds/", s.sounds))
+	s.mux.Handle("/styles/", s.gzipFSHandlerDirect("/styles/", s.styles))
 
 	// ao-bin-dumps with gzip support (data FS is already the ao-bin-dumps directory)
-	s.mux.Handle(
-		"/ao-bin-dumps/",
-		s.gzipFSHandlerDirect("/ao-bin-dumps/", s.data, dataCacheDuration),
-	)
+	s.mux.Handle("/ao-bin-dumps/", s.gzipFSHandlerDirect("/ao-bin-dumps/", s.data))
 
 	// API endpoints
-	s.settingsAPI.Register(s.mux)
+	apiMux := http.NewServeMux()
+	s.settingsAPI.Register(apiMux)
 	if s.networkAPI != nil {
-		s.networkAPI.Register(s.mux)
+		s.networkAPI.Register(apiMux)
 	}
+	s.mux.Handle("/api/", noStore(apiMux))
+}
+
+func noStore(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		h.ServeHTTP(w, r)
+	})
 }
 
 // renderPage renders a page template
@@ -225,7 +242,8 @@ func (s *HTTPServer) renderPage(w http.ResponseWriter, r *http.Request, page str
 	data := templates.NewPageData(page, "OpenRadar - "+title).WithVersion(s.version)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Vary", "Hx-Request")
 
 	// Check if this is an HTMX request (SPA navigation)
 	isHTMX := r.Header.Get("Hx-Request") == "true"
@@ -246,19 +264,22 @@ func (s *HTTPServer) renderPage(w http.ResponseWriter, r *http.Request, page str
 	}
 }
 
-// setCacheHeaders sets Cache-Control and optional Vary headers
-func setCacheHeaders(
-	w http.ResponseWriter,
-	duration time.Duration,
-	noCache bool,
-	vary string,
-) {
-	if noCache {
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		w.Header().Set("Pragma", "no-cache")
-		w.Header().Set("Expires", "0")
-	} else if duration > 0 {
-		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(duration.Seconds())))
+// assetETag returns "" when the build carries no trustworthy fingerprint.
+// An ETag identifies a representation, so the gzip variant needs its own.
+func (s *HTTPServer) assetETag(gzipped bool) string {
+	if s.devMode || s.assetID == "" {
+		return ""
+	}
+	if gzipped {
+		return `"` + s.assetID + `-gz"`
+	}
+	return `"` + s.assetID + `"`
+}
+
+func (s *HTTPServer) setStaticCacheHeaders(w http.ResponseWriter, vary string, gzipped bool) {
+	w.Header().Set("Cache-Control", "no-cache")
+	if etag := s.assetETag(gzipped); etag != "" {
+		w.Header().Set("Etag", etag)
 	}
 	if vary != "" {
 		w.Header().Set("Vary", vary)
@@ -266,16 +287,11 @@ func setCacheHeaders(
 }
 
 // fsHandler creates a file server handler from fs.FS
-func (s *HTTPServer) fsHandler(
-	prefix string,
-	fsys fs.FS,
-	cacheDuration time.Duration,
-	noCache bool,
-) http.Handler {
+func (s *HTTPServer) fsHandler(prefix string, fsys fs.FS) http.Handler {
 	handler := http.StripPrefix(prefix, http.FileServer(http.FS(fsys)))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		setCacheHeaders(w, cacheDuration, noCache, "")
+		s.setStaticCacheHeaders(w, "", false)
 		handler.ServeHTTP(w, r)
 	})
 }
@@ -286,7 +302,6 @@ func (s *HTTPServer) fsHandlerWithFallback(
 	fsys fs.FS,
 	subdir string,
 	fallbackFile string,
-	cacheDuration time.Duration,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extract filename from path
@@ -305,60 +320,63 @@ func (s *HTTPServer) fsHandlerWithFallback(
 			}
 		}
 
-		// Set headers
-		setCacheHeaders(w, cacheDuration, false, "")
+		s.setStaticCacheHeaders(w, "", false)
 		w.Header().Set("Content-Type", "image/webp")
-		//nolint:gosec // G705: data is read from embed.FS (compiled-in assets), not user-controlled.
-		_, _ = w.Write(data)
+		http.ServeContent(w, r, urlPath, time.Time{}, bytes.NewReader(data))
 	})
 }
 
 // gzipFSHandlerDirect serves files directly from fs.FS with gzip support
 // It looks for pre-compressed .gz files first
-func (s *HTTPServer) gzipFSHandlerDirect(
-	prefix string,
-	fsys fs.FS,
-	cacheDuration time.Duration,
-) http.Handler {
+func (s *HTTPServer) gzipFSHandlerDirect(prefix string, fsys fs.FS) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		urlPath := strings.TrimPrefix(r.URL.Path, prefix)
 		acceptsGzip := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
 
-		// Try serving .gz file if client accepts gzip
-		if acceptsGzip {
-			gzPath := urlPath + ".gz"
-			if data, err := fs.ReadFile(fsys, gzPath); err == nil {
-				w.Header().Set("Content-Encoding", "gzip")
-				setContentType(w, urlPath)
-				setCacheHeaders(w, cacheDuration, false, "Accept-Encoding")
-				//nolint:gosec // G705: data is read from embed.FS (compiled-in assets), not user-controlled.
-				_, _ = w.Write(data)
-				return
-			}
-		}
-
-		// Try serving original file
-		data, err := fs.ReadFile(fsys, urlPath)
+		body, gzipped, err := readAsset(fsys, urlPath, acceptsGzip)
 		if err != nil {
 			http.NotFound(w, r)
 			return
 		}
 
-		setContentType(w, urlPath)
-		setCacheHeaders(w, cacheDuration, false, "Accept-Encoding")
-
-		// Compress on the fly if large and client accepts gzip
-		if acceptsGzip && len(data) > 1024 {
+		if gzipped {
 			w.Header().Set("Content-Encoding", "gzip")
-			gz := gzip.NewWriter(w)
-			_, _ = gz.Write(data)
-			_ = gz.Close()
-			return
+			// ServeContent would slice the gzip stream, and a slice of it cannot be inflated.
+			r.Header.Del("Range")
 		}
-
-		//nolint:gosec // G705: data is read from embed.FS (compiled-in assets), not user-controlled.
-		_, _ = w.Write(data)
+		setContentType(w, urlPath)
+		s.setStaticCacheHeaders(w, "Accept-Encoding", gzipped)
+		http.ServeContent(w, r, urlPath, time.Time{}, bytes.NewReader(body))
 	})
+}
+
+// readAsset prefers a pre-compressed sibling, then falls back to compressing on
+// the fly. It reports whether the returned bytes are gzip-encoded.
+func readAsset(fsys fs.FS, urlPath string, acceptsGzip bool) (body []byte, gzipped bool, err error) {
+	if acceptsGzip {
+		if data, err := fs.ReadFile(fsys, urlPath+".gz"); err == nil {
+			return data, true, nil
+		}
+	}
+
+	data, err := fs.ReadFile(fsys, urlPath)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !acceptsGzip || len(data) <= 1024 {
+		return data, false, nil
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(data); err != nil {
+		return nil, false, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, false, err
+	}
+	return buf.Bytes(), true, nil
 }
 
 // setContentType sets Content-Type header based on file extension

--- a/internal/server/http_cache_test.go
+++ b/internal/server/http_cache_test.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nospy/albion-openradar/internal/logger"
+	"github.com/nospy/albion-openradar/internal/templates"
+)
+
+const testAppDir = "../.."
+
+// zeroModTimeFS mirrors embed.FS, whose FileInfo.ModTime is the zero time
+// (embed/embed.go: func (f *file) ModTime() time.Time { return time.Time{} }).
+// Serving from os.DirFS directly would expose a real modtime and let
+// http.ServeContent emit a Last-Modified header that production never has.
+type zeroModTimeFS struct{ inner fs.FS }
+
+type zeroModTimeFile struct{ fs.File }
+
+type zeroModTimeInfo struct{ fs.FileInfo }
+
+func (zeroModTimeInfo) ModTime() time.Time { return time.Time{} }
+
+func (f zeroModTimeFile) Stat() (fs.FileInfo, error) {
+	i, err := f.File.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return zeroModTimeInfo{i}, nil
+}
+
+func (f zeroModTimeFile) Seek(offset int64, whence int) (int64, error) {
+	s, ok := f.File.(io.Seeker)
+	if !ok {
+		return 0, fs.ErrInvalid
+	}
+	return s.Seek(offset, whence)
+}
+
+func (f zeroModTimeFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	d, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, fs.ErrInvalid
+	}
+	return d.ReadDir(n)
+}
+
+func (z zeroModTimeFS) Open(name string) (fs.File, error) {
+	f, err := z.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return zeroModTimeFile{f}, nil
+}
+
+func newTestServer(t *testing.T, version string, devMode bool) *HTTPServer {
+	t.Helper()
+	return newTestServerBuild(t, version, "2026-07-09T10:00:00Z", devMode)
+}
+
+func newTestServerBuild(t *testing.T, version, buildTime string, devMode bool) *HTTPServer {
+	t.Helper()
+
+	log := logger.New(t.TempDir(), false)
+	tmpl, err := templates.NewEngineDev(testAppDir + "/internal/templates")
+	if err != nil {
+		t.Fatalf("template engine: %v", err)
+	}
+
+	wrap := func(dir string) fs.FS {
+		disk := os.DirFS(testAppDir + dir)
+		if devMode {
+			return disk
+		}
+		return zeroModTimeFS{disk}
+	}
+
+	s := &HTTPServer{
+		mux:     http.NewServeMux(),
+		logger:  log,
+		images:  wrap("/web/images"),
+		scripts: wrap("/web/scripts"),
+		data:    wrap("/web/ao-bin-dumps"),
+		sounds:  wrap("/web/sounds"),
+		styles:  wrap("/web/styles"),
+		tmpl:    tmpl,
+		version: version,
+		assetID: buildID(version, buildTime),
+		devMode: devMode,
+	}
+	s.settingsAPI = NewSettingsAPI(t.TempDir(), log, nil, t.TempDir())
+	s.setupRoutes()
+	return s
+}
+
+func do(s *HTTPServer, method, path string, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, http.NoBody)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// staticRoutes covers every static handler: gzipFSHandlerDirect (scripts,
+// styles, ao-bin-dumps), fsHandler (images, sounds) and fsHandlerWithFallback
+// (Items, Spells).
+var staticRoutes = []string{
+	"/scripts/core/DatabaseLoader.js",
+	"/styles/app.css",
+	"/images/icon.png",
+	"/images/Items/T4_BAG.webp",
+	"/images/Spells/SPELL_GENERIC.webp",
+	"/sounds/player.mp3",
+	"/ao-bin-dumps/harvestables.min.json",
+}
+
+func TestETagDistinguishesTwoBuildsOfTheSameVersion(t *testing.T) {
+	first := newTestServerBuild(t, "2.2.3", "2026-07-09T10:00:00Z", false)
+	second := newTestServerBuild(t, "2.2.3", "2026-07-09T11:00:00Z", false)
+
+	a := do(first, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil).Header().Get("Etag")
+	b := do(second, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil).Header().Get("Etag")
+
+	if a == "" || b == "" {
+		t.Fatalf("missing Etag: %q, %q", a, b)
+	}
+	if a == b {
+		t.Errorf("both builds emit %s: rebuilding a tag with new assets would 304 forever", a)
+	}
+}
+
+// RFC 9110: opaque-tag = DQUOTE *etagc DQUOTE, etagc = %x21 / %x23-7E / obs-text.
+func TestETagIsAWellFormedOpaqueTag(t *testing.T) {
+	s := newTestServerBuild(t, `fix/"quoted" branch`, "2026-07-09T10:00:00Z", false)
+
+	rec := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil)
+	etag := rec.Header().Get("Etag")
+
+	if len(etag) < 2 || etag[0] != '"' || etag[len(etag)-1] != '"' {
+		t.Fatalf("Etag = %q, want a double-quoted tag", etag)
+	}
+	for i, c := range []byte(etag[1 : len(etag)-1]) {
+		if c <= 0x20 || c >= 0x7f || c == '"' {
+			t.Errorf("Etag byte %d = %q is not a legal etagc", i, c)
+		}
+	}
+
+	replay := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", map[string]string{"If-None-Match": etag})
+	if replay.Code != http.StatusNotModified {
+		t.Errorf("replaying the emitted Etag gives %d, want 304", replay.Code)
+	}
+}
+
+func TestRangeIsIgnoredOnGzipEncodedAssets(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	rec := do(s, http.MethodGet, "/ao-bin-dumps/harvestables.min.json", map[string]string{
+		"Accept-Encoding": "gzip",
+		"Range":           "bytes=100-200",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: a range of a gzip stream cannot be inflated", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Errorf("Content-Range = %q, want none", got)
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(rec.Body.Bytes())); err != nil {
+		t.Errorf("body is not a decodable gzip stream: %v", err)
+	}
+}
+
+func TestRangeStillWorksOnIdentityAssets(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	for _, path := range []string{"/images/icon.png", "/ao-bin-dumps/harvestables.min.json"} {
+		t.Run(path, func(t *testing.T) {
+			rec := do(s, http.MethodGet, path, map[string]string{"Range": "bytes=0-99"})
+
+			if rec.Code != http.StatusPartialContent {
+				t.Errorf("status = %d, want 206", rec.Code)
+			}
+			if rec.Body.Len() != 100 {
+				t.Errorf("body = %d bytes, want 100", rec.Body.Len())
+			}
+		})
+	}
+}
+
+func TestHTMLPagesAreNoCache(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	rec := do(s, http.MethodGet, "/", nil)
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+}
+
+func TestHTMLPagesVaryOnHxRequest(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	full := do(s, http.MethodGet, "/players", nil)
+	partial := do(s, http.MethodGet, "/players", map[string]string{"Hx-Request": "true"})
+
+	if full.Body.Len() == partial.Body.Len() {
+		t.Fatal("full page and HTMX partial are identical, this test proves nothing")
+	}
+	for _, rec := range []*httptest.ResponseRecorder{full, partial} {
+		if got := rec.Header().Get("Vary"); got != "Hx-Request" {
+			t.Errorf("Vary = %q, want %q: the same URL serves two representations", got, "Hx-Request")
+		}
+	}
+}
+
+func TestAPIResponsesAreNoStore(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	rec := do(s, http.MethodGet, "/api/settings/logging", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: a 404 would carry the header too", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
+	}
+}
+
+func TestUntrustedVersionEmitsNoETag(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version string
+		devMode bool
+	}{
+		{"unversioned build", "dev", false},
+		{"empty version", "", false},
+		{"dev mode", "2.2.3", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer(t, tc.version, tc.devMode)
+
+			rec := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil)
+
+			if got := rec.Header().Get("Etag"); got != "" {
+				t.Errorf("Etag = %q, want none", got)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+				t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+			}
+		})
+	}
+}
+
+func TestGzipRepresentationHasDistinctETag(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	gzipped := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", map[string]string{
+		"Accept-Encoding": "gzip",
+	})
+	identity := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil)
+
+	if got := gzipped.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+	if a, b := gzipped.Header().Get("Etag"), identity.Header().Get("Etag"); a == b {
+		t.Errorf("both representations emit %s, but an ETag identifies a representation", a)
+	}
+	if got := gzipped.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Errorf("Vary = %q, want %q", got, "Accept-Encoding")
+	}
+}
+
+func TestIdentityETagDoesNotValidateGzipRepresentation(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	identity := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", nil).Header().Get("Etag")
+	rec := do(s, http.MethodGet, "/scripts/core/DatabaseLoader.js", map[string]string{
+		"Accept-Encoding": "gzip",
+		"If-None-Match":   identity,
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: identity validator must not match gzip bytes", rec.Code)
+	}
+}
+
+func TestMatchingIfNoneMatchReturns304(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	for _, path := range staticRoutes {
+		t.Run(path, func(t *testing.T) {
+			etag := do(s, http.MethodGet, path, nil).Header().Get("Etag")
+			rec := do(s, http.MethodGet, path, map[string]string{"If-None-Match": etag})
+
+			if rec.Code != http.StatusNotModified {
+				t.Errorf("status = %d, want 304", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %d bytes, want 0", rec.Body.Len())
+			}
+		})
+	}
+}
+
+func TestStaleIfNoneMatchReturnsFullBody(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	for _, path := range staticRoutes {
+		t.Run(path, func(t *testing.T) {
+			rec := do(s, http.MethodGet, path, map[string]string{"If-None-Match": `"from-an-older-build"`})
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", rec.Code)
+			}
+			if rec.Body.Len() == 0 {
+				t.Error("body is empty, want the asset")
+			}
+		})
+	}
+}
+
+func TestStaticAssetsAlwaysRevalidate(t *testing.T) {
+	s := newTestServer(t, "2.2.3", false)
+
+	for _, path := range staticRoutes {
+		t.Run(path, func(t *testing.T) {
+			rec := do(s, http.MethodGet, path, nil)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+				t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+			}
+			if rec.Header().Get("Etag") == "" {
+				t.Error("no Etag, so revalidation can never answer 304")
+			}
+		})
+	}
+}

--- a/web/scripts/data/HarvestablesDatabase.js
+++ b/web/scripts/data/HarvestablesDatabase.js
@@ -41,7 +41,7 @@ export class HarvestablesDatabase {
         try {
             window.logger?.info(CATEGORIES.SYSTEM, 'HarvestablesLoading', {path: jsonPath});
 
-            const response = await fetch(jsonPath);
+            const response = await fetch(jsonPath, {cache: 'no-cache'});
             if (!response.ok) {
                 throw new Error(`Failed to fetch harvestables: ${response.status}`);
             }

--- a/web/scripts/data/ItemsDatabase.js
+++ b/web/scripts/data/ItemsDatabase.js
@@ -23,7 +23,7 @@ export class ItemsDatabase {
         try {
             window.logger?.info(CATEGORIES.SYSTEM, 'ItemsLoading', {path: jsonPath});
 
-            const response = await fetch(jsonPath);
+            const response = await fetch(jsonPath, {cache: 'no-cache'});
             if (!response.ok) {
                 throw new Error(`Failed to fetch items.min.json: ${response.status}`);
             }

--- a/web/scripts/data/LocalizationDatabase.js
+++ b/web/scripts/data/LocalizationDatabase.js
@@ -54,7 +54,7 @@ export class LocalizationDatabase {
                 { path: jsonPath, lang }
             );
 
-            const response = await fetch(jsonPath);
+            const response = await fetch(jsonPath, {cache: 'no-cache'});
             if (!response.ok) {
                 throw new Error(`Failed to fetch localization.json: ${response.status}`);
             }

--- a/web/scripts/data/MobsDatabase.js
+++ b/web/scripts/data/MobsDatabase.js
@@ -68,7 +68,7 @@ export class MobsDatabase {
                 { path: jsonPath }
             );
 
-            const response = await fetch(jsonPath);
+            const response = await fetch(jsonPath, {cache: 'no-cache'});
             if (!response.ok) {
                 throw new Error(`Failed to fetch mobs: ${response.status}`);
             }

--- a/web/scripts/data/SpellsDatabase.js
+++ b/web/scripts/data/SpellsDatabase.js
@@ -24,7 +24,7 @@ export class SpellsDatabase {
         try {
             window.logger?.info(CATEGORIES.SYSTEM, 'SpellsLoading', {path: jsonPath});
 
-            const response = await fetch(jsonPath);
+            const response = await fetch(jsonPath, {cache: 'no-cache'});
             if (!response.ok) {
                 throw new Error(`Failed to fetch spells: ${response.status}`);
             }

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -23,7 +23,7 @@ export class ZonesDatabase {
         path: jsonPath,
       });
 
-      const response = await fetch(jsonPath);
+      const response = await fetch(jsonPath, {cache: 'no-cache'});
       if (!response.ok) {
         throw new Error(`Failed to fetch zones.json: ${response.status}`);
       }

--- a/web/scripts/data/_DatabaseCacheMode.test.js
+++ b/web/scripts/data/_DatabaseCacheMode.test.js
@@ -1,0 +1,46 @@
+import {describe, test, expect, beforeEach, afterEach} from 'vitest';
+import {ItemsDatabase} from './ItemsDatabase.js';
+import {SpellsDatabase} from './SpellsDatabase.js';
+import {HarvestablesDatabase} from './HarvestablesDatabase.js';
+import {MobsDatabase} from './MobsDatabase.js';
+import {ZonesDatabase} from './ZonesDatabase.js';
+import {LocalizationDatabase} from './LocalizationDatabase.js';
+
+// A browser still holding a `max-age=604800` entry from an older release never
+// asks the server. Only a "no-cache" request cache mode revalidates a fresh entry.
+
+const databases = [
+    ['ItemsDatabase', () => new ItemsDatabase(), '/ao-bin-dumps/items.min.json'],
+    ['SpellsDatabase', () => new SpellsDatabase(), '/ao-bin-dumps/spells.min.json'],
+    ['HarvestablesDatabase', () => new HarvestablesDatabase(), '/ao-bin-dumps/harvestables.min.json'],
+    ['MobsDatabase', () => new MobsDatabase(), '/ao-bin-dumps/mobs.min.json'],
+    ['ZonesDatabase', () => new ZonesDatabase(), '/ao-bin-dumps/zones.json'],
+    ['LocalizationDatabase', () => new LocalizationDatabase(), '/ao-bin-dumps/localization.json'],
+];
+
+describe('game data is fetched with a revalidating cache mode', () => {
+    let originalFetch;
+    let calls;
+
+    beforeEach(() => {
+        originalFetch = globalThis.fetch;
+        calls = [];
+        globalThis.fetch = (url, init) => {
+            calls.push({url, init});
+            return Promise.resolve({ok: true, json: () => Promise.resolve({})});
+        };
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test.each(databases)('%s.load() passes cache: no-cache', async (_name, create, path) => {
+        await create().load(path).catch(() => {
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe(path);
+        expect(calls[0].init).toEqual({cache: 'no-cache'});
+    });
+});


### PR DESCRIPTION
Static assets were cached with `public, max-age` (game data 7 days, images 24h, scripts 1h) and carried no validator: embed.FS has a zero modtime, so no Last-Modified, and no ETag was set. After each release the browser kept serving the previous version's data and scripts at the same URLs, mislabeling mobs and resources even on a fixed binary (incognito worked, only a full cache clear fixed it).

Static assets now serve `Cache-Control: no-cache` with a build-scoped ETag (`version-buildTime`, distinct `-gz` variant) and answer 304 through `http.ServeContent`. API responses are `no-store`, HTML pages are `no-cache` with `Vary: Hx-Request`, and the six database loaders fetch with `{cache: 'no-cache'}`. Caches poisoned by 2.2.2 self-heal: the old script entries expire within 1h, then the new loaders force-revalidate the stale data JSON. A single hard refresh (Ctrl+F5) does it immediately.

Closes #146

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Testing
`internal/server/http_cache_test.go` (13 tests on the real mux and repo assets: 304 on matching ETag, full body on a stale validator, per-representation gzip ETag, Range on gzip bodies, Vary, no-store, no ETag on unversioned builds) and `web/scripts/data/_DatabaseCacheMode.test.js` (the six loaders pass `cache: 'no-cache'`). `go test ./...`, `golangci-lint run` and `npm test` (696 tests) green locally, CI green. Live test with a rebuilt binary planned before release.

## Checklist
- [x] Code compiles without errors
- [x] Tested on Windows / Linux
- [x] Updated documentation if needed
