### PR TITLE
fix(#163): report a blocked threat sound instead of swallowing it

### DIFF
--- a/web/scripts/handlers/PlayersHandler.js
+++ b/web/scripts/handlers/PlayersHandler.js
@@ -1,6 +1,7 @@
 import {CATEGORIES} from "../constants/LoggerConstants.js";
 import zonesDatabase from "../data/ZonesDatabase.js";
 import settingsSync from "../utils/SettingsSync.js";
+import alertSound from "../utils/AlertSound.js";
 
 class Player {
     constructor(posX, posY, id, nickname, guildName1, faction, allianceName, equipments, spells) {
@@ -88,14 +89,7 @@ export class PlayersHandler {
     }
 
     playThreatSound() {
-        try {
-            const audio = new Audio('/sounds/player.mp3');
-            audio.play().catch((err) => {
-                window.logger?.debug(CATEGORIES.PLAYERS, 'audio_blocked', {error: err?.message});
-            });
-        } catch (err) {
-            window.logger?.debug(CATEGORIES.PLAYERS, 'audio_error', {error: err?.message});
-        }
+        return alertSound.play();
     }
 
     triggerScreenFlash() {

--- a/web/scripts/handlers/_PlayersHandler.test.js
+++ b/web/scripts/handlers/_PlayersHandler.test.js
@@ -735,15 +735,14 @@ describe('PlayersHandler', () => {
             expect(playMock).toHaveBeenCalledTimes(2);
         });
 
-        // @verified 2026-05-22: synthetic. A rejected play() promise is swallowed and logged, not thrown.
-        test('synthetic: rejected play() is caught and logged', async () => {
+        // @verified 2026-08-09: a rejected play() is reported at warn level so a silent alert is visible in the logs.
+        test('synthetic: rejected play() is caught and reported', async () => {
             const playMock = vi.fn().mockRejectedValue(new Error('autoplay blocked'));
             vi.stubGlobal('Audio', vi.fn(function () { this.play = playMock; }));
 
-            expect(() => handler.playThreatSound()).not.toThrow();
-            await Promise.resolve();
+            await expect(handler.playThreatSound()).resolves.toBeUndefined();
 
-            expect(window.logger.debug).toHaveBeenCalled();
+            expect(window.logger.warn).toHaveBeenCalled();
         });
     });
 

--- a/web/scripts/utils/AlertSound.js
+++ b/web/scripts/utils/AlertSound.js
@@ -1,0 +1,27 @@
+import {CATEGORIES} from '../constants/LoggerConstants.js';
+
+const BLOCKED_MESSAGE = 'Threat sound blocked by the browser. Click anywhere on the page to allow it.';
+
+export class AlertSound {
+    constructor(src) {
+        this.src = src;
+        this.reported = false;
+    }
+
+    async play() {
+        try {
+            await new Audio(this.src).play();
+        } catch (err) {
+            this.report(err);
+        }
+    }
+
+    report(err) {
+        window.logger?.warn(CATEGORIES.PLAYERS, 'ThreatSoundBlocked', {error: err?.message});
+        if (this.reported) return;
+        this.reported = true;
+        window.toast?.warning(BLOCKED_MESSAGE, 0);
+    }
+}
+
+export default new AlertSound('/sounds/player.mp3');

--- a/web/scripts/utils/_AlertSound.test.js
+++ b/web/scripts/utils/_AlertSound.test.js
@@ -1,0 +1,78 @@
+// synthetic: browser audio policy is not observable in a capture
+import {describe, test, expect, beforeEach, afterEach, vi} from 'vitest';
+
+import {AlertSound} from './AlertSound.js';
+
+describe('AlertSound', () => {
+    let toast;
+
+    beforeEach(() => {
+        toast = {warning: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn()};
+        window.toast = toast;
+        window.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    // @verified 2026-05-22: a reused element stopped emitting after a long session, so each trigger builds its own.
+    test('synthetic: each trigger builds a fresh element', async () => {
+        const play = vi.fn().mockResolvedValue();
+        const ctor = vi.fn(function () { this.play = play; });
+        vi.stubGlobal('Audio', ctor);
+        const sound = new AlertSound('/sounds/player.mp3');
+
+        await sound.play();
+        await sound.play();
+
+        expect(ctor).toHaveBeenCalledTimes(2);
+        expect(ctor).toHaveBeenCalledWith('/sounds/player.mp3');
+        expect(play).toHaveBeenCalledTimes(2);
+    });
+
+    // @verified 2026-08-09: a blocked alert reaches the user instead of being swallowed into a debug log.
+    test('synthetic: a rejected play raises a persistent warning', async () => {
+        vi.stubGlobal('Audio', vi.fn(function () { this.play = vi.fn().mockRejectedValue(new Error('NotAllowedError')); }));
+        const sound = new AlertSound('/sounds/player.mp3');
+
+        await sound.play();
+
+        expect(window.logger.warn).toHaveBeenCalled();
+        expect(toast.warning).toHaveBeenCalledTimes(1);
+        expect(toast.warning.mock.calls[0][1]).toBe(0);
+    });
+
+    // @verified 2026-08-09: a stream of hostiles cannot bury the screen in toasts.
+    test('synthetic: repeated rejections warn the user once', async () => {
+        vi.stubGlobal('Audio', vi.fn(function () { this.play = vi.fn().mockRejectedValue(new Error('NotAllowedError')); }));
+        const sound = new AlertSound('/sounds/player.mp3');
+
+        await sound.play();
+        await sound.play();
+        await sound.play();
+
+        expect(toast.warning).toHaveBeenCalledTimes(1);
+        expect(window.logger.warn).toHaveBeenCalledTimes(3);
+    });
+
+    // @verified 2026-08-09: a working alert stays silent in the interface.
+    test('synthetic: a successful play warns about nothing', async () => {
+        vi.stubGlobal('Audio', vi.fn(function () { this.play = vi.fn().mockResolvedValue(); }));
+        const sound = new AlertSound('/sounds/player.mp3');
+
+        await sound.play();
+
+        expect(toast.warning).not.toHaveBeenCalled();
+        expect(window.logger.warn).not.toHaveBeenCalled();
+    });
+
+    // @verified 2026-08-09: a constructor that throws is handled like a rejected play, the caller never sees it.
+    test('synthetic: a throwing constructor does not escape', async () => {
+        vi.stubGlobal('Audio', vi.fn(() => { throw new Error('no media support'); }));
+        const sound = new AlertSound('/sounds/player.mp3');
+
+        await expect(sound.play()).resolves.toBeUndefined();
+        expect(toast.warning).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Description

A rejected `play()` went to a debug log named `audio_blocked`. A player whose browser refuses the alert saw the screen flash and never learned the sound had been suppressed. Browsers block audio until the page receives a user gesture, which is exactly the case for a radar left in the background.

The failure is now logged at warn level and raises a persistent toast telling the player to click the page. Raised once, so a stream of hostiles cannot bury the screen. Reuses the existing `window.toast`, already used by `DatabaseLoader`, `PageController` and `WebSocketManager`.

Both alert paths were checked first and gate flash and sound identically (`PlayersHandler.js:220-227` on spawn, `324-330` on faction change). Nothing branches on zone for audio, so this is not Mists specific.

A fresh `Audio` element per trigger is kept. Reusing one stopped emitting after a long session, fixed on 2026-05-22 and pinned by a test.

This does not prove the reporter's cause. It makes the failure visible, so the next session answers the question.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Testing

`web/scripts/utils/_AlertSound.test.js`, 5 tests: fresh element per trigger, rejection raises a persistent toast, repeated rejections warn once while every failure still logs, a successful play stays silent, a throwing constructor does not escape.

`_PlayersHandler.test.js` updated from `logger.debug` to `logger.warn`, the intended contract change.

`npm test` 751 passing across 29 files, eslint clean.

## Checklist

- [x] Code compiles without errors
- [x] Tests pass
- [x] No new lint warnings
