### PR TITLE
fix(#187) avalon hideout detection

### DIFF
--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -4,6 +4,7 @@ export class ZonesDatabase {
   constructor() {
     this.zones = {};
     this.overrides = new Map();
+    this.unresolved = new Set();
     this.loaded = false;
     this.stats = {
       totalZones: 0,
@@ -71,7 +72,20 @@ export class ZonesDatabase {
       const baseId = id.split("-")[0];
       raw = this.zones[baseId] || null;
     }
+    if (!raw) this._recordUnresolved(id);
     return this._applyAvalonRoadsRule(raw);
+  }
+
+  // An unresolved id answers safe, which disables the threat gate, the flash and the sound at
+  // once. Recorded once per id because lookups run per detection and per frame.
+  _recordUnresolved(id) {
+    if (this.unresolved.has(id)) return;
+    this.unresolved.add(id);
+    window.logger?.warn(CATEGORIES.MAP, "ZoneUnresolved", { mapId: id });
+  }
+
+  forgetUnresolved() {
+    this.unresolved.clear();
   }
 
   // Roads of Avalon are full-loot PvP regardless of origin. Every TUNNEL_ family is a Roads map,

--- a/web/scripts/data/ZonesDatabase.js
+++ b/web/scripts/data/ZonesDatabase.js
@@ -74,11 +74,11 @@ export class ZonesDatabase {
     return this._applyAvalonRoadsRule(raw);
   }
 
-  // Roads of Avalon are full-loot PvP regardless of origin. zones.json tags TUNNEL_ROYAL
-  // and TUNNEL_ROYAL_RED as safe/red, overridden here.
+  // Roads of Avalon are full-loot PvP regardless of origin. Every TUNNEL_ family is a Roads map,
+  // and zones.json tags several of them safe or red.
   _applyAvalonRoadsRule(zone) {
     if (!zone) return null;
-    if (zone.type === "TUNNEL_ROYAL" || zone.type === "TUNNEL_ROYAL_RED") {
+    if (String(zone.type).startsWith("TUNNEL_")) {
       return { ...zone, pvpType: "black" };
     }
     return zone;

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -168,11 +168,49 @@ describe('ZonesDatabase Avalon Roads pvpType', () => {
         expect(zonesDatabase.isRedZone('TNL-023')).toBe(false);
     });
 
-    // @verified 2026-05-07: Hideout interiors stay safe. Player-owned hideouts inside Avalon are
-    // not PvP zones; only the surrounding Roads are.
-    test('TUNNEL_HIDEOUT keeps safe pvpType', () => {
-        expect(zonesDatabase.getPvpType('TNL-151')).toBe('safe');
-        expect(zonesDatabase.isSafeZone('TNL-151')).toBe(true);
+    // @verified 2026-09-04: issue #187. TNL-151 is Quaent-Vynsum, map file
+    // TNL-151_RDS_RO_AUTO_T6_AVA_AVA, a Roads map that carries a hideout. The 2026-05-07 test
+    // asserted safe here, reading TUNNEL_HIDEOUT as a hideout interior. Interiors are the separate
+    // HIDEOUT-NNNNx family, checked below.
+    test('TUNNEL_HIDEOUT is forced to black, it is a Roads map carrying a hideout', () => {
+        expect(zonesDatabase.getPvpType('TNL-151')).toBe('black');
+        expect(zonesDatabase.isBlackZone('TNL-151')).toBe(true);
+    });
+
+    // @verified 2026-09-04: issue #187. Same family, deep variant.
+    test('TUNNEL_HIDEOUT_DEEP is forced to black', () => {
+        expect(zonesDatabase.getPvpType('TNL-154')).toBe('black');
+    });
+
+    // @verified 2026-09-04: the intent behind the 2026-05-07 comment, applied to the entries it
+    // actually meant. A hideout interior is not a PvP zone.
+    test('HIDEOUT interiors keep safe pvpType', () => {
+        expect(zonesDatabase.getPvpType('HIDEOUT-0001a')).toBe('safe');
+        expect(zonesDatabase.isSafeZone('HIDEOUT-0001a')).toBe(true);
+    });
+
+    // @verified 2026-09-04: every Roads entry, not a sample. A data refresh that adds a Roads
+    // family fails here instead of in a player's session.
+    test('every TUNNEL_ family in the shipped database classifies as black', () => {
+        const roads = Object.entries(zonesDatabase.zones)
+            .filter(([, zone]) => String(zone.type).startsWith('TUNNEL_'));
+        const wrong = roads
+            .filter(([id]) => zonesDatabase.getPvpType(id) !== 'black')
+            .map(([id, zone]) => `${id} ${zone.type} ${zone.pvpType}`);
+
+        expect(roads.length).toBeGreaterThan(0);
+        expect(wrong).toEqual([]);
+    });
+
+    // @verified 2026-09-04: the Roads set and the RDS map-file set are the same 400 entries, so
+    // keying the rule on the type name covers exactly the Roads and nothing else.
+    test('TUNNEL_ types and RDS map files describe the same zones', () => {
+        const byType = Object.keys(zonesDatabase.zones)
+            .filter(id => String(zonesDatabase.zones[id].type).startsWith('TUNNEL_')).sort();
+        const byFile = Object.keys(zonesDatabase.zones)
+            .filter(id => String(zonesDatabase.zones[id].file).includes('_RDS_')).sort();
+
+        expect(byType).toEqual(byFile);
     });
 
     // @verified 2026-05-07: regression guard. TUNNEL_LOW already correctly black in zones.json,

--- a/web/scripts/data/_ZonesDatabase.test.js
+++ b/web/scripts/data/_ZonesDatabase.test.js
@@ -1,4 +1,4 @@
-import {describe, test, expect, beforeAll, beforeEach} from 'vitest';
+import {describe, test, expect, beforeAll, beforeEach, vi} from 'vitest';
 import {readFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import {dirname, join} from 'node:path';
@@ -229,6 +229,38 @@ describe('ZonesDatabase Avalon Roads pvpType', () => {
         expect(zonesDatabase.getPvpType('1000')).toBe('safe');
         expect(zonesDatabase.getPvpType('0212')).toBe('yellow');
         expect(zonesDatabase.getPvpType('3316')).toBe('black');
+    });
+});
+
+describe('ZonesDatabase unresolved map ids', () => {
+    beforeEach(() => {
+        zonesDatabase.forgetUnresolved();
+        window.logger = {debug: () => {}, info: () => {}, warn: vi.fn(), error: () => {}};
+    });
+
+    // @verified 2026-09-04: an id the database cannot place answers safe, which disables the threat
+    // gate, the flash and the sound at once. Silent is the one thing it must not be.
+    test('an unknown map id is recorded', () => {
+        expect(zonesDatabase.getZone('NOPE-9999')).toBeNull();
+
+        expect(window.logger.warn).toHaveBeenCalledWith(
+            expect.anything(), 'ZoneUnresolved', expect.objectContaining({mapId: 'NOPE-9999'}));
+    });
+
+    // @verified 2026-09-04: zone lookups run per detection and per frame, so one record per id.
+    test('the same unknown id is recorded once', () => {
+        for (let i = 0; i < 5; i++) zonesDatabase.getZone('NOPE-9999');
+
+        expect(window.logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    // @verified 2026-09-04: a resolvable id must stay silent, including one resolved by the
+    // compound-id fallback.
+    test('a resolvable id is not recorded', () => {
+        zonesDatabase.getZone('TNL-151');
+        zonesDatabase.getZone('1000');
+
+        expect(window.logger.warn).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
The Avalon override reached TUNNEL_ROYAL and TUNNEL_ROYAL_RED only, so the 72
TUNNEL_HIDEOUT and 28 TUNNEL_HIDEOUT_DEEP maps kept the safe tag zones.json
gives them. isPlayerThreat refuses on safe, so on a Roads map carrying a
hideout no player was listed, nothing flashed and nothing sounded, while the
zone label read as safe.

A test had asserted that safe value since 2026-05-07, reading TUNNEL_HIDEOUT as
a hideout interior. TNL-151 is Quaent-Vynsum, map file
TNL-151_RDS_RO_AUTO_T6_AVA_AVA, a Roads map that carries a hideout. Interiors
are the separate HIDEOUT family and keep their own classification, now asserted
on the entries that reasoning actually meant.

The rule keys on the TUNNEL_ prefix, which covers the same 400 entries as the
RDS map-file token, pinned by a test over the shipped database.## Description
Brief description of the changes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Testing
How did you test these changes?

## Checklist
- [x] Code compiles without errors
- [ ] Tested on Windows / Linux
- [ ] Updated documentation if needed
