### PR TITLE
feat(radar): extend zoom-out range

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -6,6 +6,17 @@
 #   docker build -f Dockerfile.windows -o dist/ \
 #     --build-arg VERSION=x.y.z --build-arg BUILD_TIME=2026-04-15T12:00:00Z .
 
+FROM node:25-bookworm-slim AS frontend
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY web ./web
+COPY internal/templates ./internal/templates
+RUN npm run build
+
 FROM golang:1.26-bookworm AS builder
 
 ARG VERSION=dev
@@ -31,6 +42,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+COPY --from=frontend /app/web/styles/tailwind.css ./web/styles/tailwind.css
+COPY --from=frontend /app/web/styles/fonts ./web/styles/fonts
+COPY --from=frontend /app/web/scripts/vendors ./web/scripts/vendors
 
 ENV CGO_ENABLED=1 \
     GOOS=windows \

--- a/internal/templates/pages/radar.gohtml
+++ b/internal/templates/pages/radar.gohtml
@@ -43,7 +43,7 @@
                 <div class="hidden sm:flex items-center gap-2">
                     <span class="text-xs text-base-content/50">Zoom:</span>
                     <button id="zoomOut" class="btn btn-ghost btn-xs">−</button>
-                    <input type="range" id="settingRadarZoom" min="0.3" max="3" step="0.1" value="1" class="range range-primary range-xs w-24">
+                    <input type="range" id="settingRadarZoom" min="0.1" max="3" step="0.1" value="1" class="range range-primary range-xs w-24">
                     <button id="zoomIn" class="btn btn-ghost btn-xs">+</button>
                     <span id="zoomValue" class="text-xs text-base-content/60 font-mono w-10">100%</span>
                     <button id="zoomReset" class="btn btn-ghost btn-xs text-xs">Reset</button>
@@ -206,7 +206,7 @@ window.onGlobalsReady(function() {
     }
 
     function setZoom(value) {
-        value = Math.max(0.3, Math.min(3, value));
+        value = Math.max(0.1, Math.min(3, value));
         settingsSync.setFloat('settingRadarZoom', value);
         updateZoomDisplay(value);
     }

--- a/web/scripts/utils/_RadarZoomContract.test.js
+++ b/web/scripts/utils/_RadarZoomContract.test.js
@@ -1,0 +1,18 @@
+import {readFileSync} from 'node:fs';
+import {describe, expect, test} from 'vitest';
+
+const radarTemplate = readFileSync(
+    'internal/templates/pages/radar.gohtml',
+    'utf8',
+);
+
+describe('radar zoom range contract', () => {
+    test('allows zooming out to ten percent for a wider view', () => {
+        expect(radarTemplate).toContain(
+            'id="settingRadarZoom" min="0.1" max="3" step="0.1"',
+        );
+        expect(radarTemplate).toContain(
+            'Math.max(0.1, Math.min(3, value))',
+        );
+    });
+});

--- a/web/scripts/utils/_WindowsDockerBuildContract.test.js
+++ b/web/scripts/utils/_WindowsDockerBuildContract.test.js
@@ -1,0 +1,15 @@
+import {readFileSync} from 'node:fs';
+import {describe, expect, test} from 'vitest';
+
+const dockerfile = readFileSync('Dockerfile.windows', 'utf8');
+
+describe('Windows Docker build frontend assets', () => {
+    test('builds and embeds the generated Tailwind stylesheet', () => {
+        expect(dockerfile).toContain('AS frontend');
+        expect(dockerfile).toContain('RUN npm ci');
+        expect(dockerfile).toContain('RUN npm run build');
+        expect(dockerfile).toContain(
+            'COPY --from=frontend /app/web/styles/tailwind.css ./web/styles/tailwind.css',
+        );
+    });
+});


### PR DESCRIPTION
## Resumen
- reduce el zoom mínimo del radar de 30% a 10%
- amplía hasta 3× el campo visual lineal mostrado
- añade una prueba de contrato para mantener sincronizados el slider y el límite aplicado
- corrige el build Docker de Windows para generar Tailwind y los assets frontend antes de incrustarlos en el `.exe`

## Validación
- `npm test` — 748/748
- `npm run lint`
- `npm run typecheck`
- build real `Dockerfile.windows` completado; el ejecutable contiene `tailwind.css` y tokens DaisyUI

> El zoom amplía la vista renderizada. La detección sigue limitada por los eventos que Albion envía al cliente.