### PR TITLE
ci: keep every commit visible in release notes and flag pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
         run: |
           gh release create "${{ env.VERSION }}" \
             --draft \
+            $([[ "${{ env.VERSION }}" == *-* ]] && echo --prerelease) \
             --title "OpenRadar v${{ env.VERSION }}" \
             --notes-file dist/RELEASE.md \
             dist/OpenRadar-linux-amd64 \

--- a/cliff.toml
+++ b/cliff.toml
@@ -17,6 +17,8 @@ Real-time radar for Albion Online.
 ### 🐛 Bug Fixes
 {% elif group == "Performance" -%}
 ### ⚡ Performance
+{% elif group == "Other" -%}
+### 📦 Other
 {% else -%}
 ### {{ group }}
 {% endif %}
@@ -50,13 +52,13 @@ postprocessors = [
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+filter_unconventional = false
 split_commits = false
 commit_parsers = [
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug fixes" },
   { message = "^perf", group = "Performance" },
-  { message = "^docs", skip = true },
+  { message = "^docs?", skip = true },
   { message = "^test", skip = true },
   { message = "^ci", skip = true },
   { message = "^build", skip = true },
@@ -64,9 +66,10 @@ commit_parsers = [
   { message = "^style", skip = true },
   { message = "^refactor", skip = true },
   { message = "^Merge", skip = true },
+  { message = ".*", group = "Other" },
 ]
 filter_commits = false
 tag_pattern = "v?[0-9]+\\.[0-9]+\\.[0-9]+"
-ignore_tags = ""
+ignore_tags = "-(alpha|beta|rc)"
 topo_order = false
 sort_commits = "oldest"


### PR DESCRIPTION
## Summary

Three things git-cliff got wrong on the last two releases, each checked with a dry run on real history: `doc:` commits leaked as a raw section while `docs:` was skipped (both skipped now), titles outside the convention vanished silently (they land under Other now), and a final release after a beta would have produced empty notes because the beta counted as the previous version (pre-release tags are ignored now). The release step also passes `--prerelease` when the tag carries a dash.

## Test plan

- `npx git-cliff --config cliff.toml 2.2.2..2.2.3`, `2.2.3..2.2.4-beta1` and `--tag 2.2.4 2.2.3..HEAD` all render without a `doc` section and with the full range in the changelog link.
- The shell expression for the flag was exercised locally with `2.2.4` (empty) and `2.2.4-beta1` (`--prerelease`).